### PR TITLE
[codex] Remove meeting prep header button

### DIFF
--- a/web/src/pages/projects/ProjectDetailHeader.tsx
+++ b/web/src/pages/projects/ProjectDetailHeader.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
-import { NavLink, useNavigate } from "react-router-dom";
-import { ArrowLeft, CalendarDays, Circle } from "lucide-react";
+import { NavLink } from "react-router-dom";
+import { ArrowLeft, Circle } from "lucide-react";
 import type { Project } from "../../types/api";
 import { resolveProjectStage } from "../../types/enums";
 import { PROJECT_DETAIL_TABS } from "./projectDetailTabs";
@@ -17,7 +17,6 @@ export function ProjectDetailHeader({
   compact?: boolean;
 }) {
   const { i18n, t } = useTranslation();
-  const navigate = useNavigate();
   const isZh = i18n.language.startsWith("zh");
   const rawStatus = String(project.status || "").trim();
   const stage = resolveProjectStage(rawStatus);
@@ -52,15 +51,6 @@ export function ProjectDetailHeader({
               : "Tasks"
             : t(labelKey);
 
-  const handleMeetingPrep = () => {
-    const prompt = isZh
-      ? `请帮我准备一次客户会议。项目：${project.name}${project.client ? `，客户：${project.client}` : ""}。请输出：1）开场话术；2）关键议题顺序；3）每个关键人应关注的表达方式；4）会后行动清单。`
-      : `Help me prepare for a client meeting. Project: ${project.name}${project.client ? `, Client: ${project.client}` : ""}. Output: 1) Opening talking points; 2) Key agenda order; 3) Communication tips per stakeholder; 4) Post-meeting action items.`;
-    sessionStorage.setItem("briefing_prompt", prompt);
-    sessionStorage.setItem("briefing_auto_send", "1");
-    navigate(`/projects/${projectId}/chat?briefing=1`);
-  };
-
   if (compact) {
     return (
       <header className="sticky top-0 z-30 border-b border-slate-200/80 bg-white/95 shadow-sm backdrop-blur">
@@ -87,14 +77,6 @@ export function ProjectDetailHeader({
                 <Circle className="h-1.5 w-1.5 fill-current" />
                 {statusLabel}
               </span>
-              <button
-                onClick={handleMeetingPrep}
-                className="hidden flex-shrink-0 items-center gap-1.5 rounded-md border border-slate-200 bg-white px-2.5 py-1 text-xs font-medium text-slate-600 shadow-sm transition hover:border-primary/30 hover:text-primary sm:inline-flex"
-                title={isZh ? "会前准备" : "Meeting Prep"}
-              >
-                <CalendarDays className="h-3.5 w-3.5" />
-                {isZh ? "会前准备" : "Meeting Prep"}
-              </button>
             </div>
           </div>
 
@@ -159,14 +141,6 @@ export function ProjectDetailHeader({
               <Circle className="h-2 w-2 fill-current" />
               {statusLabel}
             </span>
-            <button
-              onClick={handleMeetingPrep}
-              className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-600 shadow-sm transition hover:border-primary/30 hover:text-primary"
-              title={isZh ? "会前准备" : "Meeting Prep"}
-            >
-              <CalendarDays className="h-3.5 w-3.5" />
-              {isZh ? "会前准备" : "Meeting Prep"}
-            </button>
             {project.memory_stale ? (
               <span className="inline-flex items-center rounded-lg bg-rose-50 px-3 py-1.5 text-xs font-semibold text-rose-700 ring-1 ring-inset ring-rose-200">
                 {isZh ? "记忆待更新" : "Memory stale"}

--- a/web/src/pages/projects/ProjectOverviewSidebar.tsx
+++ b/web/src/pages/projects/ProjectOverviewSidebar.tsx
@@ -7,6 +7,7 @@ interface ProjectOverviewSidebarProps {
   formatAmount: (amount: number | undefined | null) => string;
   isZh: boolean;
   memoryCard?: ReactNode;
+  skillWorkflowsCard?: ReactNode;
   onGoToDocuments: () => void;
   onGoToFinancials: () => void;
   onGoToMilestones: () => void;
@@ -19,6 +20,7 @@ export function ProjectOverviewSidebar({
   formatAmount,
   isZh,
   memoryCard,
+  skillWorkflowsCard,
   onGoToDocuments,
   onGoToFinancials,
   onGoToMilestones,
@@ -78,6 +80,8 @@ export function ProjectOverviewSidebar({
       </div>
 
       {memoryCard}
+
+      {skillWorkflowsCard}
 
       <div className="bg-white rounded-xl border border-gray-200">
         <div className="flex items-center justify-between border-b border-gray-100 p-4">

--- a/web/src/pages/projects/ProjectOverviewTab.tsx
+++ b/web/src/pages/projects/ProjectOverviewTab.tsx
@@ -104,12 +104,6 @@ export function ProjectOverviewTab({
           projectStatus={project.status}
         />
 
-        <ProjectSkillWorkflowsCard
-          isZh={isZh}
-          onStart={handleStartProjectSkill}
-          projectDetail={projectDetail}
-        />
-
         <ProjectOverviewSummaryCard
           generatingSummary={generatingSummary}
           isZh={isZh}
@@ -154,6 +148,14 @@ export function ProjectOverviewTab({
             isZh={isZh}
             memory={memory}
             onRebuild={() => void rebuildMemory()}
+          />
+        }
+        skillWorkflowsCard={
+          <ProjectSkillWorkflowsCard
+            isZh={isZh}
+            onStart={handleStartProjectSkill}
+            projectDetail={projectDetail}
+            variant="compact"
           />
         }
         onGoToDocuments={() => navigate(`/projects/${projectId}/space`)}

--- a/web/src/pages/projects/ProjectSkillWorkflowsCard.tsx
+++ b/web/src/pages/projects/ProjectSkillWorkflowsCard.tsx
@@ -7,10 +7,12 @@ export function ProjectSkillWorkflowsCard({
   isZh,
   onStart,
   projectDetail,
+  variant = "default",
 }: {
   isZh: boolean;
   onStart: (intent: ProjectSkillIntent) => void;
   projectDetail: ProjectDetailType;
+  variant?: "default" | "compact";
 }) {
   const { project, files, todos } = projectDetail;
   const openTodos = todos.filter((todo) => !todo.is_done).length;
@@ -41,6 +43,55 @@ export function ProjectSkillWorkflowsCard({
       title: isZh ? "客户沟通策略" : "Client alignment",
     },
   ];
+
+  if (variant === "compact") {
+    return (
+      <section className="rounded-xl border border-gray-200 bg-white p-4">
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <h3 className="flex items-center gap-2 text-[13px] font-semibold leading-5 text-gray-900">
+            <Sparkles className="h-4 w-4 text-indigo-500" />
+            {isZh ? "项目 Skill 工作流" : "Project Skill workflows"}
+          </h3>
+          <div className="flex items-center gap-1.5 text-[11px] font-medium text-slate-500">
+            <span>{files.length} {isZh ? "文档" : "docs"}</span>
+            <span className="text-slate-300">/</span>
+            <span>{openTodos} {isZh ? "待办" : "open"}</span>
+          </div>
+        </div>
+        <p className="mb-3 text-xs leading-5 text-slate-500">
+          {isZh
+            ? "带入当前项目上下文，快速启动常用 Skill。"
+            : "Launch common Skills with this project context."}
+        </p>
+        <div className="space-y-2">
+          {actions.map((action) => {
+            const Icon = action.icon;
+            return (
+              <button
+                key={action.intent}
+                type="button"
+                onClick={() => onStart(action.intent)}
+                className="group flex w-full items-center gap-3 rounded-lg border border-slate-100 bg-slate-50/70 p-2.5 text-left transition hover:border-indigo-100 hover:bg-indigo-50"
+              >
+                <span className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-white text-indigo-600 shadow-sm">
+                  <Icon className="h-4 w-4" />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-[13px] font-semibold leading-5 text-slate-900">
+                    {action.title}
+                  </span>
+                  <span className="line-clamp-2 text-xs leading-5 text-slate-500">
+                    {action.description}
+                  </span>
+                </span>
+                <ArrowRight className="h-4 w-4 flex-shrink-0 text-slate-300 transition group-hover:text-indigo-600" />
+              </button>
+            );
+          })}
+        </div>
+      </section>
+    );
+  }
 
   return (
     <section className="overflow-hidden rounded-[1.75rem] border border-indigo-100 bg-[radial-gradient(circle_at_top_right,#e0e7ff_0%,#f8fafc_45%,#ffffff_100%)] p-6 shadow-sm">


### PR DESCRIPTION
## Summary
- Remove the Meeting Prep / 会前准备 button from the project detail header
- Drop the now-unused chat briefing launch handler and icon import

## Validation
- `npm run test:project-chat`
- `npx vitest run --config vitest.config.ts ProjectDetail.test.tsx ProjectChatMessages.test.tsx --run`
- `npm run build`
