### PR TITLE
Track B v1: user-memory prompt injection + settings UI

### DIFF
--- a/backend/app/services/chat/runtime.py
+++ b/backend/app/services/chat/runtime.py
@@ -663,6 +663,22 @@ def prepare_chat_runtime(
     )
     intent_frame = _build_intent_frame(intent_decision, skill_decision, effective_skill, context_mode, consulting_frame)
     system = _append_intent_frame(system, intent_frame, consulting_frame)
+
+    # V0.0.4 track B: inject the current user's explicit preferences (language,
+    # tone, reporting style, …) so AI behaviour stays consistent across
+    # projects without re-asking every turn. Skipped when there's no user_id
+    # or no UserMemory row.
+    from app.services.chat.user_memory_prompt import (
+        format_user_memory_for_prompt,
+        load_user_memory_preferences,
+    )
+
+    user_memory_prefs = load_user_memory_preferences(session, owner_user_id)
+    user_memory_section = format_user_memory_for_prompt(user_memory_prefs)
+    if user_memory_section:
+        system = f"{system.rstrip()}\n\n{user_memory_section}\n"
+        prepare_metrics["user_memory_injected"] = True
+        prepare_metrics["user_memory_chars"] = len(user_memory_section)
     prepare_metrics["intent_frame"] = intent_frame
     prepare_metrics["consulting_frame"] = {
         "job_type": consulting_frame.job_type,

--- a/backend/app/services/chat/user_memory_prompt.py
+++ b/backend/app/services/chat/user_memory_prompt.py
@@ -1,0 +1,116 @@
+"""User-memory → system-prompt injection (V0.0.4 track B).
+
+Given the current user's ``UserMemory`` row, build a compact prompt fragment the
+model can use to personalise its reply (语言、汇报风格、工作偏好…) without
+re-asking every turn.
+
+Kept deliberately small:
+* Loads only the row for ``user_id``; returns the parsed JSON dict (or ``None``).
+* Renders a flat, bulletised section capped at ``_MAX_PROMPT_CHARS`` so a
+  poorly-shaped preference blob can never blow up the system prompt.
+* Skips wholly empty / boolean-False values so the section only surfaces signals
+  the user actually wrote down.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from sqlmodel import Session, select
+
+from app.models.db import UserMemory
+
+
+_MAX_PROMPT_CHARS = 1200  # safety cap for the entire injected section
+_MAX_BULLET_CHARS = 160   # one bullet's printed length cap
+_MAX_BULLETS = 16         # never inject more than this many bullets
+
+
+def load_user_memory_preferences(session: Session, user_id: int | None) -> dict[str, Any] | None:
+    """Return the user's preferences dict, or ``None`` if there's no row /
+    no usable JSON / no user_id."""
+    if not user_id:
+        return None
+    row = session.exec(select(UserMemory).where(UserMemory.user_id == user_id)).first()
+    if row is None:
+        return None
+    try:
+        prefs = json.loads(row.preferences_json or "{}")
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(prefs, dict) or not prefs:
+        return None
+    return prefs
+
+
+def _is_meaningful(value: Any) -> bool:
+    """Drop empty strings / empty lists / dicts / ``None`` / ``False``."""
+    if value is None or value is False:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, (list, tuple, set, dict)):
+        return len(value) > 0
+    return True
+
+
+def _format_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return "是" if value else "否"
+    if isinstance(value, (list, tuple, set)):
+        items = [str(v).strip() for v in value if _is_meaningful(v)]
+        return "、".join(items)
+    if isinstance(value, dict):
+        # Render at most a couple of top-level entries inline.
+        parts = []
+        for k, v in value.items():
+            if not _is_meaningful(v):
+                continue
+            parts.append(f"{k}={_format_value(v)}")
+        return "; ".join(parts)
+    return str(value).strip()
+
+
+def _flatten_bullets(preferences: dict[str, Any]) -> list[str]:
+    """Walk one level of nesting and produce ``key: value`` bullets."""
+    bullets: list[str] = []
+    for top_key, top_val in preferences.items():
+        if not _is_meaningful(top_val):
+            continue
+        if isinstance(top_val, dict):
+            for sub_key, sub_val in top_val.items():
+                if not _is_meaningful(sub_val):
+                    continue
+                line = f"{top_key}.{sub_key}: {_format_value(sub_val)}"
+                if len(line) > _MAX_BULLET_CHARS:
+                    line = line[: _MAX_BULLET_CHARS - 1] + "…"
+                bullets.append(line)
+                if len(bullets) >= _MAX_BULLETS:
+                    return bullets
+        else:
+            line = f"{top_key}: {_format_value(top_val)}"
+            if len(line) > _MAX_BULLET_CHARS:
+                line = line[: _MAX_BULLET_CHARS - 1] + "…"
+            bullets.append(line)
+            if len(bullets) >= _MAX_BULLETS:
+                return bullets
+    return bullets
+
+
+def format_user_memory_for_prompt(preferences: dict[str, Any] | None) -> str:
+    """Render a compact prompt section from a preferences dict, or empty string."""
+    if not isinstance(preferences, dict) or not preferences:
+        return ""
+    bullets = _flatten_bullets(preferences)
+    if not bullets:
+        return ""
+    body = "\n".join(f"- {b}" for b in bullets)
+    section = (
+        "## 当前用户偏好（User Memory）\n"
+        "用户已显式声明的工作方式与回复偏好。除非用户在本轮明确说明相反，"
+        "请在不影响项目事实与客户事实的前提下尽量遵循。\n"
+        f"{body}"
+    )
+    if len(section) > _MAX_PROMPT_CHARS:
+        section = section[: _MAX_PROMPT_CHARS - 1] + "…"
+    return section

--- a/backend/tests/test_user_memory_prompt.py
+++ b/backend/tests/test_user_memory_prompt.py
@@ -1,0 +1,121 @@
+"""Tests for the user-memory → system-prompt injection helper."""
+from __future__ import annotations
+
+import json
+import unittest
+from types import SimpleNamespace
+
+from sqlmodel import Session, SQLModel
+
+from app.models.db import User, UserMemory
+from app.services.chat.user_memory_prompt import (
+    format_user_memory_for_prompt,
+    load_user_memory_preferences,
+)
+from tests.test_database import create_test_engine, drop_all_tables
+
+
+class FormatUserMemoryTest(unittest.TestCase):
+    """Pure formatting tests — no DB needed."""
+
+    def test_empty_input_yields_empty_string(self):
+        self.assertEqual(format_user_memory_for_prompt(None), "")
+        self.assertEqual(format_user_memory_for_prompt({}), "")
+        # Whitespace-only / falsy values get filtered out and produce nothing.
+        self.assertEqual(format_user_memory_for_prompt({"a": "", "b": None, "c": []}), "")
+
+    def test_flat_preferences_render_as_bullets(self):
+        out = format_user_memory_for_prompt({"language": "zh", "tone": "direct"})
+        self.assertIn("User Memory", out)
+        self.assertIn("- language: zh", out)
+        self.assertIn("- tone: direct", out)
+
+    def test_nested_one_level_renders_dotted_keys(self):
+        out = format_user_memory_for_prompt(
+            {
+                "response_preferences": {"language": "zh", "verbosity": "normal"},
+                "work_style": {"prefers_root_cause_first": True},
+            }
+        )
+        self.assertIn("- response_preferences.language: zh", out)
+        self.assertIn("- response_preferences.verbosity: normal", out)
+        self.assertIn("- work_style.prefers_root_cause_first: 是", out)
+
+    def test_list_values_join_with_chinese_punctuation(self):
+        out = format_user_memory_for_prompt({"format_preferences": ["conclusion_first", "action_plan"]})
+        self.assertIn("- format_preferences: conclusion_first、action_plan", out)
+
+    def test_falsy_nested_values_are_dropped(self):
+        out = format_user_memory_for_prompt(
+            {
+                "response_preferences": {
+                    "language": "zh",
+                    "verbosity": "",
+                    "fancy_mode": False,
+                },
+            }
+        )
+        self.assertIn("response_preferences.language: zh", out)
+        self.assertNotIn("verbosity", out)
+        self.assertNotIn("fancy_mode", out)
+
+    def test_overall_section_is_capped(self):
+        big = {f"k{i}": "x" * 200 for i in range(50)}
+        out = format_user_memory_for_prompt(big)
+        # _MAX_PROMPT_CHARS is 1200; allow a tiny tail for the ellipsis.
+        self.assertLessEqual(len(out), 1201)
+
+
+class LoadUserMemoryFromDbTest(unittest.TestCase):
+    def setUp(self):
+        self.engine = create_test_engine()
+        drop_all_tables(self.engine)
+        SQLModel.metadata.create_all(self.engine)
+        with Session(self.engine) as session:
+            session.add(User(id=1, email="a@x.com", display_name="A", password_hash="x"))
+            session.commit()
+
+    def tearDown(self):
+        SQLModel.metadata.drop_all(self.engine)
+        self.engine.dispose()
+
+    def test_returns_none_without_user_id(self):
+        with Session(self.engine) as session:
+            self.assertIsNone(load_user_memory_preferences(session, None))
+            self.assertIsNone(load_user_memory_preferences(session, 0))
+
+    def test_returns_none_when_no_row(self):
+        with Session(self.engine) as session:
+            self.assertIsNone(load_user_memory_preferences(session, 1))
+
+    def test_returns_parsed_preferences(self):
+        with Session(self.engine) as session:
+            session.add(
+                UserMemory(
+                    user_id=1,
+                    preferences_json=json.dumps({"language": "zh", "tone": "direct"}),
+                    version=1,
+                )
+            )
+            session.commit()
+        with Session(self.engine) as session:
+            prefs = load_user_memory_preferences(session, 1)
+        self.assertEqual(prefs, {"language": "zh", "tone": "direct"})
+
+    def test_returns_none_for_malformed_json(self):
+        with Session(self.engine) as session:
+            session.add(UserMemory(user_id=1, preferences_json="{not json", version=1))
+            session.commit()
+        with Session(self.engine) as session:
+            self.assertIsNone(load_user_memory_preferences(session, 1))
+
+    def test_returns_none_for_empty_object(self):
+        with Session(self.engine) as session:
+            session.add(UserMemory(user_id=1, preferences_json="{}", version=1))
+            session.commit()
+        with Session(self.engine) as session:
+            self.assertIsNone(load_user_memory_preferences(session, 1))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/web/src/pages/settings/ProfileSettings.tsx
+++ b/web/src/pages/settings/ProfileSettings.tsx
@@ -3,6 +3,7 @@ import { User, Mail, KeyRound, Check, Loader2, AlertCircle, X, Lock, Clock3, Typ
 import { api } from '../../api/client'
 import type { User as UserType } from '../../types/api'
 import { BROWSER_TIMEZONE_VALUE, DEFAULT_APP_TIMEZONE, getBrowserTimeZone, setAppTimeZone } from '../../utils/timezone'
+import { UserMemorySettingsCard } from './UserMemorySettingsCard'
 import {
   APP_FONT_SIZE_SETTING_KEY,
   getStoredAppFontSize,
@@ -317,6 +318,9 @@ export function ProfileSettings() {
           )}
         </div>
       </div>
+
+      {/* User Memory (AI 个人偏好) Card */}
+      <UserMemorySettingsCard />
 
       {/* Password Card */}
       <div className="card space-y-4">

--- a/web/src/pages/settings/UserMemorySettingsCard.tsx
+++ b/web/src/pages/settings/UserMemorySettingsCard.tsx
@@ -1,0 +1,292 @@
+/**
+ * "AI 个人偏好" card (V0.0.4 track B v1).
+ *
+ * Reads/writes the current user's UserMemory preferences via /user-memory.
+ * Surfaces a small, structured set of preferences (language, tone, response
+ * shape, confirm-before-destructive) — that's enough to demonstrate the
+ * backend prompt-injection without inviting users to free-edit arbitrary JSON.
+ *
+ * Behaviour:
+ * - Loads existing preferences on mount.
+ * - Save explicitly via the "保存" button (PUT /user-memory).
+ * - "清除所有偏好" wipes the row (DELETE /user-memory).
+ * - All preferences are optional. Defaults stay unset → the backend section
+ *   simply omits them.
+ */
+import { useEffect, useState } from "react";
+import { AlertCircle, Brain, Check, Eraser, Loader2 } from "lucide-react";
+
+import { api } from "../../api/client";
+
+type Language = "" | "zh" | "en" | "auto";
+type Tone = "" | "direct" | "friendly" | "formal";
+type FormatShape = "" | "conclusion_first" | "free";
+
+interface UserMemoryResponse {
+  preferences: Record<string, unknown>;
+  version: number;
+  updated_at: string;
+}
+
+interface PreferencesShape {
+  response_preferences?: {
+    language?: Language;
+    tone?: Tone;
+    format?: FormatShape;
+  };
+  work_style?: {
+    ask_before_destructive?: boolean;
+  };
+}
+
+const LANGUAGE_OPTIONS: { value: Language; label: string }[] = [
+  { value: "", label: "未设置" },
+  { value: "zh", label: "中文优先" },
+  { value: "en", label: "English first" },
+  { value: "auto", label: "跟随对话语言" },
+];
+
+const TONE_OPTIONS: { value: Tone; label: string }[] = [
+  { value: "", label: "未设置" },
+  { value: "direct", label: "直接、协作" },
+  { value: "friendly", label: "友好、亲和" },
+  { value: "formal", label: "正式、客户场合" },
+];
+
+const FORMAT_OPTIONS: { value: FormatShape; label: string }[] = [
+  { value: "", label: "未设置" },
+  { value: "conclusion_first", label: "先给结论再展开" },
+  { value: "free", label: "由模型自由判断" },
+];
+
+function compactPreferences(prefs: PreferencesShape): Record<string, unknown> {
+  const compact: PreferencesShape = {};
+  const rp = prefs.response_preferences ?? {};
+  const rpOut: PreferencesShape["response_preferences"] = {};
+  if (rp.language) rpOut.language = rp.language;
+  if (rp.tone) rpOut.tone = rp.tone;
+  if (rp.format) rpOut.format = rp.format;
+  if (Object.keys(rpOut).length > 0) compact.response_preferences = rpOut;
+
+  const ws = prefs.work_style ?? {};
+  if (typeof ws.ask_before_destructive === "boolean") {
+    compact.work_style = { ask_before_destructive: ws.ask_before_destructive };
+  }
+  return compact as unknown as Record<string, unknown>;
+}
+
+function readShape(raw: Record<string, unknown> | undefined): PreferencesShape {
+  if (!raw || typeof raw !== "object") return {};
+  const rp = (raw as { response_preferences?: unknown }).response_preferences;
+  const ws = (raw as { work_style?: unknown }).work_style;
+  const out: PreferencesShape = {};
+  if (rp && typeof rp === "object") {
+    const block = rp as Partial<Record<string, unknown>>;
+    out.response_preferences = {
+      language: (block.language as Language) ?? "",
+      tone: (block.tone as Tone) ?? "",
+      format: (block.format as FormatShape) ?? "",
+    };
+  }
+  if (ws && typeof ws === "object") {
+    const block = ws as Partial<Record<string, unknown>>;
+    if (typeof block.ask_before_destructive === "boolean") {
+      out.work_style = { ask_before_destructive: block.ask_before_destructive };
+    }
+  }
+  return out;
+}
+
+export function UserMemorySettingsCard() {
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [clearing, setClearing] = useState(false);
+  const [version, setVersion] = useState(0);
+  const [prefs, setPrefs] = useState<PreferencesShape>({});
+  const [msg, setMsg] = useState<{ type: "success" | "error"; text: string } | null>(null);
+
+  useEffect(() => {
+    api
+      .get<UserMemoryResponse>("/user-memory")
+      .then((data) => {
+        setPrefs(readShape(data.preferences as Record<string, unknown>));
+        setVersion(data.version || 0);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  const updateResponsePref = <K extends keyof NonNullable<PreferencesShape["response_preferences"]>>(
+    key: K,
+    value: NonNullable<PreferencesShape["response_preferences"]>[K],
+  ) => {
+    setPrefs((cur) => ({
+      ...cur,
+      response_preferences: { ...(cur.response_preferences ?? {}), [key]: value },
+    }));
+    setMsg(null);
+  };
+
+  const updateWorkStyle = (value: boolean | null) => {
+    setPrefs((cur) => {
+      if (value === null) {
+        const { work_style: _omit, ...rest } = cur;
+        return rest;
+      }
+      return { ...cur, work_style: { ask_before_destructive: value } };
+    });
+    setMsg(null);
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setMsg(null);
+    try {
+      const payload = compactPreferences(prefs);
+      const data = await api.put<UserMemoryResponse>("/user-memory", { preferences: payload });
+      setVersion(data.version || version + 1);
+      setMsg({ type: "success", text: "偏好已保存,下一轮对话生效。" });
+      setTimeout(() => setMsg(null), 3000);
+    } catch (err: any) {
+      setMsg({ type: "error", text: err.response?.data?.detail || "保存失败" });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleClear = async () => {
+    if (!confirm("将清除所有 AI 偏好,AI 将不再读取这些个人化设置。继续?")) return;
+    setClearing(true);
+    setMsg(null);
+    try {
+      await api.delete("/user-memory");
+      setPrefs({});
+      setMsg({ type: "success", text: "偏好已清除。" });
+      setTimeout(() => setMsg(null), 3000);
+    } catch (err: any) {
+      setMsg({ type: "error", text: err.response?.data?.detail || "清除失败" });
+    } finally {
+      setClearing(false);
+    }
+  };
+
+  const selectCls =
+    "rounded-xl border border-outline/20 bg-surface-container-lowest px-3 py-2 text-on-surface focus:outline-none focus:ring-2 focus:ring-primary/20";
+
+  return (
+    <div className="card space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-label-lg text-on-surface flex items-center gap-2 mb-1">
+            <Brain className="w-4 h-4 text-primary" />
+            AI 个人偏好
+          </h3>
+          <p className="text-body-sm text-on-surface-muted">
+            跨项目生效。AI 会在系统提示词中读取这些偏好,但不会写入客户/项目记忆。
+          </p>
+        </div>
+        {version > 0 && (
+          <span className="text-xs text-on-surface-muted">v{version}</span>
+        )}
+      </div>
+
+      {loading ? (
+        <div className="flex items-center gap-2 text-sm text-on-surface-muted">
+          <Loader2 className="w-4 h-4 animate-spin" />
+          正在加载...
+        </div>
+      ) : (
+        <>
+          <div className="space-y-3">
+            <div className="space-y-1.5">
+              <label className="text-label-sm text-on-surface-muted">回复语言</label>
+              <select
+                value={prefs.response_preferences?.language ?? ""}
+                onChange={(e) => updateResponsePref("language", e.target.value as Language)}
+                className={selectCls + " w-full"}
+              >
+                {LANGUAGE_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>{o.label}</option>
+                ))}
+              </select>
+            </div>
+
+            <div className="space-y-1.5">
+              <label className="text-label-sm text-on-surface-muted">回复语气</label>
+              <select
+                value={prefs.response_preferences?.tone ?? ""}
+                onChange={(e) => updateResponsePref("tone", e.target.value as Tone)}
+                className={selectCls + " w-full"}
+              >
+                {TONE_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>{o.label}</option>
+                ))}
+              </select>
+            </div>
+
+            <div className="space-y-1.5">
+              <label className="text-label-sm text-on-surface-muted">回复结构</label>
+              <select
+                value={prefs.response_preferences?.format ?? ""}
+                onChange={(e) => updateResponsePref("format", e.target.value as FormatShape)}
+                className={selectCls + " w-full"}
+              >
+                {FORMAT_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>{o.label}</option>
+                ))}
+              </select>
+            </div>
+
+            <div className="space-y-1.5">
+              <label className="text-label-sm text-on-surface-muted">写入/删除前是否再确认</label>
+              <select
+                value={
+                  typeof prefs.work_style?.ask_before_destructive === "boolean"
+                    ? prefs.work_style.ask_before_destructive
+                      ? "true"
+                      : "false"
+                    : ""
+                }
+                onChange={(e) => {
+                  if (e.target.value === "") updateWorkStyle(null);
+                  else updateWorkStyle(e.target.value === "true");
+                }}
+                className={selectCls + " w-full"}
+              >
+                <option value="">未设置</option>
+                <option value="true">是</option>
+                <option value="false">否</option>
+              </select>
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between gap-3">
+            <button
+              onClick={handleClear}
+              disabled={clearing}
+              className="btn-secondary flex items-center gap-2 px-3 disabled:opacity-40"
+            >
+              {clearing ? <Loader2 className="w-4 h-4 animate-spin" /> : <Eraser className="w-4 h-4" />}
+              清除所有偏好
+            </button>
+            <button
+              onClick={handleSave}
+              disabled={saving}
+              className="btn-primary flex items-center gap-2 px-4 disabled:opacity-40"
+            >
+              {saving ? <Loader2 className="w-4 h-4 animate-spin" /> : <Check className="w-4 h-4" />}
+              保存
+            </button>
+          </div>
+
+          {msg && (
+            <p className={`text-xs flex items-center gap-1 ${msg.type === "success" ? "text-active" : "text-error"}`}>
+              {msg.type === "error" && <AlertCircle className="w-3 h-3" />}
+              {msg.text}
+            </p>
+          )}
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
V0.0.4 main track B (user memory v1) full feature. The `UserMemory` table and minimal `/user-memory` API have been on `main` since the kickoff commit; this PR wires the two ends — **backend prompt injection** + **frontend settings card** — so user preferences actually affect AI behaviour and are user-editable.

End-state user value: 把"以后给我用英文回复 / 先给结论 / 写入前再确认我一下"这种偏好显式写进设置,**跨项目生效**,模型每轮都能读到,不用反复声明。

## Backend
- New module `app/services/chat/user_memory_prompt.py`:
  - `load_user_memory_preferences(session, user_id)` reads `UserMemory`, returns the parsed dict or `None` (missing row / malformed JSON / no user_id / empty object — all defensive).
  - `format_user_memory_for_prompt(prefs)` renders a compact bulletised section, supports one level of nesting with dotted keys, drops falsy values, caps at 1200 chars overall and 160 chars per bullet, max 16 bullets.
- `prepare_chat_runtime` (and via delegation `prepare_chat_runtime_async`) loads the current user's preferences and appends the section to the system prompt right after the intent frame. Skipped silently when no `owner_user_id` or no usable row. `prepare_metrics` records `user_memory_injected` + `user_memory_chars`.

## Frontend
- New `UserMemorySettingsCard` component mounted in `ProfileSettings` between the profile + password cards.
- Four structured selectors covering exactly what the prompt formatter knows how to render:
  - `response_preferences.language` (zh / en / auto)
  - `response_preferences.tone` (direct / friendly / formal)
  - `response_preferences.format` (conclusion_first / free)
  - `work_style.ask_before_destructive` (true / false)
- "未设置" → omitted from the PUT payload → prompt section simply doesn't list that key. Explicit `保存` (PUT) + `清除所有偏好` (DELETE with confirm).

## Test plan
- [x] 11 backend unit tests (`test_user_memory_prompt.py`): empty input / flat / nested-dotted / list values joined with chinese punctuation / falsy filtering / hard cap; DB-loader paths.
- [x] Full backend chat regression (339 tests in chat_flow + chat_end_to_end + chat_streaming + sse_events + user_memory + user_memory_prompt) still passes after the injection wire.
- [x] Frontend `tsc --noEmit` clean; `vite build` succeeds; full vitest 62 files / 401 tests pass.
- [ ] After merge: set a non-default preference (e.g. language=en) in `/settings/profile`, send a project chat message in English context, verify the model honours the preference. Verify the assistant message metadata includes the injected section in `prepare_metrics`.

## Guard rails (already enforced by the API)
- A user only reads/edits their own row (`current_user.id` scope).
- Top-level keys belonging to client/project memory (`client_id`, `project_id`, `milestones`, `contract_amount`, …) are rejected with 400 — the user-memory layer can never accidentally absorb client/project facts.

## What this unlocks for V0.0.4
This closes the most-visible part of **Track B v1** in `docs/13`. The follow-up "在对话里说 '记住这个偏好' 走 HITAS 确认卡" flow is left as the next step (already designed in docs/13 §3 wiring through Run Harness's `confirmation_required`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)