### PR TITLE
[codex] Fix project chat skill routing and naming

### DIFF
--- a/backend/app/services/chat/phases/p2_tools.py
+++ b/backend/app/services/chat/phases/p2_tools.py
@@ -262,13 +262,19 @@ async def run_p2_tools(
     for workflow_event in workflow_plan_events():
         yield sse_event(workflow_event)
 
+    tool_step_title = "执行 Skill / 工具" if runtime.skill_name else "执行工具"
+    tool_step_message = (
+        "第 3 步：正在执行规划好的 Skill 或工具调用。"
+        if runtime.skill_name
+        else "第 3 步：正在执行规划好的工具调用。"
+    )
     yield sse_event(
         workflow_status(
             step_index=3,
             step_total=4,
-            title="执行 Skill / 工具",
+            title=tool_step_title,
             stage="tools",
-            message="第 3 步：正在执行规划好的 Skill 或工具调用。",
+            message=tool_step_message,
         )
     )
     yield sse_event(
@@ -312,7 +318,7 @@ async def run_p2_tools(
                     workflow_status(
                         step_index=3,
                         step_total=4,
-                        title="执行 Skill / 工具",
+                        title=tool_step_title,
                         stage="tools",
                         message=f"第 3 步：已补齐 Markdown 工具参数（{'；'.join(repaired_changes)}）。",
                     )
@@ -336,7 +342,7 @@ async def run_p2_tools(
                     workflow_status(
                         step_index=3,
                         step_total=4,
-                        title="执行 Skill / 工具",
+                        title=tool_step_title,
                         stage="tools",
                         message=f"第 3 步：已补齐文件生成参数（{'；'.join(repaired_changes)}）。",
                         )
@@ -451,7 +457,7 @@ async def run_p2_tools(
                 workflow_status(
                     step_index=3,
                     step_total=4,
-                    title="执行 Skill / 工具",
+                    title=tool_step_title,
                     stage="tools",
                     status="confirmation_required",
                     message="第 3 步：该操作会修改或删除项目内容，已暂停等待确认。",
@@ -611,7 +617,7 @@ async def run_p2_tools(
                 workflow_status(
                     step_index=3,
                     step_total=4,
-                    title="执行 Skill / 工具",
+                    title=tool_step_title,
                     stage="tools",
                     message=f"第 3 步：{tool_name} 首次执行失败，正在自动重试一次。",
                 )
@@ -666,7 +672,7 @@ async def run_p2_tools(
             workflow_status(
                 step_index=3,
                 step_total=4,
-                title="执行 Skill / 工具",
+                title=tool_step_title,
                 stage="tools",
                 status="confirmation_required" if has_confirmation else "error" if has_tool_error else "completed",
                 message=(
@@ -675,7 +681,7 @@ async def run_p2_tools(
                     else
                     "第 3 步：工具执行遇到错误，正在整理可恢复信息。"
                     if has_tool_error
-                    else "第 3 步：Skill / 工具调用已完成。"
+                    else f"第 3 步：{tool_step_title}已完成。"
                 ),
             )
         )

--- a/backend/app/services/chat/phases/p3_followup.py
+++ b/backend/app/services/chat/phases/p3_followup.py
@@ -357,6 +357,7 @@ async def run_p3_followup(
         yield sse_event(
             {"type": "status", "stage": "tools", "message": "检测到后续工具调用，正在执行..."}
         )
+        tool_step_title = "执行 Skill / 工具" if runtime.skill_name else "执行工具"
 
         for tool_data in p3_tool_use_blocks:
             tool_name = tool_data.get("name", "")
@@ -390,7 +391,7 @@ async def run_p3_followup(
                         workflow_status(
                             step_index=3,
                             step_total=4,
-                            title="执行 Skill / 工具",
+                            title=tool_step_title,
                             stage="tools",
                             message=f"第 3 步：已补齐后续 Markdown 工具参数（{'；'.join(repaired_changes)}）。",
                         )
@@ -414,7 +415,7 @@ async def run_p3_followup(
                         workflow_status(
                             step_index=3,
                             step_total=4,
-                            title="执行 Skill / 工具",
+                            title=tool_step_title,
                             stage="tools",
                             message=f"第 3 步：已补齐后续文件生成参数（{'；'.join(repaired_changes)}）。",
                         )
@@ -533,7 +534,7 @@ async def run_p3_followup(
                     workflow_status(
                         step_index=3,
                         step_total=4,
-                        title="执行 Skill / 工具",
+                        title=tool_step_title,
                         stage="tools",
                         status="confirmation_required",
                         message="第 3 步：后续工具调用涉及修改或删除，等待确认后再执行。",

--- a/backend/app/services/chat/runtime.py
+++ b/backend/app/services/chat/runtime.py
@@ -39,7 +39,12 @@ from app.services.chat.working_memory import (
 from app.services.consulting_intelligence import ConsultingTurnFrame, build_consulting_turn_frame
 from app.services.intent_router import IntentDecision, classify_chat_intent, classify_chat_intent_async
 from app.services.policy_guards import filter_tools_for_access
-from app.services.skill_router import SkillActivationDecision, auto_select_skill, decide_skill_activation
+from app.services.skill_router import (
+    SkillActivationDecision,
+    auto_select_skill,
+    decide_skill_activation,
+    is_proposal_presentation_request,
+)
 from app.services.task_orchestrator import RULE_FIRST_OVERRIDE_CONFIDENCE, rule_based_project_task_route
 from app.services.artifact_intent import ArtifactContract
 from app.tools.project_markdown import PROJECT_MARKDOWN_TOOL_NAME
@@ -287,6 +292,7 @@ def _resolve_effective_skill(session: Session, req: SendMessageRequest) -> tuple
             and task_route.task_type
             and task_route.confidence >= RULE_FIRST_OVERRIDE_CONFIDENCE
             and office_output_kind in {"pptx", "xlsx", "docx", "pdf"}
+            and not is_proposal_presentation_request(req.content)
         ):
             auto_decision = SkillActivationDecision(
                 False,

--- a/backend/app/services/chat/workflow.py
+++ b/backend/app/services/chat/workflow.py
@@ -257,7 +257,7 @@ def workflow_plan_events(*, step_total: int = TOOL_WORKFLOW_STEP_TOTAL) -> list[
             title="判断执行方式",
             stage="planning",
             status="completed",
-            message="第 1 步：已判断这是需要调用 Skill / 工具的执行型任务。",
+            message="第 1 步：已判断这是需要读取上下文或调用工具的任务。",
         ),
         workflow_status(
             step_index=2,

--- a/backend/app/services/deliverable_naming.py
+++ b/backend/app/services/deliverable_naming.py
@@ -47,6 +47,7 @@ def clean_deliverable_topic(value: str) -> str:
     for pattern in cleanup_patterns:
         text = re.sub(pattern, " ", text, flags=re.IGNORECASE)
     text = re.sub(r"\s+", "", text).strip("-_｜|/ ")
+    text = re.sub(r"(吧|呢|吗|嘛|呀|啦|哈|哦|啊)+$", "", text)
     generic_values = {"", "客户", "项目", "方案", "建议", "材料", "交付物", "沟通", "初稿"}
     if any(marker in text for marker in _INSTRUCTION_ONLY_MARKERS):
         return ""

--- a/backend/app/services/skill_router.py
+++ b/backend/app/services/skill_router.py
@@ -104,8 +104,8 @@ _SKILL_ALIAS_TERMS: tuple[tuple[tuple[str, ...], tuple[str, ...]], ...] = (
     (("office", "文档编辑"), ("office", "word", "excel", "ppt", "pptx", "docx", "xlsx", "编辑文档", "修改ppt", "更新word")),
     (("顾问式ppt", "presentation"), ("ppt", "pptx", "演示文稿", "幻灯片", "deck", "汇报材料", "路演", "客户介绍")),
     (("presentation-builder", "presentation builder"), ("ppt", "pptx", "deck", "演示文稿", "汇报材料", "项目汇报", "客户简报")),
-    (("咨询提案", "proposal"), ("提案", "建议书", "proposal", "sow", "商业案例", "报价方案", "客户方案")),
-    (("consulting-proposal-advisor", "proposal advisor"), ("提案", "建议书", "proposal", "sow", "商业案例", "报价", "客户方案")),
+    (("咨询提案", "proposal"), ("提案", "建议书", "proposal", "sow", "商业案例", "报价方案", "客户方案", "方案沟通", "客户沟通", "沟通材料")),
+    (("consulting-proposal-advisor", "proposal advisor"), ("提案", "建议书", "proposal", "sow", "商业案例", "报价", "客户方案", "方案沟通", "客户沟通", "沟通材料")),
     (("数字化战略", "digital"), ("数字化战略", "数字化转型", "转型战略", "digital strategy")),
     (("digital-strategy", "digital strategy"), ("数字化战略", "数字化转型", "转型路线图", "数字化蓝图", "top-level design")),
     (("ai-strategy", "ai strategy"), ("ai战略", "ai 战略", "人工智能战略", "ai roadmap", "ai转型")),
@@ -114,6 +114,28 @@ _SKILL_ALIAS_TERMS: tuple[tuple[tuple[str, ...], tuple[str, ...]], ...] = (
     (("访谈", "interview"), ("访谈", "访谈提纲", "访谈问题", "interview guide")),
     (("会前", "brief", "meeting"), ("会前", "见客户", "客户会议准备", "客户简报", "pre-meeting", "meeting prep")),
 )
+
+
+def is_proposal_presentation_request(content: str) -> bool:
+    """Return true for proposal/client-communication requests that need a deck."""
+    text = _normalize_for_skill_match(content)
+    if not text:
+        return False
+    presentation_terms = ("ppt", "pptx", "powerpoint", "deck", "演示文稿", "幻灯片")
+    proposal_terms = (
+        "方案沟通",
+        "客户沟通",
+        "沟通方案",
+        "沟通材料",
+        "客户方案",
+        "方案建议",
+        "提案",
+        "建议书",
+        "售前方案",
+        "汇报方案",
+        "项目方案",
+    )
+    return any(term in text for term in presentation_terms) and any(term in text for term in proposal_terms)
 
 
 def skill_auto_match_score(content: str, skill: Skill) -> tuple[int, str]:
@@ -128,6 +150,12 @@ def skill_auto_match_score(content: str, skill: Skill) -> tuple[int, str]:
     haystack = _normalize_for_skill_match(
         "\n".join([skill.name or "", skill.description or "", skill.category or ""])
     )
+    if is_proposal_presentation_request(content) and any(
+        marker in haystack
+        for marker in ("consulting-proposal-advisor", "proposaladvisor", "咨询提案", "提案", "建议书")
+    ):
+        return 94, "proposal_presentation_intent"
+
     best_score = 0
     best_reason = "no_match"
 

--- a/backend/tests/test_chat_flow.py
+++ b/backend/tests/test_chat_flow.py
@@ -3677,7 +3677,51 @@ class ChatStreamingServiceTestCase(unittest.TestCase):
         )
         self.assertEqual(mocked_context.call_args.kwargs["skill_id"], skill_id)
 
-    def test_prepare_chat_runtime_routes_explicit_ppt_before_auto_skill(self):
+    def test_prepare_chat_runtime_associates_proposal_ppt_with_proposal_skill(self):
+        conv_id = self._create_conversation()
+        with Session(self.engine) as session:
+            project = session.get(Project, 1)
+            if project is None:
+                project = Project(id=1, name="Project", client="Client")
+                session.add(project)
+                session.commit()
+            session.add(
+                Skill(
+                    name="consulting-proposal-advisor",
+                    category="顾问基础能力",
+                    description="Create client-ready consulting proposals, PPT outlines, PPTX decks, business cases, SOWs, roadmaps.",
+                    system_prompt="proposal skill system",
+                )
+            )
+            session.commit()
+
+            with patch.object(chat_streaming_module, "build_chat_context") as mocked_context, patch.object(
+                chat_streaming_module,
+                "_load_provider_module",
+            ) as mocked_provider, patch.object(
+                chat_streaming_module,
+                "get_selected_model",
+                return_value="kimi-k2.6",
+            ):
+                mocked_context.return_value = context_builder_module.ChatContext(max_tokens=8192)
+                mocked_provider.return_value = SimpleNamespace(
+                    build_system_prompt=lambda skill_prompt, rag_context, project_context, **kwargs: f"system:{skill_prompt}"
+                )
+
+                runtime = chat_streaming_module.prepare_chat_runtime(
+                    session,
+                    chat_router_module.SendMessageRequest(
+                        conversation_id=conv_id,
+                        project_id=1,
+                        content="给我一个客户沟通的初步方案 ppt版本",
+                    ),
+                )
+
+        self.assertEqual(runtime.skill_name, "consulting-proposal-advisor")
+        self.assertIn("auto_skill_match:consulting-proposal-advisor:proposal_presentation_intent", runtime.prepare_metrics["skill_decision"])
+        self.assertEqual(mocked_context.call_args.kwargs["skill_id"], runtime.prepare_metrics["effective_skill_id"])
+
+    def test_prepare_chat_runtime_routes_generic_ppt_before_auto_skill(self):
         conv_id = self._create_conversation()
         with Session(self.engine) as session:
             project = session.get(Project, 1)
@@ -3713,15 +3757,12 @@ class ChatStreamingServiceTestCase(unittest.TestCase):
                     chat_router_module.SendMessageRequest(
                         conversation_id=conv_id,
                         project_id=1,
-                        content="给我一个客户沟通的初步方案 ppt版本",
+                        content="给我做一个客户介绍 PPT",
                     ),
                 )
 
         self.assertFalse(runtime.skill_name)
         self.assertEqual(runtime.prepare_metrics["skill_decision"], "auto_skill_skipped_task_route:generate_client_ppt")
-        self.assertEqual(runtime.prepare_metrics["chat_mode"], "task_orchestration")
-        self.assertEqual(runtime.prepare_metrics["action_policy"], "durable_task")
-        self.assertEqual(runtime.prepare_metrics["tool_access_policy"], "write_allowed")
         self.assertEqual(runtime.prepare_metrics["artifact_contract"]["output_kind"], "pptx")
         self.assertEqual(mocked_context.call_args.kwargs["skill_id"], None)
 

--- a/backend/tests/test_skill_router.py
+++ b/backend/tests/test_skill_router.py
@@ -1,6 +1,10 @@
 from types import SimpleNamespace
 
-from app.services.skill_router import decide_skill_activation, skill_auto_match_score
+from app.services.skill_router import (
+    decide_skill_activation,
+    is_proposal_presentation_request,
+    skill_auto_match_score,
+)
 
 
 def test_selected_skill_runs_for_clear_workflow_deliverable_request():
@@ -33,3 +37,17 @@ def test_presentation_builder_matches_client_deck_language():
 
     assert score >= 82
     assert reason.startswith("alias:")
+
+
+def test_consulting_proposal_skill_wins_for_proposal_presentation_language():
+    skill = SimpleNamespace(
+        name="consulting-proposal-advisor",
+        description="Create client-ready consulting proposals and PPTX decks",
+        category="consulting",
+    )
+
+    score, reason = skill_auto_match_score("准备一个方案沟通ppt吧", skill)
+
+    assert is_proposal_presentation_request("准备一个方案沟通ppt吧") is True
+    assert score >= 94
+    assert reason == "proposal_presentation_intent"

--- a/backend/tests/test_task_orchestrator.py
+++ b/backend/tests/test_task_orchestrator.py
@@ -356,6 +356,18 @@ def test_deliverable_title_removes_excel_command_language():
     assert task_orchestrator.file_name_for_deliverable(title, "xlsx") == "东阿阿胶股份有限公司-访谈问卷.xlsx"
 
 
+def test_deliverable_title_removes_final_modal_particle():
+    title = task_orchestrator.normalize_deliverable_title(
+        content="准备一个方案沟通ppt吧",
+        explicit_title="",
+        file_type="pptx",
+        client_name="广州岭南商旅投资集团有限公司",
+    )
+
+    assert title == "广州岭南商旅投资集团有限公司-方案沟通"
+    assert "吧" not in task_orchestrator.file_name_for_deliverable(title, "pptx")
+
+
 def test_llm_router_uses_structured_plan():
     async def fake_complete(*args, **kwargs):
         return json.dumps(

--- a/web/src/components/Layout.test.tsx
+++ b/web/src/components/Layout.test.tsx
@@ -75,6 +75,19 @@ describe('Layout', () => {
     })
   })
 
+  it('uses cached user initials before /auth/me resolves', () => {
+    localStorage.setItem('user', JSON.stringify({ display_name: 'Guo Liang', email: 'guo@example.com' }))
+    renderLayout()
+
+    expect(screen.getByRole('button', { name: 'User menu' })).toHaveTextContent('GL')
+  })
+
+  it('does not flash a placeholder letter while user data loads', () => {
+    renderLayout()
+
+    expect(screen.getByRole('button', { name: 'User menu' })).toHaveTextContent('')
+  })
+
   it('shows unread badge count', async () => {
     renderLayout()
     await waitFor(() => {

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -11,6 +11,7 @@ import {
   BookOpen,
   LogOut,
   Settings,
+  UserRound,
 } from 'lucide-react'
 import { useState, useEffect } from 'react'
 import { api } from '../api/client'
@@ -18,13 +19,48 @@ import type { User } from '../types/api'
 import { primaryRouteLoaders, warmPrimaryRoutes } from '../routeLoaders'
 import { DEFAULT_APP_TIMEZONE, setAppTimeZone } from '../utils/timezone'
 
+function getStoredUser(): User | null {
+  try {
+    const raw = localStorage.getItem('user')
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as Partial<User>
+    if (!parsed || typeof parsed !== 'object') return null
+    const displayName = typeof parsed.display_name === 'string' ? parsed.display_name.trim() : ''
+    const email = typeof parsed.email === 'string' ? parsed.email : ''
+    if (!displayName && !email) return null
+    return {
+      id: typeof parsed.id === 'number' ? parsed.id : 0,
+      email,
+      display_name: displayName || email,
+      is_admin: !!parsed.is_admin,
+      is_active: parsed.is_active !== false,
+    }
+  } catch {
+    return null
+  }
+}
+
+function getUserInitials(user: User | null) {
+  const name = user?.display_name?.trim()
+  if (!name) return ''
+  const words = name.split(/\s+/).filter(Boolean)
+  if (words.length >= 2) {
+    return words
+      .slice(0, 2)
+      .map((word) => word[0])
+      .join('')
+      .toUpperCase()
+  }
+  return Array.from(words[0] || name).slice(0, 2).join('').toUpperCase()
+}
+
 export function Layout() {
   const { t, i18n } = useTranslation()
   const isZh = i18n.language.startsWith('zh')
   const location = useLocation()
   const navigate = useNavigate()
   const [showUserMenu, setShowUserMenu] = useState(false)
-  const [user, setUser] = useState<User | null>(null)
+  const [user, setUser] = useState<User | null>(() => getStoredUser())
   const [unreadCount, setUnreadCount] = useState(0)
   const isProjectDetailRoute = /^\/projects\/(?!new(?:\/|$))[^/]+/.test(location.pathname)
 
@@ -39,7 +75,12 @@ export function Layout() {
   ]
 
   useEffect(() => {
-    api.get<User>('/auth/me').then(setUser).catch(() => {})
+    api.get<User>('/auth/me')
+      .then((nextUser) => {
+        setUser(nextUser)
+        localStorage.setItem('user', JSON.stringify(nextUser))
+      })
+      .catch(() => {})
   }, [])
 
   useEffect(() => {
@@ -85,14 +126,7 @@ export function Layout() {
     window.location.href = '/login'
   }
 
-  const initials = user?.display_name
-    ? user.display_name
-        .split(' ')
-        .map((word) => word[0])
-        .join('')
-        .toUpperCase()
-        .slice(0, 2)
-    : 'A'
+  const initials = getUserInitials(user)
 
   return (
     <div className="flex h-full flex-col bg-surface">
@@ -151,10 +185,11 @@ export function Layout() {
               <div className="relative">
                 <button
                   onClick={() => setShowUserMenu(!showUserMenu)}
-                  className="flex h-7 w-7 items-center justify-center rounded-full bg-gradient-primary text-[11px] font-medium leading-none text-white"
+                  className="flex h-7 w-7 items-center justify-center rounded-full bg-gradient-primary text-[9px] font-semibold leading-none text-white"
+                  aria-label="User menu"
                   title={user?.display_name || 'User'}
                 >
-                  {initials}
+                  {initials || <UserRound className="h-3.5 w-3.5" aria-hidden="true" />}
                 </button>
 
                 {showUserMenu && (

--- a/web/src/pages/projects/projectChatWorkflow.test.ts
+++ b/web/src/pages/projects/projectChatWorkflow.test.ts
@@ -31,7 +31,7 @@ describe("workflowStepsFromToolCalls", () => {
     expect(steps.map((step) => step.step_title)).toEqual([
       "理解需求与上下文",
       "制定执行计划",
-      "执行 Skill / 工具",
+      "执行工具",
       "整理结果与链接",
     ]);
     expect(steps[2].details).toContain("读取项目文件：已完成。");
@@ -40,6 +40,20 @@ describe("workflowStepsFromToolCalls", () => {
       "写入项目 Markdown 文档：已完成：Created 项目背景.md；已写入项目 Markdown 文件。",
     );
     expect(JSON.stringify(steps)).not.toContain("Executing read_project_file");
+  });
+
+  it("keeps Skill wording only for actual skill tool calls", () => {
+    const calls: ToolCallEvent[] = [
+      {
+        tool_name: "generate_ppt_from_skill",
+        status: "completed",
+        message: "Skill 交付物已生成。",
+      },
+    ];
+
+    const steps = workflowStepsFromToolCalls(calls);
+
+    expect(steps[2].step_title).toBe("执行 Skill / 工具");
   });
 
   it("preserves existing workflow steps without wrapping again", () => {

--- a/web/src/pages/projects/projectChatWorkflow.ts
+++ b/web/src/pages/projects/projectChatWorkflow.ts
@@ -197,6 +197,19 @@ function summarizeToolCalls(calls: ToolCallEvent[]) {
   return Array.from(byTool.values());
 }
 
+function isSkillToolCall(call: ToolCallEvent) {
+  const text = [
+    call.tool_name,
+    call.step_title || "",
+    call.message || "",
+    call.summary || "",
+    ...(call.details || []),
+  ]
+    .join("\n")
+    .toLowerCase();
+  return text.includes("skill") || call.tool_name === "generate_ppt_from_skill";
+}
+
 export function workflowStepsFromToolCalls(calls: ToolCallEvent[]): ToolCallEvent[] {
   if (!calls.length || calls.some((call) => call.step_index !== undefined && call.step_index !== null)) {
     return calls;
@@ -213,6 +226,7 @@ export function workflowStepsFromToolCalls(calls: ToolCallEvent[]): ToolCallEven
       call.tool_name,
     ),
   );
+  const toolStepTitle = summarizedCalls.some(isSkillToolCall) ? "执行 Skill / 工具" : "执行工具";
 
   return [
     {
@@ -234,7 +248,7 @@ export function workflowStepsFromToolCalls(calls: ToolCallEvent[]): ToolCallEven
       step_title: "制定执行计划",
     },
     {
-      tool_name: "执行 Skill / 工具",
+      tool_name: toolStepTitle,
       status: toolStatus,
       message:
         toolStatus === "completed"
@@ -245,7 +259,7 @@ export function workflowStepsFromToolCalls(calls: ToolCallEvent[]): ToolCallEven
       confirmation_token: summarizedCalls.find((call) => call.status === "confirmation_required")?.confirmation_token,
       step_index: 3,
       step_total: 4,
-      step_title: "执行 Skill / 工具",
+      step_title: toolStepTitle,
     },
     {
       tool_name: "整理结果与链接",


### PR DESCRIPTION
## Summary
- Fix the avatar fallback so the header no longer flashes a temporary “A”, and reduce initials sizing.
- Clarify project chat progress labels so normal tool calls are not shown as Skill execution.
- Route proposal/client-communication PPT requests to the consulting proposal Skill while preserving generic PPT generation.
- Clean generated deliverable names by removing trailing modal particles such as “吧”.

## Validation
- npm test -- --run Layout.test.tsx
- npm test -- --run projectChatWorkflow.test.ts ProjectChatToolCallCard.test.tsx
- npm run build
- PYTHONPATH=. .venv/bin/python -m pytest -q tests/test_skill_router.py tests/test_task_orchestrator.py::test_deliverable_title_removes_final_modal_particle tests/test_chat_flow.py::ChatStreamingServiceTestCase::test_prepare_chat_runtime_associates_proposal_ppt_with_proposal_skill tests/test_chat_flow.py::ChatStreamingServiceTestCase::test_prepare_chat_runtime_routes_generic_ppt_before_auto_skill
- python3 -m compileall -q backend/app/services backend/tests/test_skill_router.py backend/tests/test_task_orchestrator.py backend/tests/test_chat_flow.py
- git diff --check
