### PR TITLE
[codex] Tighten header avatar initials

### DIFF
--- a/web/src/components/Layout.test.tsx
+++ b/web/src/components/Layout.test.tsx
@@ -73,6 +73,11 @@ describe('Layout', () => {
     await waitFor(() => {
       expect(screen.getByText('JD')).toBeInTheDocument()
     })
+    expect(screen.getByTestId('user-initials')).toHaveStyle({
+      fontSize: '8px',
+      lineHeight: '1',
+      transform: 'scale(0.82)',
+    })
   })
 
   it('uses cached user initials before /auth/me resolves', () => {
@@ -80,6 +85,10 @@ describe('Layout', () => {
     renderLayout()
 
     expect(screen.getByRole('button', { name: 'User menu' })).toHaveTextContent('GL')
+    expect(screen.getByTestId('user-initials')).toHaveStyle({
+      fontSize: '8px',
+      transform: 'scale(0.82)',
+    })
   })
 
   it('does not flash a placeholder letter while user data loads', () => {

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -127,6 +127,7 @@ export function Layout() {
   }
 
   const initials = getUserInitials(user)
+  const initialsScale = initials.length >= 2 ? 0.82 : 0.92
 
   return (
     <div className="flex h-full flex-col bg-surface">
@@ -185,11 +186,26 @@ export function Layout() {
               <div className="relative">
                 <button
                   onClick={() => setShowUserMenu(!showUserMenu)}
-                  className="flex h-7 w-7 items-center justify-center rounded-full bg-gradient-primary text-[9px] font-semibold leading-none text-white"
+                  className="flex h-7 w-7 items-center justify-center overflow-hidden rounded-full bg-gradient-primary text-white"
                   aria-label="User menu"
                   title={user?.display_name || 'User'}
                 >
-                  {initials || <UserRound className="h-3.5 w-3.5" aria-hidden="true" />}
+                  {initials ? (
+                    <span
+                      className="block max-w-[18px] text-center font-semibold leading-none"
+                      data-testid="user-initials"
+                      style={{
+                        fontSize: '8px',
+                        lineHeight: 1,
+                        transform: `scale(${initialsScale})`,
+                        transformOrigin: 'center',
+                      }}
+                    >
+                      {initials}
+                    </span>
+                  ) : (
+                    <UserRound className="h-3.5 w-3.5" aria-hidden="true" />
+                  )}
                 </button>
 
                 {showUserMenu && (


### PR DESCRIPTION
## Summary
- Add a constrained inner span for header avatar initials so the letters cannot inherit oversized button text.
- Clamp initials with 8px font size, max width, overflow clipping, and a two-letter scale.
- Extend Layout tests to assert the initials sizing guard.

## Validation
- npm test -- --run Layout.test.tsx
- npm run build
