### PR TITLE
[codex] Harden artifact downloads

### DIFF
--- a/backend/app/routers/artifacts.py
+++ b/backend/app/routers/artifacts.py
@@ -1,9 +1,7 @@
 """Artifacts router — download and list generated files (GeneratedFile model)."""
 from __future__ import annotations
 
-import json
 from datetime import datetime
-from pathlib import Path
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -13,7 +11,10 @@ from sqlmodel import Session, select
 
 from app.config import UPLOADS_DIR
 from app.database import get_session
-from app.models.db import GeneratedFile
+from app.models.db import GeneratedFile, User
+from app.routers.auth import get_current_user
+from app.routers.chat_security import require_conversation_access, require_project_access
+from app.services.upload_paths import normalize_relative_upload_path, resolve_upload_path
 
 router = APIRouter(prefix="/artifacts", tags=["artifacts"])
 
@@ -30,31 +31,78 @@ class ArtifactOut(BaseModel):
     created_at: datetime
 
 
+def _authorize_artifact(
+    session: Session,
+    artifact: GeneratedFile,
+    current_user: User,
+    *,
+    require_write: bool = False,
+) -> None:
+    if artifact.conversation_id:
+        require_conversation_access(
+            session,
+            artifact.conversation_id,
+            current_user,
+            require_write=require_write,
+        )
+        return
+    if artifact.project_id:
+        require_project_access(
+            session,
+            artifact.project_id,
+            current_user,
+            require_write=require_write,
+        )
+        return
+    if not current_user.is_admin:
+        raise HTTPException(status_code=403, detail="Artifact owner required")
+
+
 @router.get("", response_model=List[ArtifactOut])
 def list_artifacts(
     conversation_id: Optional[int] = None,
     project_id: Optional[int] = None,
+    current_user: User = Depends(get_current_user),
     session: Session = Depends(get_session),
 ):
     """List generated files (artifacts)."""
+    if conversation_id:
+        require_conversation_access(session, conversation_id, current_user)
+    if project_id:
+        require_project_access(session, project_id, current_user)
+
     stmt = select(GeneratedFile).order_by(GeneratedFile.created_at.desc())
     if conversation_id:
         stmt = stmt.where(GeneratedFile.conversation_id == conversation_id)
     if project_id:
         stmt = stmt.where(GeneratedFile.project_id == project_id)
-    return session.exec(stmt).all()
+    artifacts = session.exec(stmt).all()
+    if conversation_id or project_id or current_user.is_admin:
+        return artifacts
+
+    visible_artifacts: list[GeneratedFile] = []
+    for artifact in artifacts:
+        try:
+            _authorize_artifact(session, artifact, current_user)
+        except HTTPException:
+            continue
+        visible_artifacts.append(artifact)
+    return visible_artifacts
 
 
 @router.get("/download-by-path")
-def download_by_path(path: str = Query(..., description="Relative path under uploads dir")):
+def download_by_path(
+    path: str = Query(..., description="Relative path under uploads dir"),
+    current_user: User = Depends(get_current_user),
+    session: Session = Depends(get_session),
+):
     """Download a generated file by its relative path (e.g. generated/xxx.pptx)."""
-    # Prevent path traversal
-    safe_path = Path(path).parts
-    if ".." in safe_path:
-        raise HTTPException(400, "Invalid path")
-    file_path = UPLOADS_DIR / path
-    if not file_path.is_file():
-        raise HTTPException(404, "File not found")
+    relative_path = normalize_relative_upload_path(UPLOADS_DIR, path)
+    artifact = session.exec(select(GeneratedFile).where(GeneratedFile.path == relative_path)).first()
+    if not artifact:
+        raise HTTPException(404, "Artifact not found")
+    _authorize_artifact(session, artifact, current_user)
+    file_path = resolve_upload_path(UPLOADS_DIR, relative_path)
 
     ext = file_path.suffix.lstrip(".")
     mime_types = {
@@ -71,24 +119,31 @@ def download_by_path(path: str = Query(..., description="Relative path under upl
 
 
 @router.get("/{artifact_id}")
-def get_artifact(artifact_id: int, session: Session = Depends(get_session)):
+def get_artifact(
+    artifact_id: int,
+    current_user: User = Depends(get_current_user),
+    session: Session = Depends(get_session),
+):
     """Get artifact details."""
     artifact = session.get(GeneratedFile, artifact_id)
     if not artifact:
         raise HTTPException(404, "Artifact not found")
+    _authorize_artifact(session, artifact, current_user)
     return artifact
 
 
 @router.get("/{artifact_id}/download")
-def download_artifact(artifact_id: int, session: Session = Depends(get_session)):
+def download_artifact(
+    artifact_id: int,
+    current_user: User = Depends(get_current_user),
+    session: Session = Depends(get_session),
+):
     """Download the artifact file."""
     artifact = session.get(GeneratedFile, artifact_id)
     if not artifact:
         raise HTTPException(404, "Artifact not found")
-    
-    file_path = UPLOADS_DIR / artifact.path
-    if not file_path.exists():
-        raise HTTPException(404, "File not found on server")
+    _authorize_artifact(session, artifact, current_user)
+    file_path = resolve_upload_path(UPLOADS_DIR, artifact.path)
     
     # Map file types to MIME types
     mime_types = {
@@ -113,15 +168,20 @@ def download_artifact(artifact_id: int, session: Session = Depends(get_session))
 
 
 @router.delete("/{artifact_id}")
-def delete_artifact(artifact_id: int, session: Session = Depends(get_session)):
+def delete_artifact(
+    artifact_id: int,
+    current_user: User = Depends(get_current_user),
+    session: Session = Depends(get_session),
+):
     """Delete an artifact and its file."""
     artifact = session.get(GeneratedFile, artifact_id)
     if not artifact:
         raise HTTPException(404, "Artifact not found")
+    _authorize_artifact(session, artifact, current_user, require_write=True)
     
     # Delete file if exists
     if artifact.path:
-        file_path = UPLOADS_DIR / artifact.path
+        file_path = resolve_upload_path(UPLOADS_DIR, artifact.path, must_exist=False)
         if file_path.exists():
             file_path.unlink()
     

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -12,6 +12,7 @@ from app.config import LOGIN_RATE_LIMIT_ATTEMPTS, LOGIN_RATE_LIMIT_WINDOW_SECOND
 from app.database import get_session, engine
 from app.models.db import User, UserToken
 from app.services.time_utils import utc_now_naive
+from app.services.token_cache import invalidate_token_cache
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 _LOGIN_ATTEMPTS: dict[str, list[float]] = {}
@@ -107,6 +108,7 @@ def _clear_failed_login_attempts(key: str) -> None:
 def _revoke_user_tokens(session: Session, user_id: int) -> None:
     tokens = session.exec(select(UserToken).where(UserToken.user_id == user_id)).all()
     for token in tokens:
+        invalidate_token_cache(token.token)
         session.delete(token)
 
 
@@ -239,14 +241,7 @@ def logout(
 ):
     # 删除当前设备的 token，不影响其他设备
     if x_auth_token:
-        # 清除 token 缓存（函数内导入避免循环依赖）
-        try:
-            import sys
-            main_module = sys.modules.get('__main__')
-            if main_module and hasattr(main_module, 'invalidate_token_cache'):
-                main_module.invalidate_token_cache(x_auth_token)
-        except Exception:
-            pass  # 缓存清除失败不影响登出
+        invalidate_token_cache(x_auth_token)
             
         user_token = session.exec(
             select(UserToken).where(UserToken.token == x_auth_token)
@@ -369,7 +364,10 @@ def update_user(
     if body.is_active is not None:
         user.is_active = body.is_active
         if not body.is_active:
+            if user.auth_token:
+                invalidate_token_cache(user.auth_token)
             user.auth_token = None  # force logout
+            _revoke_user_tokens(session, user.id)
     session.add(user)
     session.commit()
     session.refresh(user)
@@ -398,6 +396,9 @@ def delete_user(
     ).all()
     if len(active_admins) == 1 and active_admins[0].id == user_id:
         raise HTTPException(status_code=400, detail="Cannot delete the last active admin")
+    if user.auth_token:
+        invalidate_token_cache(user.auth_token)
+    _revoke_user_tokens(session, user.id)
     session.delete(user)
     session.commit()
     return {"ok": True}
@@ -417,6 +418,8 @@ def admin_reset_password(
     if len(body.new_password) < 6:
         raise HTTPException(status_code=400, detail="Password must be at least 6 characters")
     user.password_hash = _hash(body.new_password)
+    if user.auth_token:
+        invalidate_token_cache(user.auth_token)
     user.auth_token = None  # force re-login
     _revoke_user_tokens(session, user.id)
     session.add(user)
@@ -435,6 +438,8 @@ def change_password(
     if len(body.new_password) < 6:
         raise HTTPException(status_code=400, detail="Password must be at least 6 characters")
     current_user.password_hash = _hash(body.new_password)
+    if current_user.auth_token:
+        invalidate_token_cache(current_user.auth_token)
     current_user.auth_token = None
     _revoke_user_tokens(session, current_user.id)
     session.add(current_user)

--- a/backend/app/services/project_files.py
+++ b/backend/app/services/project_files.py
@@ -8,6 +8,7 @@ from fastapi import HTTPException, UploadFile
 from sqlmodel import Session, select
 
 from app.models.db import GeneratedFile, ProjectFile, TaskArtifact
+from app.services.upload_paths import resolve_upload_path
 from app.services.time_utils import utc_now_naive
 from app.services.project_todos import ensure_project_exists
 
@@ -75,17 +76,14 @@ def get_project_file_or_404(session: Session, project_id: int, file_id: int) -> 
 
 
 def resolve_project_file_path(project_file: ProjectFile, uploads_dir: Path) -> Path:
-    full_path = uploads_dir / project_file.path
-    if not full_path.is_file():
-        raise HTTPException(404, "File not found on disk")
-    return full_path
+    return resolve_upload_path(uploads_dir, project_file.path)
 
 
 def delete_project_file(session: Session, project_id: int, file_id: int, *, uploads_dir: Path) -> None:
     project_file = session.get(ProjectFile, file_id)
     if not project_file or project_file.project_id != project_id:
         raise HTTPException(404, "File not found")
-    full_path = uploads_dir / project_file.path
+    full_path = resolve_upload_path(uploads_dir, project_file.path, must_exist=False)
 
     derivative_files = session.exec(
         select(ProjectFile).where(ProjectFile.source_file_id == file_id)

--- a/backend/app/services/token_cache.py
+++ b/backend/app/services/token_cache.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import time
+from typing import Optional
+
+
+_TOKEN_CACHE: dict[str, tuple[int, float]] = {}
+
+
+def get_cached_user_id(token: str) -> Optional[int]:
+    entry = _TOKEN_CACHE.get(token)
+    if entry and time.time() < entry[1]:
+        return entry[0]
+    if entry:
+        _TOKEN_CACHE.pop(token, None)
+    return None
+
+
+def cache_token(token: str, user_id: int, ttl_seconds: int) -> None:
+    _TOKEN_CACHE[token] = (user_id, time.time() + ttl_seconds)
+
+
+def invalidate_token_cache(token: str) -> None:
+    _TOKEN_CACHE.pop(token, None)
+
+
+def clear_token_cache() -> None:
+    _TOKEN_CACHE.clear()

--- a/backend/app/services/upload_paths.py
+++ b/backend/app/services/upload_paths.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import HTTPException
+
+
+def resolve_upload_path(
+    uploads_dir: Path,
+    stored_path: str,
+    *,
+    must_exist: bool = True,
+    allow_absolute: bool = True,
+) -> Path:
+    """Resolve a stored uploads path and ensure it cannot escape uploads_dir."""
+    uploads_root = uploads_dir.resolve()
+    raw_path = Path(stored_path)
+    if raw_path.is_absolute():
+        if not allow_absolute:
+            raise HTTPException(status_code=400, detail="Invalid path")
+        candidate = raw_path.resolve()
+    else:
+        candidate = (uploads_root / raw_path).resolve()
+
+    try:
+        candidate.relative_to(uploads_root)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid path")
+
+    if must_exist and not candidate.is_file():
+        raise HTTPException(status_code=404, detail="File not found")
+    return candidate
+
+
+def normalize_relative_upload_path(uploads_dir: Path, path: str) -> str:
+    """Return a normalized relative uploads path from user input."""
+    resolved = resolve_upload_path(
+        uploads_dir,
+        path,
+        must_exist=False,
+        allow_absolute=False,
+    )
+    return str(resolved.relative_to(uploads_dir.resolve()))

--- a/backend/app/tools/pdf_translation.py
+++ b/backend/app/tools/pdf_translation.py
@@ -286,7 +286,7 @@ async def translate_document(
                 "source_language": source_language,
                 "target_language": target_language,
                 "local_file_path": str(out_path),
-                "download_url": f"/artifacts/download?path=translations/{out_name}",
+                "download_url": f"/artifacts/download-by-path?path=translations/{out_name}",
                 "elapsed_seconds": round(asyncio.get_event_loop().time() - start_time, 1),
             }
         except httpx.HTTPStatusError as exc:

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,4 @@
 """AriaAI FastAPI backend — entry point."""
-import time
 import logging
 from contextlib import asynccontextmanager
 from typing import Optional
@@ -20,6 +19,7 @@ from app.routers.auth import seed_admin_user
 from app.services import scheduler
 from app.services.chat.action_reaper import reap_stale_executing_actions_with_engine
 from app.services.chat_store import purge_expired_conversations
+from app.services.token_cache import cache_token, get_cached_user_id, invalidate_token_cache
 
 # Import tools to register them
 from app.tools import file_generators  # noqa: F401
@@ -170,24 +170,7 @@ app.add_middleware(
     expose_headers=["*"],
 )
 
-# Auth token in-memory cache: token → (user_id, expiry_timestamp)
-_TOKEN_CACHE: dict[str, tuple[int, float]] = {}
 _TOKEN_CACHE_TTL = int(SETTINGS_CACHE_TTL)  # Use config value (default 300s / 5min)
-
-
-def _get_cached_user_id(token: str) -> Optional[int]:
-    entry = _TOKEN_CACHE.get(token)
-    if entry and time.time() < entry[1]:
-        return entry[0]
-    return None
-
-
-def _cache_token(token: str, user_id: int):
-    _TOKEN_CACHE[token] = (user_id, time.time() + _TOKEN_CACHE_TTL)
-
-
-def invalidate_token_cache(token: str):
-    _TOKEN_CACHE.pop(token, None)
 
 
 # Auth middleware — protects all routes except /health and /auth/*
@@ -206,7 +189,7 @@ async def auth_middleware(request: Request, call_next):
         user: Optional[User] = None
         if token:
             # Fast path: check in-memory cache first
-            cached_uid = _get_cached_user_id(token)
+            cached_uid = get_cached_user_id(token)
             if cached_uid is not None:
                 user = session.get(User, cached_uid)
                 if user and not user.is_active:
@@ -221,7 +204,7 @@ async def auth_middleware(request: Request, call_next):
                 if user_token:
                     user = session.get(User, user_token.user_id)
                     if user and user.is_active:
-                        _cache_token(token, user.id)
+                        cache_token(token, user.id, _TOKEN_CACHE_TTL)
                         from datetime import datetime
                         user_token.last_used_at = datetime.utcnow()
                         session.add(user_token)
@@ -235,7 +218,7 @@ async def auth_middleware(request: Request, call_next):
                         select(User).where(User.auth_token == token, User.is_active == True)
                     ).first()
                     if user:
-                        _cache_token(token, user.id)
+                        cache_token(token, user.id, _TOKEN_CACHE_TTL)
         
         if not user:
             return JSONResponse(status_code=401, content={"detail": "Not authenticated"})

--- a/backend/tests/test_artifacts.py
+++ b/backend/tests/test_artifacts.py
@@ -1,12 +1,12 @@
 """Tests for artifacts router — covers CRUD for generated file artifacts."""
 import unittest
 import tempfile
-import os
+import shutil
 from pathlib import Path
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel import Session, SQLModel
 
 from app.models.db import GeneratedFile, User, Conversation
 from app.routers import artifacts as artifacts_module
@@ -22,34 +22,59 @@ class ArtifactsRouterTestCase(unittest.TestCase):
         SQLModel.metadata.create_all(self.engine)
 
         self.tmpdir = tempfile.mkdtemp()
+        self.uploads_dir = Path(self.tmpdir) / "uploads"
+        self.uploads_dir.mkdir()
+        self.original_uploads_dir = artifacts_module.UPLOADS_DIR
+        artifacts_module.UPLOADS_DIR = self.uploads_dir
 
         with Session(self.engine) as session:
             user = User(email="test@test.com", password_hash="h", display_name="T")
+            other = User(email="other@test.com", password_hash="h", display_name="Other")
             session.add(user)
+            session.add(other)
             session.commit()
             session.refresh(user)
+            session.refresh(other)
             self.user_id = user.id
+            self.other_user_id = other.id
 
-            conv = Conversation(user_id=user.id, title="test conv")
+            conv = Conversation(owner_user_id=user.id, title="test conv")
+            other_conv = Conversation(owner_user_id=other.id, title="other conv")
             session.add(conv)
+            session.add(other_conv)
             session.commit()
             session.refresh(conv)
+            session.refresh(other_conv)
             self.conv_id = conv.id
 
+            report_path = self.uploads_dir / "generated" / "report.md"
+            report_path.parent.mkdir(parents=True, exist_ok=True)
+            report_path.write_text("# Test Report\nContent here")
             gf = GeneratedFile(
                 conversation_id=conv.id,
                 name="report.md",
                 file_type="markdown",
-                path=os.path.join(self.tmpdir, "report.md"),
+                path="generated/report.md",
                 size_bytes=100,
                 description="Test report",
             )
+            other_path = self.uploads_dir / "generated" / "other.md"
+            other_path.write_text("# Other Report\n")
+            other_gf = GeneratedFile(
+                conversation_id=other_conv.id,
+                name="other.md",
+                file_type="markdown",
+                path="generated/other.md",
+                size_bytes=30,
+                description="Other report",
+            )
             session.add(gf)
+            session.add(other_gf)
             session.commit()
             session.refresh(gf)
+            session.refresh(other_gf)
             self.artifact_id = gf.id
-
-            Path(gf.path).write_text("# Test Report\nContent here")
+            self.other_artifact_id = other_gf.id
 
         app = FastAPI()
         app.include_router(router)
@@ -59,6 +84,14 @@ class ArtifactsRouterTestCase(unittest.TestCase):
                 yield session
 
         app.dependency_overrides[get_session] = override_session
+        app.dependency_overrides[artifacts_module.get_current_user] = lambda: User(
+            id=self.user_id,
+            email="test@test.com",
+            password_hash="h",
+            display_name="T",
+            is_admin=True,
+            is_active=True,
+        )
 
         @app.middleware("http")
         def inject_user(request, call_next):
@@ -69,9 +102,9 @@ class ArtifactsRouterTestCase(unittest.TestCase):
         self.client = TestClient(app, raise_server_exceptions=False)
 
     def tearDown(self):
+        artifacts_module.UPLOADS_DIR = self.original_uploads_dir
         SQLModel.metadata.drop_all(self.engine)
         self.engine.dispose()
-        import shutil
         shutil.rmtree(self.tmpdir, ignore_errors=True)
 
     def test_list_artifacts(self):
@@ -100,6 +133,41 @@ class ArtifactsRouterTestCase(unittest.TestCase):
         resp = self.client.get(f"/artifacts/{self.artifact_id}/download")
         self.assertEqual(resp.status_code, 200)
         self.assertIn(b"Test Report", resp.content)
+
+    def test_download_by_path_rejects_absolute_path(self):
+        resp = self.client.get("/artifacts/download-by-path", params={"path": "/etc/passwd"})
+        self.assertEqual(resp.status_code, 400)
+
+    def test_download_by_path_rejects_traversal(self):
+        resp = self.client.get("/artifacts/download-by-path", params={"path": "../secret.txt"})
+        self.assertEqual(resp.status_code, 400)
+
+    def test_download_by_path_requires_artifact_record(self):
+        orphan_path = self.uploads_dir / "generated" / "orphan.md"
+        orphan_path.write_text("# Orphan")
+        resp = self.client.get("/artifacts/download-by-path", params={"path": "generated/orphan.md"})
+        self.assertEqual(resp.status_code, 404)
+
+    def test_non_admin_cannot_download_other_users_artifact(self):
+        app = FastAPI()
+        app.include_router(router)
+
+        def override_session():
+            with Session(self.engine) as session:
+                yield session
+
+        app.dependency_overrides[get_session] = override_session
+        app.dependency_overrides[artifacts_module.get_current_user] = lambda: User(
+            id=self.user_id,
+            email="test@test.com",
+            password_hash="h",
+            display_name="T",
+            is_admin=False,
+            is_active=True,
+        )
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get(f"/artifacts/{self.other_artifact_id}/download")
+        self.assertEqual(resp.status_code, 403)
 
     def test_delete_artifact(self):
         resp = self.client.delete(f"/artifacts/{self.artifact_id}")

--- a/backend/tests/test_auth_pure.py
+++ b/backend/tests/test_auth_pure.py
@@ -90,3 +90,24 @@ class PruneLoginAttemptsTestCase(unittest.TestCase):
         from app.routers.auth import _prune_login_attempts
         result = _prune_login_attempts(1000.0, [])
         self.assertEqual(result, [])
+
+
+class TokenCacheTestCase(unittest.TestCase):
+    def tearDown(self):
+        from app.services.token_cache import clear_token_cache
+        clear_token_cache()
+
+    def test_cache_roundtrip_and_invalidate(self):
+        from app.services.token_cache import cache_token, get_cached_user_id, invalidate_token_cache
+
+        cache_token("token-1", 42, 60)
+        self.assertEqual(get_cached_user_id("token-1"), 42)
+
+        invalidate_token_cache("token-1")
+        self.assertIsNone(get_cached_user_id("token-1"))
+
+    def test_cache_entry_expires(self):
+        from app.services.token_cache import cache_token, get_cached_user_id
+
+        cache_token("token-2", 43, -1)
+        self.assertIsNone(get_cached_user_id("token-2"))


### PR DESCRIPTION
## Summary
- add safe uploads path resolution to prevent absolute-path and traversal downloads
- require artifact access checks for list, detail, download, and delete routes
- centralize token cache invalidation so logout and account changes take effect immediately
- fix the PDF translation artifact download URL

## Validation
- python3 -m compileall -q backend/app backend/main.py backend/scripts
- PYTHONPATH=. .venv/bin/python -m pytest -q tests

## Impact
This closes artifact file access gaps and keeps generated-file downloads scoped to authorized conversations or projects.