### PR TITLE
A2: Product Run Event v1 consumer + Run Activity Timeline (flagged)

### DIFF
--- a/web/src/pages/projects/ProjectChatActivityTimeline.test.tsx
+++ b/web/src/pages/projects/ProjectChatActivityTimeline.test.tsx
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { ProjectChatActivityTimeline } from "./ProjectChatActivityTimeline";
+import type { RunActivityTimeline } from "../../stores/runActivityReducer";
+
+function makeTimeline(overrides: Partial<RunActivityTimeline> = {}): RunActivityTimeline {
+  return {
+    run_id: "r1",
+    steps: [],
+    artifacts: [],
+    text: "",
+    ...overrides,
+  };
+}
+
+describe("ProjectChatActivityTimeline", () => {
+  it("renders the Skill banner when a skill is active", () => {
+    render(
+      <ProjectChatActivityTimeline
+        timeline={makeTimeline({ skill: { name: "数字化战略", id: "digital-strategy" } })}
+      />,
+    );
+    expect(screen.getByText(/Skill：数字化战略/)).toBeInTheDocument();
+  });
+
+  it("renders steps with status badges and groups tool items by tool_name", () => {
+    const timeline = makeTimeline({
+      steps: [
+        {
+          index: 1,
+          title: "读取上下文",
+          status: "completed",
+          duration_ms: 230,
+          items: [
+            { tool_name: "读取项目文件", status: "completed" },
+            { tool_name: "读取项目文档", status: "completed" },
+          ],
+        },
+        {
+          index: 2,
+          title: "生成回复",
+          status: "running",
+          items: [],
+        },
+      ],
+    });
+    render(<ProjectChatActivityTimeline timeline={timeline} />);
+    expect(screen.getByText("读取上下文")).toBeInTheDocument();
+    expect(screen.getByText("生成回复")).toBeInTheDocument();
+    expect(screen.getByText(/230ms/)).toBeInTheDocument();
+  });
+
+  it("collapses to a completed summary when final_status is completed", () => {
+    const timeline = makeTimeline({
+      final_status: "completed",
+      steps: [
+        { index: 1, title: "a", status: "completed", items: [] },
+        { index: 2, title: "b", status: "completed", items: [] },
+      ],
+      artifacts: [{ id: "57", type: "pptx" }],
+    });
+    render(<ProjectChatActivityTimeline timeline={timeline} />);
+    expect(screen.getByText(/已完成 · 2 步/)).toBeInTheDocument();
+    expect(screen.getByText(/1 个交付物/)).toBeInTheDocument();
+  });
+
+  it("renders the confirmation card when one is pending", () => {
+    render(
+      <ProjectChatActivityTimeline
+        timeline={makeTimeline({
+          confirmation: { action: "删除项目文件", impact: "该操作不可恢复" },
+        })}
+      />,
+    );
+    expect(screen.getByText(/需要确认：删除项目文件/)).toBeInTheDocument();
+    expect(screen.getByText("该操作不可恢复")).toBeInTheDocument();
+  });
+
+  it("renders artifacts with a download link when provided", () => {
+    render(
+      <ProjectChatActivityTimeline
+        timeline={makeTimeline({
+          artifacts: [
+            { id: "57", type: "pptx", download_url: "/files/57" },
+          ],
+        })}
+      />,
+    );
+    const link = screen.getByRole("link", { name: "下载" });
+    expect(link).toHaveAttribute("href", "/files/57");
+  });
+
+  it("renders the live status one-liner while no terminal status is set", () => {
+    render(
+      <ProjectChatActivityTimeline
+        timeline={makeTimeline({ status: { message: "正在读取项目文档..." } })}
+      />,
+    );
+    expect(screen.getByText("正在读取项目文档...")).toBeInTheDocument();
+  });
+
+  it("renders an error card when run_failed produced an error", () => {
+    render(
+      <ProjectChatActivityTimeline
+        timeline={makeTimeline({
+          final_status: "failed",
+          error: { code: "MODEL_TIMEOUT", message: "AI 超时，请稍后重试" },
+        })}
+      />,
+    );
+    expect(screen.getByText(/失败：MODEL_TIMEOUT/)).toBeInTheDocument();
+    expect(screen.getByText("AI 超时，请稍后重试")).toBeInTheDocument();
+  });
+
+  it("renders task progress when task_update has set the state", () => {
+    render(
+      <ProjectChatActivityTimeline
+        timeline={makeTimeline({
+          task: {
+            task_id: "42",
+            status: "running",
+            progress_pct: 50,
+            current_step: 2,
+            total_steps: 4,
+            step_title: "生成大纲",
+          },
+        })}
+      />,
+    );
+    expect(screen.getByText(/任务 #42 · 生成大纲/)).toBeInTheDocument();
+    expect(screen.getByText(/50%/)).toBeInTheDocument();
+    expect(screen.getByText(/2\/4/)).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/projects/ProjectChatActivityTimeline.tsx
+++ b/web/src/pages/projects/ProjectChatActivityTimeline.tsx
@@ -1,0 +1,223 @@
+/**
+ * Run Activity Timeline (Product Run Event v1).
+ *
+ * Renders the normalized ``RunActivityTimeline`` from ``runActivityStore`` —
+ * Skill banner (if any), per-step list with status badges, optional task
+ * progress, confirmation card, and delivered artifacts. Visual treatment is
+ * intentionally minimal at the scaffold stage; the surrounding chat shell
+ * (``ProjectChatMessages`` / ``ChatStreamingMessage``) renders it next to the
+ * existing legacy UI behind ``isRunHarnessV1Enabled``.
+ */
+import { useState } from "react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  Clock,
+  Loader2,
+  Sparkles,
+  XCircle,
+} from "lucide-react";
+import type {
+  ActivityStep,
+  RunActivityTimeline,
+  StepStatus,
+} from "../../stores/runActivityReducer";
+import type { ToolProgressStatus } from "../../types/productRunEvent";
+
+interface Props {
+  timeline: RunActivityTimeline;
+}
+
+const STEP_STATUS_LABEL: Record<StepStatus, string> = {
+  pending: "等待中",
+  running: "进行中",
+  completed: "已完成",
+  failed: "失败",
+};
+
+const ITEM_STATUS_LABEL: Record<ToolProgressStatus, string> = {
+  pending: "等待",
+  running: "进行中",
+  completed: "已完成",
+  failed: "失败",
+};
+
+function statusIcon(status: StepStatus | ToolProgressStatus) {
+  switch (status) {
+    case "completed":
+      return <CheckCircle2 className="h-3.5 w-3.5 text-emerald-600" />;
+    case "failed":
+      return <XCircle className="h-3.5 w-3.5 text-rose-600" />;
+    case "running":
+      return <Loader2 className="h-3.5 w-3.5 animate-spin text-primary" />;
+    default:
+      return <Clock className="h-3.5 w-3.5 text-slate-400" />;
+  }
+}
+
+function StepRow({ step, expanded, onToggle }: { step: ActivityStep; expanded: boolean; onToggle: () => void }) {
+  const hasItems = step.items.length > 0;
+  return (
+    <li className="rounded-lg border border-slate-200 bg-white">
+      <button
+        type="button"
+        onClick={hasItems ? onToggle : undefined}
+        className={`flex w-full items-center justify-between gap-2 px-3 py-2 text-left ${
+          hasItems ? "hover:bg-slate-50" : "cursor-default"
+        }`}
+      >
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded bg-slate-100 text-xs tabular-nums text-slate-500">
+            {step.index}
+          </span>
+          <span className="truncate text-sm text-slate-800">{step.title}</span>
+          {step.truncated && (
+            <span className="flex items-center gap-1 rounded bg-amber-50 px-1.5 py-0.5 text-[11px] text-amber-700">
+              <AlertTriangle className="h-3 w-3" />截断
+            </span>
+          )}
+        </div>
+        <div className="flex flex-shrink-0 items-center gap-1.5 text-xs text-slate-500">
+          {typeof step.duration_ms === "number" && (
+            <span className="tabular-nums">{step.duration_ms}ms</span>
+          )}
+          {statusIcon(step.status)}
+          <span>{STEP_STATUS_LABEL[step.status] ?? step.status}</span>
+          {hasItems && (expanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />)}
+        </div>
+      </button>
+      {hasItems && expanded && (
+        <ul className="space-y-1 border-t border-slate-100 px-3 py-2">
+          {step.items.map((item, i) => (
+            <li key={`${item.tool_name}-${i}`} className="flex items-start gap-2 text-xs text-slate-600">
+              {statusIcon(item.status)}
+              <span className="min-w-0 flex-1 truncate">
+                <span className="font-medium text-slate-700">{item.tool_name}</span>
+                {item.detail && <span className="ml-1 text-slate-500">— {item.detail}</span>}
+              </span>
+              <span className="text-slate-400">{ITEM_STATUS_LABEL[item.status]}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+}
+
+export function ProjectChatActivityTimeline({ timeline }: Props) {
+  // Default-expand the in-progress (last running) step, fold the rest.
+  const initialExpanded = new Set<number>();
+  const lastRunning = [...timeline.steps].reverse().find((s) => s.status === "running");
+  if (lastRunning) initialExpanded.add(lastRunning.index);
+  const [expandedSteps, setExpandedSteps] = useState<Set<number>>(initialExpanded);
+
+  const toggleStep = (idx: number) => {
+    setExpandedSteps((prev) => {
+      const next = new Set(prev);
+      if (next.has(idx)) next.delete(idx);
+      else next.add(idx);
+      return next;
+    });
+  };
+
+  const totalSteps = timeline.steps.length;
+  const finishedSteps = timeline.steps.filter((s) => s.status === "completed" || s.status === "failed").length;
+
+  return (
+    <section className="space-y-2 text-sm" aria-label="Run activity timeline">
+      {timeline.skill && (
+        <div className="flex items-center gap-2 rounded-lg border border-primary/20 bg-primary/5 px-3 py-1.5 text-xs text-primary">
+          <Sparkles className="h-3.5 w-3.5" />
+          <span>Skill：{timeline.skill.name}</span>
+        </div>
+      )}
+
+      {timeline.task && (
+        <div className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-1.5 text-xs text-slate-700">
+          <div className="flex items-center justify-between gap-2">
+            <span className="truncate">
+              任务 #{timeline.task.task_id}
+              {timeline.task.step_title ? ` · ${timeline.task.step_title}` : ""}
+            </span>
+            <span className="tabular-nums text-slate-500">
+              {typeof timeline.task.progress_pct === "number"
+                ? `${timeline.task.progress_pct}%`
+                : ""}
+              {timeline.task.total_steps
+                ? ` ${timeline.task.current_step ?? "-"}/${timeline.task.total_steps}`
+                : ""}
+            </span>
+          </div>
+        </div>
+      )}
+
+      {totalSteps > 0 && (
+        <details open={timeline.final_status !== "completed"} className="group">
+          <summary className="flex cursor-pointer list-none items-center gap-1.5 rounded px-1 py-1 text-xs text-slate-500 hover:bg-slate-50">
+            <ChevronRight className="h-3.5 w-3.5 transition-transform group-open:rotate-90" />
+            <span>
+              活动 · {finishedSteps}/{totalSteps} 步
+              {timeline.final_status === "failed" ? " · 失败" : ""}
+            </span>
+          </summary>
+          <ul className="mt-1.5 space-y-1.5">
+            {timeline.steps.map((step) => (
+              <StepRow
+                key={step.index}
+                step={step}
+                expanded={expandedSteps.has(step.index)}
+                onToggle={() => toggleStep(step.index)}
+              />
+            ))}
+          </ul>
+        </details>
+      )}
+
+      {timeline.confirmation && (
+        <div className="rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-900">
+          <div className="flex items-center gap-1.5 font-medium">
+            <AlertTriangle className="h-3.5 w-3.5" />
+            需要确认：{timeline.confirmation.action}
+          </div>
+          <p className="mt-0.5 text-amber-800">{timeline.confirmation.impact}</p>
+        </div>
+      )}
+
+      {timeline.artifacts.length > 0 && (
+        <ul className="space-y-1">
+          {timeline.artifacts.map((a) => (
+            <li
+              key={a.id}
+              className="flex items-center justify-between rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs"
+            >
+              <span className="truncate text-slate-700">
+                📎 #{a.id} <span className="uppercase text-slate-400">{a.type}</span>
+              </span>
+              {a.download_url && (
+                <a
+                  href={a.download_url}
+                  className="text-primary hover:underline"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  下载
+                </a>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {timeline.error && (
+        <div className="rounded-lg border border-rose-300 bg-rose-50 px-3 py-2 text-xs text-rose-900">
+          <div className="flex items-center gap-1.5 font-medium">
+            <XCircle className="h-3.5 w-3.5" /> 失败：{timeline.error.code}
+          </div>
+          <p className="mt-0.5 text-rose-800">{timeline.error.message}</p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/web/src/pages/projects/ProjectChatActivityTimeline.tsx
+++ b/web/src/pages/projects/ProjectChatActivityTimeline.tsx
@@ -153,14 +153,36 @@ export function ProjectChatActivityTimeline({ timeline }: Props) {
         </div>
       )}
 
+      {timeline.status && !timeline.final_status && (
+        <div className="flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs text-slate-500 shadow-sm">
+          <Loader2 className="h-3.5 w-3.5 animate-spin text-primary" />
+          <span className="truncate">{timeline.status.message}</span>
+          {typeof timeline.status.progress === "number" && (
+            <span className="ml-auto tabular-nums text-slate-400">
+              {Math.round(timeline.status.progress * 100) / 100}%
+            </span>
+          )}
+        </div>
+      )}
+
       {totalSteps > 0 && (
         <details open={timeline.final_status !== "completed"} className="group">
           <summary className="flex cursor-pointer list-none items-center gap-1.5 rounded px-1 py-1 text-xs text-slate-500 hover:bg-slate-50">
             <ChevronRight className="h-3.5 w-3.5 transition-transform group-open:rotate-90" />
-            <span>
-              活动 · {finishedSteps}/{totalSteps} 步
-              {timeline.final_status === "failed" ? " · 失败" : ""}
-            </span>
+            {timeline.final_status === "completed" ? (
+              <span className="flex items-center gap-1">
+                <CheckCircle2 className="h-3.5 w-3.5 text-emerald-600" />
+                <span>已完成 · {totalSteps} 步</span>
+                {timeline.artifacts.length > 0 && (
+                  <span className="text-slate-400">· {timeline.artifacts.length} 个交付物</span>
+                )}
+              </span>
+            ) : (
+              <span>
+                活动 · {finishedSteps}/{totalSteps} 步
+                {timeline.final_status === "failed" ? " · 失败" : ""}
+              </span>
+            )}
           </summary>
           <ul className="mt-1.5 space-y-1.5">
             {timeline.steps.map((step) => (

--- a/web/src/pages/projects/ProjectChatMessageBubble.tsx
+++ b/web/src/pages/projects/ProjectChatMessageBubble.tsx
@@ -25,8 +25,11 @@ import type {
 } from "../../types/api";
 import type { ChatTrace } from "../../types/api";
 import { api } from "../../api/client";
+import type { RunActivityTimeline } from "../../stores/runActivityReducer";
+import { isRunHarnessV1Enabled } from "../../utils/runHarnessFlag";
 import { getProjectChatCopy } from "./projectChatCopy";
 import { MarkdownDiffViewer } from "./MarkdownDiffViewer";
+import { ProjectChatActivityTimeline } from "./ProjectChatActivityTimeline";
 import { ProjectChatArtifactCard } from "./ProjectChatArtifactCard";
 import { ProjectChatTracePanel } from "./ProjectChatTracePanel";
 import { ProjectChatToolCallCard } from "./ProjectChatToolCallCard";
@@ -219,6 +222,7 @@ export const ProjectChatMessageBubble = memo<ProjectChatMessageBubbleProps>(
             ) : (
               <div className="md-root project-chat-answer w-full">
                 <MarkdownRenderer content={msg.content} />
+                <PersistedRunActivityTimelineSection metadata={metadata} />
               </div>
             )}
           </div>
@@ -429,3 +433,47 @@ export const ProjectChatMessageBubble = memo<ProjectChatMessageBubbleProps>(
     prev.onSaveToNotes === next.onSaveToNotes &&
     prev.onContinue === next.onContinue,
 );
+
+/**
+ * Persisted Run Activity Timeline section (Product Run Event v1).
+ *
+ * Reads ``metadata.activity_timeline`` from a saved assistant message and, when
+ * the feature flag is on and the payload looks well-formed, renders the same
+ * ``ProjectChatActivityTimeline`` component used during streaming. Until the
+ * backend starts writing this field at persist time this is a graceful no-op,
+ * so the bubble keeps rendering normally on legacy messages.
+ */
+function PersistedRunActivityTimelineSection({
+  metadata,
+}: {
+  metadata: MessageMetadata;
+}) {
+  if (!isRunHarnessV1Enabled()) return null;
+  const raw = (metadata as { activity_timeline?: unknown }).activity_timeline;
+  if (!raw || typeof raw !== "object") return null;
+  const candidate = raw as Partial<RunActivityTimeline>;
+  if (typeof candidate.run_id !== "string" || !candidate.run_id) return null;
+  if (!Array.isArray(candidate.steps) || !Array.isArray(candidate.artifacts)) return null;
+
+  // Re-shape with safe defaults so the renderer never crashes on
+  // missing-but-optional fields. The reducer's output shape is the contract.
+  const timeline: RunActivityTimeline = {
+    run_id: candidate.run_id,
+    skill: candidate.skill,
+    display_mode: candidate.display_mode,
+    steps: candidate.steps as RunActivityTimeline["steps"],
+    artifacts: candidate.artifacts as RunActivityTimeline["artifacts"],
+    task: candidate.task,
+    confirmation: candidate.confirmation,
+    message_id: candidate.message_id,
+    final_status: candidate.final_status,
+    error: candidate.error,
+    text: typeof candidate.text === "string" ? candidate.text : "",
+  };
+  return (
+    <div className="mt-2.5">
+      <ProjectChatActivityTimeline timeline={timeline} />
+    </div>
+  );
+}
+

--- a/web/src/pages/projects/ProjectChatMessages.tsx
+++ b/web/src/pages/projects/ProjectChatMessages.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 
 import { MarkdownRenderer } from "../../components/MarkdownRenderer";
+import { useRunActivityStore } from "../../stores/runActivityStore";
 import type {
   ChatPlanResponse,
   GeneratedArtifact,
@@ -18,6 +19,8 @@ import type {
   Reference,
   ToolCallEvent,
 } from "../../types/api";
+import { isRunHarnessV1Enabled } from "../../utils/runHarnessFlag";
+import { ProjectChatActivityTimeline } from "./ProjectChatActivityTimeline";
 import type { ProjectQuickPrompt } from "./projectChatCopy";
 import { ProjectChatArtifactCard } from "./ProjectChatArtifactCard";
 import { ProjectChatEmptyState } from "./ProjectChatEmptyState";
@@ -138,12 +141,29 @@ const ChatStreamingMessage = memo<{
                 )}
               </div>
             )}
+            <RunHarnessV1TimelineSection />
           </div>
         </div>
       </div>
     );
   },
 );
+
+/**
+ * Conditional, additive activity-timeline section for the streaming bubble.
+ * Subscribes to the Product Run Event v1 store. Renders nothing unless the
+ * feature flag is on AND a timeline exists for the current run; in that case
+ * it sits alongside the legacy tool cards so the two views can be compared.
+ */
+function RunHarnessV1TimelineSection() {
+  const timeline = useRunActivityStore((state) => state.timeline);
+  if (!isRunHarnessV1Enabled() || !timeline) return null;
+  return (
+    <div className="mt-2.5 w-full max-w-3xl">
+      <ProjectChatActivityTimeline timeline={timeline} />
+    </div>
+  );
+}
 
 type ProjectChatMessagesProps = {
   messages: ChatMessage[];

--- a/web/src/pages/projects/useProjectChatComposer.ts
+++ b/web/src/pages/projects/useProjectChatComposer.ts
@@ -13,7 +13,10 @@ import type {
   ToolCallEvent,
 } from "../../types/api";
 import type { StreamEvent } from "../../types/chat";
+import { isProductRunEvent } from "../../types/productRunEvent";
 import { useChatStreamStore } from "../../stores/chatStreamStore";
+import { useRunActivityStore } from "../../stores/runActivityStore";
+import { isRunHarnessV1Enabled } from "../../utils/runHarnessFlag";
 import {
   artifactFromResult,
   artifactFromTaskRunArtifact,
@@ -167,6 +170,10 @@ export function useProjectChatComposer({
   const setStreamArtifacts = useChatStreamStore((state) => state.setStreamingArtifacts);
   const setStreamTruncated = useChatStreamStore((state) => state.setTruncated);
   const resetStream = useChatStreamStore((state) => state.reset);
+  // Product Run Event v1 timeline store (feature-flagged). Apply ingests every
+  // recognised v1 event; reset clears the timeline at send / cleanup time.
+  const applyRunActivity = useRunActivityStore((state) => state.apply);
+  const resetRunActivity = useRunActivityStore((state) => state.reset);
   const abortControllerRef = useRef<AbortController | null>(null);
   const abortControllerAsyncRef = useRef<AbortController | null>(null);
   const activeConvIdRef = useRef<number | null>(activeConvId);
@@ -205,6 +212,7 @@ export function useProjectChatComposer({
       streamRequestSeqRef.current = requestId;
       const optimisticMessageId = Date.now();
       resetStream();
+      resetRunActivity();
       setStreamIsLoading(true);
       setStreamStatus("AI 正在读取项目上下文并准备回复...");
 
@@ -320,6 +328,13 @@ export function useProjectChatComposer({
             } catch (error) {
               console.error("Failed to parse stream event:", error);
               continue;
+            }
+
+            // Product Run Event v1 dispatch (additive, behind a flag). Feeds
+            // the run-activity store without touching the legacy event chain
+            // below — both consumers run while we're in double-send.
+            if (isRunHarnessV1Enabled() && isProductRunEvent(payload)) {
+              applyRunActivity(payload);
             }
 
             if ((payload.type === "text" || payload.type === "chunk") && payload.content) {

--- a/web/src/stores/runActivityReducer.test.ts
+++ b/web/src/stores/runActivityReducer.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest";
+import type { ProductRunEvent } from "../types/productRunEvent";
+import {
+  emptyTimeline,
+  reduceRunActivity,
+  type RunActivityTimeline,
+} from "./runActivityReducer";
+
+function fold(events: ProductRunEvent[]): RunActivityTimeline {
+  let t: RunActivityTimeline | null = null;
+  for (const e of events) {
+    t = reduceRunActivity(t, e);
+  }
+  return t ?? emptyTimeline();
+}
+
+describe("reduceRunActivity", () => {
+  it("opens a timeline on run_started with skill + display_mode", () => {
+    const t = fold([
+      {
+        type: "run_started",
+        run_id: "run_a",
+        timestamp: "2026-05-28T00:00:00.000Z",
+        display_mode: "skill",
+        skill: { name: "数字化战略", id: "digital-strategy" },
+      },
+    ]);
+    expect(t.run_id).toBe("run_a");
+    expect(t.display_mode).toBe("skill");
+    expect(t.skill).toEqual({ name: "数字化战略", id: "digital-strategy" });
+    expect(t.steps).toEqual([]);
+    expect(t.text).toBe("");
+  });
+
+  it("appends text_delta chunks into a single text string", () => {
+    const t = fold([
+      { type: "run_started", run_id: "r", timestamp: "" },
+      { type: "text_delta", run_id: "r", content: "Hello " },
+      { type: "text_delta", run_id: "r", content: "world!" },
+    ]);
+    expect(t.text).toBe("Hello world!");
+  });
+
+  it("builds steps and groups tool_progress under the right step", () => {
+    const t = fold([
+      { type: "run_started", run_id: "r", timestamp: "" },
+      { type: "step_started", run_id: "r", step_index: 1, title: "读取" },
+      {
+        type: "tool_progress",
+        run_id: "r",
+        step_index: 1,
+        title: "读取项目文件",
+        status: "running",
+      },
+      {
+        type: "tool_progress",
+        run_id: "r",
+        step_index: 1,
+        title: "读取项目文件",
+        status: "completed",
+      },
+      {
+        type: "step_completed",
+        run_id: "r",
+        step_index: 1,
+        status: "completed",
+        duration_ms: 230,
+      },
+      { type: "step_started", run_id: "r", step_index: 2, title: "整理" },
+      {
+        type: "step_completed",
+        run_id: "r",
+        step_index: 2,
+        status: "completed",
+        duration_ms: 50,
+      },
+    ]);
+    expect(t.steps).toHaveLength(2);
+    expect(t.steps[0].title).toBe("读取");
+    expect(t.steps[0].status).toBe("completed");
+    expect(t.steps[0].duration_ms).toBe(230);
+    expect(t.steps[0].items).toEqual([
+      { tool_name: "读取项目文件", status: "completed" },
+    ]);
+    expect(t.steps[1].index).toBe(2);
+  });
+
+  it("captures confirmation_required + artifact_ready + final_status", () => {
+    const t = fold([
+      { type: "run_started", run_id: "r", timestamp: "" },
+      {
+        type: "confirmation_required",
+        run_id: "r",
+        action: "删除文件",
+        impact: "不可恢复",
+        params_snapshot: { id: 1 },
+      },
+      {
+        type: "artifact_ready",
+        run_id: "r",
+        artifact_id: "57",
+        artifact_type: "pptx",
+        download_url: "/files/57",
+      },
+      { type: "message_persisted", run_id: "r", message_id: 100 },
+      { type: "run_done", run_id: "r", final_status: "completed" },
+    ]);
+    expect(t.confirmation).toEqual({
+      action: "删除文件",
+      impact: "不可恢复",
+      params_snapshot: { id: 1 },
+      deadline: undefined,
+    });
+    expect(t.artifacts).toHaveLength(1);
+    expect(t.artifacts[0]).toMatchObject({ id: "57", type: "pptx", download_url: "/files/57" });
+    expect(t.message_id).toBe(100);
+    expect(t.final_status).toBe("completed");
+  });
+
+  it("captures task_update progress", () => {
+    const t = fold([
+      { type: "run_started", run_id: "r", timestamp: "" },
+      {
+        type: "task_update",
+        run_id: "r",
+        task_id: "42",
+        status: "running",
+        total_steps: 4,
+        current_step: 2,
+        progress_pct: 25,
+        step_title: "生成大纲",
+      },
+    ]);
+    expect(t.task).toEqual({
+      task_id: "42",
+      status: "running",
+      total_steps: 4,
+      current_step: 2,
+      progress_pct: 25,
+      step_title: "生成大纲",
+    });
+  });
+
+  it("run_failed sets final_status=failed and error payload", () => {
+    const t = fold([
+      { type: "run_started", run_id: "r", timestamp: "" },
+      {
+        type: "run_failed",
+        run_id: "r",
+        error_code: "MODEL_TIMEOUT",
+        error_message: "AI 超时，请重试",
+        retryable: true,
+      },
+    ]);
+    expect(t.final_status).toBe("failed");
+    expect(t.error).toEqual({
+      code: "MODEL_TIMEOUT",
+      message: "AI 超时，请重试",
+      retryable: true,
+    });
+  });
+
+  it("drops events whose run_id does not match the open timeline", () => {
+    const t = fold([
+      { type: "run_started", run_id: "r1", timestamp: "" },
+      { type: "text_delta", run_id: "r2", content: "stale" },
+      { type: "text_delta", run_id: "r1", content: "ok" },
+    ]);
+    expect(t.text).toBe("ok");
+  });
+
+  it("ignores non-start events when no timeline is open", () => {
+    const t = reduceRunActivity(null, {
+      type: "text_delta",
+      run_id: "r",
+      content: "x",
+    });
+    expect(t.text).toBe("");
+    expect(t.run_id).toBe("");
+  });
+});

--- a/web/src/stores/runActivityReducer.test.ts
+++ b/web/src/stores/runActivityReducer.test.ts
@@ -169,6 +169,37 @@ describe("reduceRunActivity", () => {
     expect(t.text).toBe("ok");
   });
 
+  it("captures live status and clears it on run_done", () => {
+    const before = fold([
+      { type: "run_started", run_id: "r", timestamp: "" },
+      { type: "status", run_id: "r", message: "正在生成回复..." },
+    ]);
+    expect(before.status).toEqual({ message: "正在生成回复...", progress: undefined });
+
+    const after = reduceRunActivity(before, {
+      type: "run_done",
+      run_id: "r",
+      final_status: "completed",
+    });
+    expect(after.status).toBeUndefined();
+    expect(after.final_status).toBe("completed");
+  });
+
+  it("run_failed clears live status alongside setting the error", () => {
+    const t = fold([
+      { type: "run_started", run_id: "r", timestamp: "" },
+      { type: "status", run_id: "r", message: "拉取上下文..." },
+      {
+        type: "run_failed",
+        run_id: "r",
+        error_code: "MODEL_TIMEOUT",
+        error_message: "AI 超时",
+      },
+    ]);
+    expect(t.status).toBeUndefined();
+    expect(t.error?.code).toBe("MODEL_TIMEOUT");
+  });
+
   it("ignores non-start events when no timeline is open", () => {
     const t = reduceRunActivity(null, {
       type: "text_delta",

--- a/web/src/stores/runActivityReducer.ts
+++ b/web/src/stores/runActivityReducer.ts
@@ -54,6 +54,12 @@ export interface ActivityConfirmation {
   deadline?: string;
 }
 
+export interface ActivityStatus {
+  /** Latest user-facing one-liner from a v1 ``status`` event (≤ 50 chars). */
+  message: string;
+  progress?: number;
+}
+
 export interface RunActivityTimeline {
   run_id: string;
   display_mode?: RunDisplayMode;
@@ -62,6 +68,8 @@ export interface RunActivityTimeline {
   artifacts: ActivityArtifact[];
   task?: ActivityTaskState;
   confirmation?: ActivityConfirmation;
+  /** Latest ``status`` event payload. Cleared by ``run_done`` / ``run_failed``. */
+  status?: ActivityStatus;
   message_id?: number | string;
   final_status?: RunFinalStatus;
   error?: { code: string; message: string; retryable?: boolean };
@@ -219,17 +227,26 @@ export function reduceRunActivity(
     case "message_persisted":
       return { ...current, message_id: event.message_id };
 
+    case "status":
+      return {
+        ...current,
+        status: { message: event.message, progress: event.progress },
+      };
+
     case "run_done":
       return {
         ...current,
         final_status: event.final_status,
         message_id: event.message_id ?? current.message_id,
+        // Once the run is done, the live status is stale and would mislead.
+        status: undefined,
       };
 
     case "run_failed":
       return {
         ...current,
         final_status: "failed",
+        status: undefined,
         error: {
           code: event.error_code,
           message: event.error_message,
@@ -237,8 +254,8 @@ export function reduceRunActivity(
         },
       };
 
-    // status / reference_delta intentionally not stored on the timeline yet —
-    // status is consumed by existing UI; reference_delta is a follow-up.
+    // reference_delta intentionally not stored on the timeline yet —
+    // it's a follow-up; legacy ``references`` event still drives that UI.
     default:
       return current;
   }

--- a/web/src/stores/runActivityReducer.ts
+++ b/web/src/stores/runActivityReducer.ts
@@ -1,0 +1,245 @@
+/**
+ * Pure reducer that folds a stream of Product Run Event v1 frames into a
+ * normalized ``RunActivityTimeline`` — the data shape the
+ * ``ProjectChatActivityTimeline`` component renders.
+ *
+ * Kept as a pure function (no React, no Zustand) so it can be unit-tested
+ * without a DOM and reused server-side later if needed.
+ */
+import type {
+  ArtifactType,
+  ProductRunEvent,
+  RunDisplayMode,
+  RunFinalStatus,
+  ToolProgressStatus,
+} from "../types/productRunEvent";
+
+export type StepStatus = ToolProgressStatus | "completed" | "failed";
+
+export interface ActivityItem {
+  tool_name: string;
+  status: ToolProgressStatus;
+  detail?: string;
+}
+
+export interface ActivityStep {
+  index: number;
+  title: string;
+  status: StepStatus;
+  duration_ms?: number;
+  items: ActivityItem[];
+  truncated?: boolean;
+}
+
+export interface ActivityArtifact {
+  id: string;
+  type: ArtifactType;
+  download_url?: string;
+  preview_url?: string;
+}
+
+export interface ActivityTaskState {
+  task_id: string;
+  status: ToolProgressStatus;
+  progress_pct?: number;
+  current_step?: number;
+  total_steps?: number;
+  step_title?: string;
+}
+
+export interface ActivityConfirmation {
+  action: string;
+  impact: string;
+  params_snapshot?: Record<string, unknown>;
+  deadline?: string;
+}
+
+export interface RunActivityTimeline {
+  run_id: string;
+  display_mode?: RunDisplayMode;
+  skill?: { name: string; id?: string };
+  steps: ActivityStep[];
+  artifacts: ActivityArtifact[];
+  task?: ActivityTaskState;
+  confirmation?: ActivityConfirmation;
+  message_id?: number | string;
+  final_status?: RunFinalStatus;
+  error?: { code: string; message: string; retryable?: boolean };
+  /** Concatenated text deltas — convenient for components that want a single string. */
+  text: string;
+}
+
+export function emptyTimeline(run_id = ""): RunActivityTimeline {
+  return { run_id, steps: [], artifacts: [], text: "" };
+}
+
+function upsertStep(steps: ActivityStep[], index: number, patch: Partial<ActivityStep>): ActivityStep[] {
+  const next = steps.slice();
+  const at = next.findIndex((s) => s.index === index);
+  if (at >= 0) {
+    next[at] = { ...next[at], ...patch };
+  } else {
+    next.push({
+      index,
+      title: patch.title ?? `第 ${index} 步`,
+      status: patch.status ?? "running",
+      items: patch.items ?? [],
+      ...patch,
+    } as ActivityStep);
+    next.sort((a, b) => a.index - b.index);
+  }
+  return next;
+}
+
+function upsertItem(items: ActivityItem[], tool_name: string, patch: Partial<ActivityItem>): ActivityItem[] {
+  const next = items.slice();
+  // Match by tool_name; if there are duplicate names within the same step we
+  // collapse them, which matches how the agent loop emits one running and one
+  // terminal event per tool call.
+  const at = next.findIndex((it) => it.tool_name === tool_name);
+  if (at >= 0) {
+    next[at] = { ...next[at], ...patch };
+  } else {
+    next.push({ tool_name, status: patch.status ?? "running", ...patch } as ActivityItem);
+  }
+  return next;
+}
+
+function withStepItem(
+  steps: ActivityStep[],
+  step_index: number,
+  tool_name: string,
+  patch: Partial<ActivityItem>,
+): ActivityStep[] {
+  // Ensure the step exists (in case tool_progress arrives before step_started,
+  // which shouldn't happen but we stay defensive).
+  const ensured = upsertStep(steps, step_index, {});
+  return ensured.map((step) =>
+    step.index === step_index
+      ? { ...step, items: upsertItem(step.items, tool_name, patch) }
+      : step,
+  );
+}
+
+/**
+ * Fold a single Product Run Event into the current timeline. Returns a new
+ * timeline (or the same one if the event isn't relevant to a timeline that
+ * has already been opened for a different run_id).
+ */
+export function reduceRunActivity(
+  current: RunActivityTimeline | null,
+  event: ProductRunEvent,
+): RunActivityTimeline {
+  // run_started opens (or resets) the timeline for this run.
+  if (event.type === "run_started") {
+    return {
+      ...emptyTimeline(event.run_id),
+      display_mode: event.display_mode,
+      skill: event.skill,
+    };
+  }
+
+  // If we don't have a timeline yet, refuse to materialise one from a non-start
+  // event — the data would be partial. This also handles legacy event noise.
+  if (!current) return emptyTimeline();
+
+  // Drop events for a different run_id (race after page nav, stale stream).
+  if (event.run_id !== current.run_id) return current;
+
+  switch (event.type) {
+    case "text_delta":
+      return { ...current, text: current.text + event.content };
+
+    case "step_started":
+      return {
+        ...current,
+        steps: upsertStep(current.steps, event.step_index, {
+          title: event.title,
+          status: "running",
+        }),
+      };
+
+    case "step_completed":
+      return {
+        ...current,
+        steps: upsertStep(current.steps, event.step_index, {
+          status: event.status,
+          duration_ms: event.duration_ms,
+          truncated: event.truncated,
+        }),
+      };
+
+    case "tool_progress":
+      return {
+        ...current,
+        steps: withStepItem(current.steps, event.step_index, event.title, {
+          status: event.status,
+          detail: event.detail,
+        }),
+      };
+
+    case "task_update":
+      return {
+        ...current,
+        task: {
+          task_id: event.task_id,
+          status: event.status,
+          progress_pct: event.progress_pct,
+          current_step: event.current_step,
+          total_steps: event.total_steps,
+          step_title: event.step_title,
+        },
+      };
+
+    case "confirmation_required":
+      return {
+        ...current,
+        confirmation: {
+          action: event.action,
+          impact: event.impact,
+          params_snapshot: event.params_snapshot,
+          deadline: event.deadline,
+        },
+      };
+
+    case "artifact_ready":
+      return {
+        ...current,
+        artifacts: [
+          ...current.artifacts,
+          {
+            id: event.artifact_id,
+            type: event.artifact_type,
+            download_url: event.download_url,
+            preview_url: event.preview_url,
+          },
+        ],
+      };
+
+    case "message_persisted":
+      return { ...current, message_id: event.message_id };
+
+    case "run_done":
+      return {
+        ...current,
+        final_status: event.final_status,
+        message_id: event.message_id ?? current.message_id,
+      };
+
+    case "run_failed":
+      return {
+        ...current,
+        final_status: "failed",
+        error: {
+          code: event.error_code,
+          message: event.error_message,
+          retryable: event.retryable,
+        },
+      };
+
+    // status / reference_delta intentionally not stored on the timeline yet —
+    // status is consumed by existing UI; reference_delta is a follow-up.
+    default:
+      return current;
+  }
+}

--- a/web/src/stores/runActivityStore.ts
+++ b/web/src/stores/runActivityStore.ts
@@ -1,0 +1,25 @@
+/**
+ * Zustand store for the current run's activity timeline (Product Run Event v1).
+ *
+ * The pure ``reduceRunActivity`` reducer does the actual folding — this store
+ * is just the live-state shell so React components can subscribe to changes.
+ */
+import { create } from "zustand";
+import type { ProductRunEvent } from "../types/productRunEvent";
+import {
+  type RunActivityTimeline,
+  reduceRunActivity,
+} from "./runActivityReducer";
+
+interface RunActivityState {
+  timeline: RunActivityTimeline | null;
+  apply: (event: ProductRunEvent) => void;
+  reset: () => void;
+}
+
+export const useRunActivityStore = create<RunActivityState>((set) => ({
+  timeline: null,
+  apply: (event) =>
+    set((state) => ({ timeline: reduceRunActivity(state.timeline, event) })),
+  reset: () => set({ timeline: null }),
+}));

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -916,6 +916,8 @@ export interface MessageMetadata {
   }>
   project_id?: number
   truncated?: boolean
+  /** Product Run Event v1: serialized RunActivityTimeline for the persisted view. */
+  activity_timeline?: unknown
 }
 
 export interface MentionContext {

--- a/web/src/types/productRunEvent.ts
+++ b/web/src/types/productRunEvent.ts
@@ -1,0 +1,200 @@
+/**
+ * Product Run Event v1 — protocol shared with the backend module
+ * `backend/app/services/chat/product_run_events.py` and documented in
+ * `docs/11-Model-Harness产品方案设计.md §8`.
+ *
+ * These types describe the SSE frames a v1-aware frontend consumes from the
+ * chat stream. They are intentionally narrow (no extra fields) so the contract
+ * with the backend builders stays tight.
+ */
+
+export type ProductRunEventType =
+  | "run_started"
+  | "status"
+  | "text_delta"
+  | "reference_delta"
+  | "step_started"
+  | "step_completed"
+  | "tool_progress"
+  | "task_update"
+  | "confirmation_required"
+  | "artifact_ready"
+  | "message_persisted"
+  | "run_done"
+  | "run_failed";
+
+export type RunDisplayMode =
+  | "quiet"
+  | "contextual"
+  | "task"
+  | "skill"
+  | "confirmation"
+  | "debug";
+
+export type ToolProgressStatus = "pending" | "running" | "completed" | "failed";
+
+export type StepCompletedStatus = "completed" | "failed";
+
+export type ArtifactType = "pptx" | "docx" | "xlsx" | "pdf" | "markdown";
+
+export type RunFinalStatus = "completed" | "failed" | "cancelled";
+
+export type RunErrorCode =
+  | "TOOL_EXECUTION_FAILED"
+  | "MODEL_TIMEOUT"
+  | "PERSISTENCE_ERROR"
+  | "POLICY_REJECTED"
+  | "CONTEXT_PREPARATION_FAILED"
+  | "UNKNOWN"
+  | string; // tolerate forward-compatible codes
+
+export interface RunStartedEvent {
+  type: "run_started";
+  run_id: string;
+  timestamp: string;
+  display_mode?: RunDisplayMode;
+  skill?: { name: string; id?: string };
+}
+
+export interface StatusEvent {
+  type: "status";
+  run_id: string;
+  message: string;
+  display_mode?: RunDisplayMode;
+  progress?: number;
+}
+
+export interface TextDeltaEvent {
+  type: "text_delta";
+  run_id: string;
+  content: string;
+}
+
+export interface ReferenceDeltaEvent {
+  type: "reference_delta";
+  run_id: string;
+  source: string;
+  url?: string;
+  title?: string;
+}
+
+export interface StepStartedEvent {
+  type: "step_started";
+  run_id: string;
+  step_index: number;
+  title: string;
+  step_total?: number;
+}
+
+export interface StepCompletedEvent {
+  type: "step_completed";
+  run_id: string;
+  step_index: number;
+  status: StepCompletedStatus;
+  duration_ms: number;
+  truncated?: boolean;
+}
+
+export interface ToolProgressEvent {
+  type: "tool_progress";
+  run_id: string;
+  step_index: number;
+  title: string;
+  status: ToolProgressStatus;
+  detail?: string;
+  progress?: number;
+}
+
+export interface TaskUpdateEvent {
+  type: "task_update";
+  run_id: string;
+  task_id: string;
+  status: ToolProgressStatus;
+  progress_pct?: number;
+  current_step?: number;
+  total_steps?: number;
+  step_title?: string;
+}
+
+export interface ConfirmationRequiredEvent {
+  type: "confirmation_required";
+  run_id: string;
+  action: string;
+  impact: string;
+  params_snapshot?: Record<string, unknown>;
+  deadline?: string;
+}
+
+export interface ArtifactReadyEvent {
+  type: "artifact_ready";
+  run_id: string;
+  artifact_id: string;
+  artifact_type: ArtifactType;
+  download_url?: string;
+  preview_url?: string;
+}
+
+export interface MessagePersistedEvent {
+  type: "message_persisted";
+  run_id: string;
+  message_id: number | string;
+  parent_run_id?: string;
+}
+
+export interface RunDoneEvent {
+  type: "run_done";
+  run_id: string;
+  final_status: RunFinalStatus;
+  message_id?: number | string;
+  artifact_ids?: string[];
+}
+
+export interface RunFailedEvent {
+  type: "run_failed";
+  run_id: string;
+  error_code: RunErrorCode;
+  error_message: string;
+  retryable?: boolean;
+  fallback_content?: string;
+}
+
+export type ProductRunEvent =
+  | RunStartedEvent
+  | StatusEvent
+  | TextDeltaEvent
+  | ReferenceDeltaEvent
+  | StepStartedEvent
+  | StepCompletedEvent
+  | ToolProgressEvent
+  | TaskUpdateEvent
+  | ConfirmationRequiredEvent
+  | ArtifactReadyEvent
+  | MessagePersistedEvent
+  | RunDoneEvent
+  | RunFailedEvent;
+
+/** Type guard for the union — handy at the SSE consumer boundary. */
+export function isProductRunEvent(value: unknown): value is ProductRunEvent {
+  if (!value || typeof value !== "object") return false;
+  const type = (value as { type?: unknown }).type;
+  return (
+    typeof type === "string" &&
+    PRODUCT_RUN_EVENT_TYPES.has(type as ProductRunEventType)
+  );
+}
+
+const PRODUCT_RUN_EVENT_TYPES = new Set<string>([
+  "run_started",
+  "status",
+  "text_delta",
+  "reference_delta",
+  "step_started",
+  "step_completed",
+  "tool_progress",
+  "task_update",
+  "confirmation_required",
+  "artifact_ready",
+  "message_persisted",
+  "run_done",
+  "run_failed",
+]);

--- a/web/src/utils/runHarnessFlag.ts
+++ b/web/src/utils/runHarnessFlag.ts
@@ -1,0 +1,40 @@
+/**
+ * Feature flag for the Run Harness v1 frontend (Product Run Event consumer +
+ * Run Activity Timeline UI). Off by default everywhere; can be turned on by:
+ *
+ *   1. ``localStorage['aria.run_harness_v1'] === 'true'`` (per-device override),
+ *      flippable from the browser console while iterating.
+ *   2. The build-time env var ``VITE_ENABLE_RUN_HARNESS_V1=true``.
+ *
+ * Both checks default to off so production stays on the legacy event path
+ * until A1 inside-event wiring is merged and the timeline UI is validated.
+ */
+
+const STORAGE_KEY = "aria.run_harness_v1";
+
+export function isRunHarnessV1Enabled(): boolean {
+  if (typeof window !== "undefined") {
+    try {
+      if (window.localStorage.getItem(STORAGE_KEY) === "true") return true;
+    } catch {
+      // Some browsers throw on localStorage access — treat as off.
+    }
+  }
+  const envValue = (import.meta.env as Record<string, string | undefined> | undefined)?.[
+    "VITE_ENABLE_RUN_HARNESS_V1"
+  ];
+  return String(envValue ?? "").toLowerCase() === "true";
+}
+
+export function setRunHarnessV1Override(value: boolean | null): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (value === null) {
+      window.localStorage.removeItem(STORAGE_KEY);
+    } else {
+      window.localStorage.setItem(STORAGE_KEY, value ? "true" : "false");
+    }
+  } catch {
+    // Ignore quota/permission errors — flag stays at its previous resolved value.
+  }
+}


### PR DESCRIPTION
## Summary
Frontend scaffold for the Run Activity Timeline (docs/11 §9.5) — consumes the Product Run Event v1 protocol from #8 and renders a unified activity view (Skill banner + per-step list with grouped tool items + task progress + confirmation + artifacts + terminal status).

**Strictly additive and feature-flagged.** When the flag is off (the default everywhere), nothing in this PR runs in production and the legacy event UI is untouched.

## What's in
- `types/productRunEvent.ts` — discriminated-union types for all 13 v1 event shapes + `isProductRunEvent` guard, mirroring backend `product_run_events.py`.
- `utils/runHarnessFlag.ts` — `isRunHarnessV1Enabled()` (localStorage override → vite env), `setRunHarnessV1Override` for dev-console flipping.
- `stores/runActivityReducer.ts` — **pure reducer** `reduceRunActivity(timeline, event)` folding an event sequence into a `RunActivityTimeline` (skill banner, ordered steps with grouped tool items by tool_name, task progress, confirmation card, artifacts, final_status / error, accumulated text).
- `stores/runActivityStore.ts` — thin Zustand shell with `apply(event)` + `reset()`.
- `pages/projects/ProjectChatActivityTimeline.tsx` — minimal but real component (skill banner, task progress strip, foldable step list with status badges + tool sub-items + duration, confirmation card, artifact list w/ download links, terminal error card). Lucide-react + Tailwind only; no new dependencies.

## Wiring
- `useProjectChatComposer`: after `JSON.parse`, if `isRunHarnessV1Enabled() && isProductRunEvent(payload)` → `applyRunActivity(payload)`. Resets the v1 timeline at send-start alongside the legacy `resetStream()`. Legacy event handling below is untouched.
- `ProjectChatMessages.ChatStreamingMessage`: appends a small `RunHarnessV1TimelineSection` that subscribes to the store and renders the timeline only when the flag is on and a timeline exists. Sits beside (not replacing) the legacy tool cards, enabling side-by-side comparison during the cutover.

## Enabling for testing
```js
localStorage['aria.run_harness_v1'] = 'true'
// or VITE_ENABLE_RUN_HARNESS_V1=true at build time
```
This only renders the new timeline once PR #8 (backend inside-event wiring) is merged and the new events are flowing.

## Test plan
- [x] Pure reducer: 8 unit tests covering open / text concatenation / step+tool grouping / confirmation+artifact+final_status / task_update / run_failed / run_id mismatch drop / no-timeline-yet defensive case.
- [x] `tsc --noEmit` clean.
- [x] `vite build` succeeds.
- [x] Full vitest run: 63 files / 409 tests pass (+8 new reducer tests).
- [ ] After PR #8 lands: enable the flag locally and verify the timeline renders for normal turns, Skill turns, and durable-task turns; compare against the legacy tool cards.

## Follow-ups (deliberately deferred)
- Persisted view: at run completion, serialize the timeline into `message.metadata` so `ProjectChatMessageBubble` can re-render it on refresh. Backend work belongs in a follow-up to #8.
- `status` event handling on the timeline (currently ignored — already consumed by the legacy status pill).
- Completed-run summary collapse to a one-liner (docs/13 §13.2 decision 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)