### PR TITLE
A3: persist Run Activity Timeline snapshot to message metadata

### DIFF
--- a/backend/app/services/chat/activity_timeline_persist.py
+++ b/backend/app/services/chat/activity_timeline_persist.py
@@ -1,0 +1,146 @@
+"""Persist-time serializer for the Run Activity Timeline (Product Run Event v1).
+
+At end-of-run, ``persist.run_persist`` calls :func:`build_activity_timeline` to
+snapshot the agent's actual execution into a JSON-safe dict matching the
+frontend's ``RunActivityTimeline`` shape (see ``web/src/stores/runActivityReducer.ts``).
+The dict is stored at ``message.metadata['activity_timeline']`` so the persisted
+view can re-render the same activity timeline the user saw while streaming.
+
+This is a one-shot snapshot derived from existing state fields, not a mirror of
+the live SSE reducer — fields that only make sense mid-run (live ``status``,
+pending ``confirmation``) are intentionally omitted.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+_ARTIFACT_TYPE_V1_MAP = {
+    "pptx": "pptx",
+    "docx": "docx",
+    "xlsx": "xlsx",
+    "pdf": "pdf",
+    "md": "markdown",
+    "markdown": "markdown",
+}
+
+
+def _v1_item_status(raw: Any) -> str:
+    """Coerce a tool-event status string into the v1 ToolProgressStatus enum."""
+    s = str(raw or "").lower()
+    if s in {"completed", "success", "done"}:
+        return "completed"
+    if s in {"failed", "error", "blocked"}:
+        return "failed"
+    if s in {"running", "in_progress"}:
+        return "running"
+    if s == "confirmation_required":
+        return "running"  # never reached the terminal state in this run
+    return "pending"
+
+
+def _build_step(step: Any, tool_events: list[dict]) -> dict:
+    step_tool_calls = list(getattr(step, "tool_calls", None) or [])
+    tool_names: list[str] = []
+    for tc in step_tool_calls:
+        if isinstance(tc, dict):
+            name = str(tc.get("name") or "").strip()
+            if name:
+                tool_names.append(name)
+
+    # Group by tool_name: one item per unique tool the step planned. Status
+    # comes from the most informative matching event we can find.
+    items: list[dict] = []
+    seen: set[str] = set()
+    for name in tool_names:
+        if name in seen:
+            continue
+        seen.add(name)
+        matching = [
+            ev
+            for ev in tool_events
+            if isinstance(ev, dict) and str(ev.get("tool_name") or "") == name
+        ]
+        status = "completed" if matching else "pending"
+        detail: str | None = None
+        for ev in matching:
+            ev_status = _v1_item_status(ev.get("status"))
+            # Terminal statuses (failed/completed) override running/pending.
+            if ev_status in {"completed", "failed"} or status not in {"completed", "failed"}:
+                status = ev_status
+            msg = ev.get("summary") or ev.get("message")
+            if isinstance(msg, str) and msg.strip():
+                detail = msg.strip()
+        item: dict[str, Any] = {"tool_name": name, "status": status}
+        if detail:
+            item["detail"] = detail
+        items.append(item)
+
+    title = "、".join(tool_names) if tool_names else f"第 {(getattr(step, 'index', 0) or 0) + 1} 步"
+    step_status = "failed" if any(it.get("status") == "failed" for it in items) else "completed"
+    entry: dict[str, Any] = {
+        "index": (getattr(step, "index", 0) or 0) + 1,
+        "title": title,
+        "status": step_status,
+        "duration_ms": int(getattr(step, "duration_ms", 0) or 0),
+        "items": items,
+    }
+    if getattr(step, "truncated", False):
+        entry["truncated"] = True
+    return entry
+
+
+def _build_artifacts(state_artifacts: Any) -> list[dict]:
+    out: list[dict] = []
+    for art in state_artifacts or []:
+        if not isinstance(art, dict):
+            continue
+        artifact_id = art.get("id") or art.get("project_file_id")
+        if not artifact_id:
+            continue
+        raw_kind = str(art.get("file_type") or art.get("output_kind") or "").lower().lstrip(".")
+        v1_kind = _ARTIFACT_TYPE_V1_MAP.get(raw_kind)
+        if not v1_kind:
+            continue
+        out.append({"id": str(artifact_id), "type": v1_kind})
+    return out
+
+
+def _build_skill(runtime: Any) -> dict | None:
+    name = str(getattr(runtime, "skill_name", "") or "").strip()
+    if not name:
+        return None
+    payload: dict[str, Any] = {"name": name}
+    skill_id = getattr(runtime, "skill_id", None)
+    if not skill_id:
+        prepare_metrics = getattr(runtime, "prepare_metrics", None)
+        if isinstance(prepare_metrics, dict):
+            skill_id = prepare_metrics.get("effective_skill_id")
+    if skill_id:
+        payload["id"] = str(skill_id)
+    return payload
+
+
+def build_activity_timeline(state: Any, runtime: Any, *, full_text: str = "") -> dict | None:
+    """Return the persisted timeline dict, or ``None`` if there is no run_id."""
+    run_id = str(getattr(state, "run_id", "") or "")
+    if not run_id:
+        return None
+
+    tool_events = list(getattr(state, "tool_call_events", None) or [])
+    steps = [_build_step(step, tool_events) for step in getattr(state, "steps", None) or []]
+    artifacts = _build_artifacts(getattr(state, "artifacts", None))
+
+    timeline: dict[str, Any] = {
+        "run_id": run_id,
+        "steps": steps,
+        "artifacts": artifacts,
+        "final_status": "completed",
+        "text": full_text or str(getattr(state, "full_text", "") or ""),
+    }
+
+    skill = _build_skill(runtime)
+    if skill is not None:
+        timeline["skill"] = skill
+
+    return timeline

--- a/backend/app/services/chat/persist.py
+++ b/backend/app/services/chat/persist.py
@@ -852,6 +852,15 @@ async def run_persist(
     if any(step.truncated for step in state.steps):
         metadata["truncated"] = True
 
+    # Product Run Event v1: snapshot the activity timeline so the persisted
+    # view (ProjectChatMessageBubble) can re-render it on refresh. Returns
+    # None when state.run_id is empty (legacy / no run tracked) — skip silently.
+    from app.services.chat.activity_timeline_persist import build_activity_timeline
+
+    activity_timeline = build_activity_timeline(state, runtime, full_text=full_text)
+    if activity_timeline is not None:
+        metadata["activity_timeline"] = activity_timeline
+
     state.stage_timings["save_ms"] = round((time.perf_counter() - save_started_at) * 1000)
     state.stage_timings["total_stream_ms"] = round((time.perf_counter() - stream_started_at) * 1000)
     metadata["stage_timings"] = state.stage_timings

--- a/backend/tests/test_activity_timeline_persist.py
+++ b/backend/tests/test_activity_timeline_persist.py
@@ -1,0 +1,145 @@
+"""Unit tests for the persist-time activity-timeline serializer
+(``app.services.chat.activity_timeline_persist.build_activity_timeline``)."""
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+
+from app.services.chat.activity_timeline_persist import build_activity_timeline
+
+
+def _step(*, index, tool_calls=None, duration_ms=0, truncated=False):
+    return SimpleNamespace(
+        index=index,
+        tool_calls=tool_calls or [],
+        duration_ms=duration_ms,
+        truncated=truncated,
+    )
+
+
+def _state(*, run_id="run_x", steps=None, tool_call_events=None, artifacts=None, full_text=""):
+    return SimpleNamespace(
+        run_id=run_id,
+        steps=steps or [],
+        tool_call_events=tool_call_events or [],
+        artifacts=artifacts or [],
+        full_text=full_text,
+    )
+
+
+def _runtime(*, skill_name="", skill_id=None, prepare_metrics=None):
+    return SimpleNamespace(
+        skill_name=skill_name,
+        skill_id=skill_id,
+        prepare_metrics=prepare_metrics or {},
+    )
+
+
+class BuildActivityTimelineTest(unittest.TestCase):
+    def test_returns_none_when_run_id_empty(self):
+        self.assertIsNone(build_activity_timeline(_state(run_id=""), _runtime()))
+
+    def test_text_only_turn_no_steps_no_artifacts(self):
+        timeline = build_activity_timeline(
+            _state(steps=[], tool_call_events=[], artifacts=[], full_text="hello"),
+            _runtime(),
+            full_text="hello",
+        )
+        assert timeline is not None
+        self.assertEqual(timeline["run_id"], "run_x")
+        self.assertEqual(timeline["steps"], [])
+        self.assertEqual(timeline["artifacts"], [])
+        self.assertEqual(timeline["final_status"], "completed")
+        self.assertEqual(timeline["text"], "hello")
+        self.assertNotIn("skill", timeline)
+
+    def test_step_with_tool_and_matching_event_marks_completed(self):
+        timeline = build_activity_timeline(
+            _state(
+                steps=[
+                    _step(
+                        index=0,
+                        tool_calls=[{"name": "read_project_markdown_document"}],
+                        duration_ms=180,
+                    ),
+                ],
+                tool_call_events=[
+                    {
+                        "tool_name": "read_project_markdown_document",
+                        "status": "completed",
+                        "summary": "已读取 3 个文件",
+                    }
+                ],
+            ),
+            _runtime(),
+        )
+        assert timeline is not None
+        self.assertEqual(len(timeline["steps"]), 1)
+        step = timeline["steps"][0]
+        self.assertEqual(step["index"], 1)  # 1-based for the frontend
+        self.assertEqual(step["title"], "read_project_markdown_document")
+        self.assertEqual(step["status"], "completed")
+        self.assertEqual(step["duration_ms"], 180)
+        self.assertEqual(step["items"], [
+            {"tool_name": "read_project_markdown_document", "status": "completed", "detail": "已读取 3 个文件"},
+        ])
+
+    def test_failed_event_flips_step_status_to_failed(self):
+        timeline = build_activity_timeline(
+            _state(
+                steps=[_step(index=0, tool_calls=[{"name": "generate_ppt"}])],
+                tool_call_events=[{"tool_name": "generate_ppt", "status": "failed"}],
+            ),
+            _runtime(),
+        )
+        assert timeline is not None
+        self.assertEqual(timeline["steps"][0]["status"], "failed")
+        self.assertEqual(timeline["steps"][0]["items"][0]["status"], "failed")
+
+    def test_step_without_planned_tools_uses_generic_title(self):
+        timeline = build_activity_timeline(
+            _state(steps=[_step(index=1)]),
+            _runtime(),
+        )
+        assert timeline is not None
+        self.assertEqual(timeline["steps"][0]["title"], "第 2 步")
+
+    def test_artifact_filetype_maps_md_to_markdown_and_passes_pptx(self):
+        timeline = build_activity_timeline(
+            _state(
+                artifacts=[
+                    {"id": 7, "file_type": "pptx"},
+                    {"project_file_id": 11, "file_type": "md"},
+                    {"id": 13, "file_type": "unknown"},
+                ]
+            ),
+            _runtime(),
+        )
+        assert timeline is not None
+        self.assertEqual(
+            timeline["artifacts"],
+            [
+                {"id": "7", "type": "pptx"},
+                {"id": "11", "type": "markdown"},
+            ],
+        )
+
+    def test_truncated_step_carries_flag(self):
+        timeline = build_activity_timeline(
+            _state(steps=[_step(index=0, truncated=True)]),
+            _runtime(),
+        )
+        assert timeline is not None
+        self.assertTrue(timeline["steps"][0].get("truncated"))
+
+    def test_skill_block_present_when_runtime_has_skill_name(self):
+        timeline = build_activity_timeline(
+            _state(),
+            _runtime(skill_name="数字化战略", prepare_metrics={"effective_skill_id": "digital-strategy"}),
+        )
+        assert timeline is not None
+        self.assertEqual(timeline["skill"], {"name": "数字化战略", "id": "digital-strategy"})
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/backend/tests/test_chat_end_to_end.py
+++ b/backend/tests/test_chat_end_to_end.py
@@ -620,6 +620,18 @@ class ProductRunEventV1BoundaryTests(ChatEndToEndBase):
         legacy_done = _events_of_type(events, "done")[0]
         self.assertLess(idx_persisted, events.index(legacy_done))
 
+        # The persisted assistant message must carry the snapshot timeline so
+        # the persisted view can re-render it on refresh (A3).
+        assistant = [m for m in self.assistant_messages() if m.role == "assistant"]
+        self.assertEqual(len(assistant), 1)
+        metadata = json.loads(assistant[0].metadata_json or "{}")
+        timeline = metadata.get("activity_timeline")
+        self.assertIsInstance(timeline, dict, "expected metadata.activity_timeline to be saved")
+        self.assertEqual(timeline["run_id"], run_id)
+        self.assertEqual(timeline["final_status"], "completed")
+        self.assertIsInstance(timeline.get("steps"), list)
+        self.assertIsInstance(timeline.get("artifacts"), list)
+
     async def test_run_started_carries_skill_identity_when_set(self) -> None:
         self.runtime.skill_name = "digital-strategy"
         self.set_llm_stream([["ok"]])


### PR DESCRIPTION
## Summary
Closes the persisted-view loop with the A2 frontend (#9). At end-of-run, `persist.run_persist` now snapshots the agent's actual execution into `message.metadata['activity_timeline']` matching the frontend `RunActivityTimeline` shape — so reloading or deep-linking into a conversation re-renders the same timeline the user saw while the turn was streaming.

Independent of #8 (it only reads existing `state` fields that landed on `main` in wave 2: `state.run_id`, `state.steps`, `state.tool_call_events`, `state.artifacts`). Safe to merge before or after #8.

## What's in
- New module `app/services/chat/activity_timeline_persist.py` with `build_activity_timeline(state, runtime, full_text=...)` — returns the dict or `None` when run_id is empty.
- Wiring in `persist.run_persist`: at the end of the metadata-building block, set `metadata['activity_timeline']` when the serializer returns non-None.
- Shape matches frontend `RunActivityTimeline`:
  - `run_id` (skipped when empty)
  - `skill` ({name, id?}) only when `runtime.skill_name` is set
  - `steps`: 1-indexed, title joined from planned `tool_calls`, status="failed" if any item failed, `duration_ms`, `truncated`
  - `items`: one per unique planned tool name, status derived from the most informative matching `state.tool_call_events` entry; event `summary`/`message` carried as `detail` when present
  - `artifacts`: file_type mapped to v1 enum (`md` → `markdown`; `pptx/docx/xlsx/pdf` passthrough; unknown dropped)
  - `final_status`: "completed" (failure paths emit `run_failed` via `_persist_phase_error_events` and don't reach persist)
  - `text`: final assembled assistant text

## Test plan
- [x] `test_activity_timeline_persist.py`: 8 focused unit tests covering None on empty run_id, text-only turn, step+matching-event → completed, failed-event → step failed, no-tools → generic title, artifact file_type mapping, truncated flag, skill block from runtime.
- [x] `test_chat_end_to_end.py`: extended boundary happy-path to assert the saved message metadata includes a well-formed `activity_timeline` (right `run_id`, list-shaped `steps`/`artifacts`, `final_status=completed`).
- [x] 186 backend tests pass (chat e2e + streaming + sse contracts + multiturn golden + product-run-events + new persist module).
- [ ] After all three (PR #8 + #9 + this) are merged: enable the flag (`localStorage['aria.run_harness_v1']='true'`), run a turn, refresh — verify the timeline is still rendered from metadata.

## Coordination
- **#8** wires the live SSE events (`step_started` / `step_completed` / `tool_progress` / `task_update` / `confirmation_required` / `artifact_ready`).
- **#9** consumes those into `RunActivityTimeline` + renders the streaming view.
- **This PR** persists the timeline so the **same UI** also renders on refresh / navigate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)