### PR TITLE
V0.0.4 finishing touches: D.3 + D.2 + A4 + B remember-pref

### DIFF
--- a/backend/app/services/chat/__init__.py
+++ b/backend/app/services/chat/__init__.py
@@ -173,6 +173,20 @@ async def stream_chat_events(
     state = ChatSessionState(stage_timings=dict(runtime.prepare_metrics or {}))
     state.run_id = make_run_id()
 
+    # V0.0.4 D.3: structured run-lifecycle log. Stays human-readable; easy to
+    # grep / pipe into JSON later. Emitted at run start, persist success, and
+    # in every error path so we can correlate runs to failures by run_id.
+    logger.info(
+        "[run start] run_id=%s conv=%s project=%s mode=%s policy=%s skill=%s model=%s",
+        state.run_id,
+        runtime.conv_id,
+        getattr(req, "project_id", None),
+        getattr(runtime, "chat_mode", ""),
+        getattr(runtime, "action_policy", ""),
+        getattr(runtime, "skill_name", "") or "-",
+        getattr(runtime, "selected_model", ""),
+    )
+
     # ------------------------------------------------------------------
     # Emit conversation_id, run_started (Product Run Event v1), and prepare
     # metrics upfront. run_started is additive — legacy frontends ignore it.
@@ -215,7 +229,11 @@ async def stream_chat_events(
         async for event in run_durable_task(runtime, req, bind, state):
             yield event
     except Exception as exc:
-        logger.error(f"[durable_task error] {exc}", exc_info=True)
+        logger.error(
+            "[run failed] run_id=%s phase=durable_task exc_type=%s exc=%s",
+            state.run_id, exc.__class__.__name__, exc,
+            exc_info=True,
+        )
         for event in _persist_phase_error_events(
             runtime=runtime,
             req=req,
@@ -237,6 +255,13 @@ async def stream_chat_events(
             }
         )
         yield sse_event(run_done(state.run_id, RunFinalStatus.COMPLETED))
+        logger.info(
+            "[run done] run_id=%s path=durable_task duration_ms=%s artifacts=%s tool_events=%s",
+            state.run_id,
+            state.stage_timings.get("total_stream_ms"),
+            len(state.artifacts or []),
+            len(state.tool_call_events or []),
+        )
         return
 
     # ==================================================================
@@ -246,7 +271,11 @@ async def stream_chat_events(
         async for event in run_agent_loop(runtime, req, state):
             yield event
     except Exception as exc:
-        logger.error(f"[agent_loop error] {exc}", exc_info=True)
+        logger.error(
+            "[run failed] run_id=%s phase=agent_loop exc_type=%s exc=%s",
+            state.run_id, exc.__class__.__name__, exc,
+            exc_info=True,
+        )
         for event in _persist_phase_error_events(
             runtime=runtime,
             req=req,
@@ -265,7 +294,11 @@ async def stream_chat_events(
         async for event in run_persist(runtime, req, bind, state):
             yield event
     except Exception as exc:
-        logger.error(f"[persist error] {exc}", exc_info=True)
+        logger.error(
+            "[run failed] run_id=%s phase=persist exc_type=%s exc=%s",
+            state.run_id, exc.__class__.__name__, exc,
+            exc_info=True,
+        )
         for event in _persist_phase_error_events(
             runtime=runtime,
             req=req,
@@ -279,3 +312,12 @@ async def stream_chat_events(
 
     # Successful end-of-run terminator (Product Run Event v1).
     yield sse_event(run_done(state.run_id, RunFinalStatus.COMPLETED))
+    logger.info(
+        "[run done] run_id=%s path=agent_loop duration_ms=%s steps=%s artifacts=%s tool_events=%s",
+        state.run_id,
+        state.stage_timings.get("total_stream_ms")
+        or round((time.perf_counter() - stream_started_at) * 1000),
+        len(state.steps or []),
+        len(state.artifacts or []),
+        len(state.tool_call_events or []),
+    )

--- a/backend/app/services/chat/persist.py
+++ b/backend/app/services/chat/persist.py
@@ -852,6 +852,19 @@ async def run_persist(
     if any(step.truncated for step in state.steps):
         metadata["truncated"] = True
 
+    # V0.0.4 A4: surface the routing decision so the frontend can show a small
+    # badge ("按对话大纲生成 PPT" vs "自动生成项目 PPT" etc.) without re-running
+    # any heuristic on its side.
+    prepare_metrics_all = getattr(runtime, "prepare_metrics", {}) if isinstance(getattr(runtime, "prepare_metrics", {}), dict) else {}
+    route_method = prepare_metrics_all.get("intent_method") or ""
+    route_reason = prepare_metrics_all.get("intent_reason") or ""
+    if route_method or route_reason:
+        route_decision = {"method": str(route_method), "reason": str(route_reason)}
+        chat_mode_value = prepare_metrics_all.get("chat_mode")
+        if chat_mode_value:
+            route_decision["chat_mode"] = str(chat_mode_value)
+        metadata["route_decision"] = route_decision
+
     state.stage_timings["save_ms"] = round((time.perf_counter() - save_started_at) * 1000)
     state.stage_timings["total_stream_ms"] = round((time.perf_counter() - stream_started_at) * 1000)
     metadata["stage_timings"] = state.stage_timings

--- a/backend/tests/test_chat_end_to_end.py
+++ b/backend/tests/test_chat_end_to_end.py
@@ -637,5 +637,107 @@ class ProductRunEventV1BoundaryTests(ChatEndToEndBase):
         self.assertNotIn("skill", started)
 
 
+# ----------------------------------------------------------------------
+# Scenario 9: Product Run Event v1 contract goldens (docs/13 §7.2 / D.2)
+# ----------------------------------------------------------------------
+#
+# These tests pin the SHAPE of the v1 events that flow from the orchestrator
+# today. They protect against silent protocol drift when later waves extend the
+# event types — a missing or renamed required field will break the contract
+# test immediately, before frontend consumers (PR #9) get hit by it.
+
+
+def _strip_volatile_run_event_fields(event: dict) -> dict:
+    """Drop fields that legitimately change between runs (timestamps, run_id)
+    so the assertion can equality-check against a stable golden snapshot."""
+    cleaned = dict(event)
+    for vol_key in ("run_id", "timestamp"):
+        cleaned.pop(vol_key, None)
+    return cleaned
+
+
+class ProductRunEventV1ContractGoldens(ChatEndToEndBase):
+    """Lock down the exact field shape of every v1 event the orchestrator emits
+    today. New event types added by later A1 waves must add their own golden."""
+
+    async def test_happy_text_only_run_started_shape(self) -> None:
+        self.set_llm_stream([["hi"]])
+        events = await self.drain()
+        started = _events_of_type(events, "run_started")[0]
+        # Plain text-only run: no skill, no display_mode (we don't set them yet).
+        self.assertEqual(_strip_volatile_run_event_fields(started), {"type": "run_started"})
+        # Volatile fields are nonetheless present and well-formed.
+        self.assertTrue(started["run_id"].startswith("run_"))
+        self.assertIsInstance(started["timestamp"], str)
+        self.assertGreater(len(started["timestamp"]), 10)
+
+    async def test_run_started_skill_block_shape(self) -> None:
+        self.runtime.skill_name = "digital-strategy"
+        self.set_llm_stream([["ok"]])
+        events = await self.drain()
+        started = _events_of_type(events, "run_started")[0]
+        cleaned = _strip_volatile_run_event_fields(started)
+        # Skill block has exactly {name}; no id is set unless runtime.skill_id is.
+        self.assertEqual(cleaned, {"type": "run_started", "skill": {"name": "digital-strategy"}})
+
+    async def test_message_persisted_shape(self) -> None:
+        self.set_llm_stream([["hello"]])
+        events = await self.drain()
+        persisted = _events_of_type(events, "message_persisted")[0]
+        cleaned = _strip_volatile_run_event_fields(persisted)
+        # message_id is an int from the DB; assert the shape, not the value.
+        self.assertEqual(set(cleaned.keys()), {"type", "message_id"})
+        self.assertEqual(cleaned["type"], "message_persisted")
+        self.assertIsInstance(cleaned["message_id"], int)
+
+    async def test_run_done_completed_shape(self) -> None:
+        self.set_llm_stream([["hello"]])
+        events = await self.drain()
+        done = _events_of_type(events, "run_done")[0]
+        self.assertEqual(
+            _strip_volatile_run_event_fields(done),
+            {"type": "run_done", "final_status": "completed"},
+        )
+
+    async def test_run_failed_shape_on_llm_exception(self) -> None:
+        async def boom(*_a, **_kw):
+            raise RuntimeError("boom: model exploded")
+            # unreachable but keeps this a valid async generator if not raised
+            yield ""  # pragma: no cover
+
+        self.runtime.llm.stream_response = boom
+
+        events = await self.drain()
+        failed = _events_of_type(events, "run_failed")
+        self.assertEqual(len(failed), 1)
+        cleaned = _strip_volatile_run_event_fields(failed[0])
+        # Required + expected-optional fields; error_code is from the enum.
+        self.assertEqual(cleaned["type"], "run_failed")
+        self.assertEqual(cleaned["error_code"], "UNKNOWN")
+        self.assertIsInstance(cleaned["error_message"], str)
+        self.assertTrue(cleaned["error_message"])
+        # retryable is set; fallback_content carries the full failure text.
+        self.assertIn("retryable", cleaned)
+        self.assertIn("fallback_content", cleaned)
+
+    async def test_v1_event_order_is_stable(self) -> None:
+        """The v1 boundary events must appear in this exact relative order:
+        run_started → ... → message_persisted → run_done."""
+        self.set_llm_stream([["hello"]])
+        events = await self.drain()
+
+        positions = {
+            t: next((i for i, e in enumerate(events) if e.get("type") == t), -1)
+            for t in ("run_started", "message_persisted", "run_done")
+        }
+        self.assertGreater(positions["run_started"], -1)
+        self.assertGreater(positions["message_persisted"], positions["run_started"])
+        self.assertGreater(positions["run_done"], positions["message_persisted"])
+        # And legacy ``done`` is still emitted before ``run_done``.
+        legacy_done = next((i for i, e in enumerate(events) if e.get("type") == "done"), -1)
+        self.assertGreater(legacy_done, -1)
+        self.assertLess(legacy_done, positions["run_done"])
+
+
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()

--- a/web/src/pages/projects/ProjectChatMessageBubble.tsx
+++ b/web/src/pages/projects/ProjectChatMessageBubble.tsx
@@ -28,8 +28,11 @@ import { api } from "../../api/client";
 import { getProjectChatCopy } from "./projectChatCopy";
 import { MarkdownDiffViewer } from "./MarkdownDiffViewer";
 import { ProjectChatArtifactCard } from "./ProjectChatArtifactCard";
+import { ProjectChatPptPathBadge } from "./ProjectChatPptPathBadge";
+import { ProjectChatRememberPreferenceModal } from "./ProjectChatRememberPreferenceModal";
 import { ProjectChatTracePanel } from "./ProjectChatTracePanel";
 import { ProjectChatToolCallCard } from "./ProjectChatToolCallCard";
+import { detectPreferenceSuggestion } from "../../utils/preferenceHints";
 import { useAppTimeZone } from "../../hooks/useAppTimeZone";
 import { formatTimeOnly } from "../../utils/timezone";
 import {
@@ -215,13 +218,22 @@ export const ProjectChatMessageBubble = memo<ProjectChatMessageBubbleProps>(
             }`}
           >
             {isUser ? (
-              <p className="whitespace-pre-wrap">{msg.content}</p>
+              <>
+                <p className="whitespace-pre-wrap">{msg.content}</p>
+                <UserMessagePreferenceHint content={msg.content} />
+              </>
             ) : (
               <div className="md-root project-chat-answer w-full">
                 <MarkdownRenderer content={msg.content} />
               </div>
             )}
           </div>
+
+          {!isUser && artifacts.length > 0 && (
+            <div className="mt-1.5">
+              <ProjectChatPptPathBadge metadata={metadata} artifacts={artifacts} />
+            </div>
+          )}
 
           {!isUser &&
             (references.length > 0 ||
@@ -429,3 +441,39 @@ export const ProjectChatMessageBubble = memo<ProjectChatMessageBubbleProps>(
     prev.onSaveToNotes === next.onSaveToNotes &&
     prev.onContinue === next.onContinue,
 );
+
+/**
+ * "💡 记住为偏好" affordance shown under a user message that looks like a
+ * lasting preference (see ``utils/preferenceHints``). Click → opens a small
+ * modal that writes the suggestion to /user-memory. Renders nothing when no
+ * preference phrase is detected — keeps the chat quiet on normal turns.
+ */
+function UserMessagePreferenceHint({ content }: { content: string }) {
+  const [savedKey, setSavedKey] = useState<string | null>(null);
+  const [modalOpen, setModalOpen] = useState(false);
+  const suggestion = detectPreferenceSuggestion(content);
+  if (!suggestion) return null;
+  if (savedKey === suggestion.key) {
+    return (
+      <p className="mt-1 text-[11px] text-on-surface-muted">已记住为偏好 ✓</p>
+    );
+  }
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setModalOpen(true)}
+        className="mt-1 inline-flex items-center gap-1 text-[11px] text-on-surface-muted hover:text-primary"
+      >
+        💡 记住为偏好：{suggestion.label}
+      </button>
+      {modalOpen && (
+        <ProjectChatRememberPreferenceModal
+          suggestion={suggestion}
+          onClose={() => setModalOpen(false)}
+          onSaved={() => setSavedKey(suggestion.key)}
+        />
+      )}
+    </>
+  );
+}

--- a/web/src/pages/projects/ProjectChatPptPathBadge.tsx
+++ b/web/src/pages/projects/ProjectChatPptPathBadge.tsx
@@ -1,0 +1,59 @@
+/**
+ * Small badge that surfaces *how* a PPT was generated this turn (V0.0.4 A4).
+ *
+ * Reads ``metadata.route_decision`` + ``metadata.task_run`` and renders a
+ * one-line chip beside the assistant reply. Stays silent when no PPT was
+ * generated, so it never clutters normal text turns.
+ */
+import { FileText, ListTree, Workflow } from "lucide-react";
+import type { GeneratedArtifact, MessageMetadata } from "../../types/api";
+
+interface Props {
+  metadata: MessageMetadata;
+  artifacts: GeneratedArtifact[];
+}
+
+function isPptArtifact(a: GeneratedArtifact): boolean {
+  const t = (a.file_type || "").toLowerCase().replace(/^\./, "");
+  if (t === "pptx" || t === "ppt") return true;
+  return (a.name || "").toLowerCase().endsWith(".pptx");
+}
+
+export function ProjectChatPptPathBadge({ metadata, artifacts }: Props) {
+  const hasPpt = artifacts.some(isPptArtifact);
+  if (!hasPpt) return null;
+
+  const reason = metadata.route_decision?.reason || "";
+  const taskType = metadata.task_run?.task_type || "";
+
+  // (1) Conversational PPT path (the rule:pptx_from_prior_outline I added
+  //     earlier in V0.0.4) — the model built slides from the conversation.
+  if (reason === "rule:pptx_from_prior_outline") {
+    return (
+      <div className="inline-flex items-center gap-1.5 rounded-full border border-primary/20 bg-primary/5 px-2 py-0.5 text-[11px] text-primary">
+        <ListTree className="h-3 w-3" />
+        PPT 按本次对话的大纲生成
+      </div>
+    );
+  }
+
+  // (2) Deterministic durable-task pipeline (generate_client_ppt) — the
+  //     pipeline built its own outline from project memory.
+  if (taskType === "generate_client_ppt") {
+    return (
+      <div className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[11px] text-slate-600">
+        <Workflow className="h-3 w-3" />
+        PPT 自动从项目记忆生成
+      </div>
+    );
+  }
+
+  // (3) Fallback: a PPT exists but we can't tell the path with confidence —
+  //     still show a neutral chip so the user sees it was deliberate.
+  return (
+    <div className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[11px] text-slate-600">
+      <FileText className="h-3 w-3" />
+      已生成 PPT
+    </div>
+  );
+}

--- a/web/src/pages/projects/ProjectChatRememberPreferenceModal.tsx
+++ b/web/src/pages/projects/ProjectChatRememberPreferenceModal.tsx
@@ -1,0 +1,100 @@
+/**
+ * "记住为偏好" mini-modal — saves the suggested preference into UserMemory.
+ *
+ * Triggered from ``ProjectChatMessageBubble`` when ``detectPreferenceSuggestion``
+ * matches the user's message. Reads the current preferences, merges the
+ * suggested key/value, and writes them back via the existing /user-memory API.
+ */
+import { useState } from "react";
+import { Brain, Check, Loader2, X } from "lucide-react";
+
+import { api } from "../../api/client";
+import {
+  applyPreferenceSuggestion,
+  type PreferenceSuggestion,
+} from "../../utils/preferenceHints";
+
+interface Props {
+  suggestion: PreferenceSuggestion;
+  onClose: () => void;
+  onSaved?: () => void;
+}
+
+export function ProjectChatRememberPreferenceModal({ suggestion, onClose, onSaved }: Props) {
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const current = await api
+        .get<{ preferences: Record<string, unknown> }>("/user-memory")
+        .catch(() => ({ preferences: {} }));
+      const merged = applyPreferenceSuggestion(current.preferences || {}, suggestion);
+      await api.put("/user-memory", { preferences: merged });
+      onSaved?.();
+      onClose();
+    } catch (err: any) {
+      setError(err.response?.data?.detail || "保存失败,请稍后再试");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+      <div className="w-full max-w-md overflow-hidden rounded-2xl border border-outline/10 bg-surface-container-lowest shadow-2xl">
+        <div className="flex items-start justify-between gap-3 border-b border-outline/10 px-5 py-3.5">
+          <div className="flex items-start gap-3">
+            <div className="mt-0.5 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-xl bg-primary/10">
+              <Brain className="h-4 w-4 text-primary" />
+            </div>
+            <div>
+              <h3 className="text-sm font-semibold text-on-surface">记住为我的 AI 偏好</h3>
+              <p className="mt-0.5 text-xs text-on-surface-muted">
+                跨项目生效,可随时在「设置 → 个人信息 → AI 个人偏好」修改。
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            disabled={saving}
+            aria-label="关闭"
+            className="rounded-lg p-1.5 text-on-surface-muted hover:bg-surface-container-low disabled:opacity-50"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="space-y-2 px-5 py-4 text-sm">
+          <p className="text-on-surface font-medium">{suggestion.label}</p>
+          <p className="text-xs text-on-surface-muted">{suggestion.hint}</p>
+          {error && (
+            <p className="rounded-lg border border-error/30 bg-error/10 px-3 py-2 text-xs text-error">
+              {error}
+            </p>
+          )}
+        </div>
+
+        <div className="flex items-center justify-end gap-2 border-t border-outline/10 bg-surface-container-low/50 px-5 py-3">
+          <button
+            onClick={onClose}
+            disabled={saving}
+            className="rounded-lg px-3 py-1.5 text-sm text-on-surface-muted hover:bg-surface-container-low disabled:opacity-50"
+          >
+            不用
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            className="btn-primary flex items-center gap-1.5 px-3 py-1.5 text-sm disabled:opacity-50"
+          >
+            {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Check className="h-3.5 w-3.5" />}
+            记住
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -916,6 +916,12 @@ export interface MessageMetadata {
   }>
   project_id?: number
   truncated?: boolean
+  /** V0.0.4 A4: routing decision snapshot (intent_method / intent_reason / chat_mode). */
+  route_decision?: {
+    method?: string
+    reason?: string
+    chat_mode?: string
+  }
 }
 
 export interface MentionContext {

--- a/web/src/utils/preferenceHints.test.ts
+++ b/web/src/utils/preferenceHints.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyPreferenceSuggestion,
+  detectPreferenceSuggestion,
+} from "./preferenceHints";
+
+describe("detectPreferenceSuggestion", () => {
+  it("returns null for unrelated content", () => {
+    expect(detectPreferenceSuggestion("帮我看一下这份合同")).toBeNull();
+    expect(detectPreferenceSuggestion("")).toBeNull();
+    expect(detectPreferenceSuggestion("hi")).toBeNull();
+  });
+
+  it("picks up '以后用中文回复' as a Chinese-language preference", () => {
+    const out = detectPreferenceSuggestion("以后请你都用中文回复我");
+    expect(out).not.toBeNull();
+    expect(out?.key).toBe("response_preferences.language");
+    expect(out?.value).toBe("zh");
+  });
+
+  it("picks up '以后用 English' as an English-language preference", () => {
+    const out = detectPreferenceSuggestion("从现在开始, please reply in English");
+    expect(out).not.toBeNull();
+    expect(out?.key).toBe("response_preferences.language");
+    expect(out?.value).toBe("en");
+  });
+
+  it("picks up '先给结论' as a conclusion-first format preference", () => {
+    const out = detectPreferenceSuggestion("先给结论再展开论证");
+    expect(out?.key).toBe("response_preferences.format");
+    expect(out?.value).toBe("conclusion_first");
+  });
+
+  it("picks up direct-tone phrasing", () => {
+    const out = detectPreferenceSuggestion("以后直接说重点就行");
+    expect(out?.key).toBe("response_preferences.tone");
+    expect(out?.value).toBe("direct");
+  });
+
+  it("picks up '写入前再确认我一下'", () => {
+    const out = detectPreferenceSuggestion("以后写入项目空间前请先确认我一下");
+    expect(out?.key).toBe("work_style.ask_before_destructive");
+    expect(out?.value).toBe(true);
+  });
+});
+
+describe("applyPreferenceSuggestion", () => {
+  it("merges a dotted-key suggestion into the existing preferences", () => {
+    const start: Record<string, unknown> = {
+      response_preferences: { tone: "direct" },
+    };
+    const out = applyPreferenceSuggestion(start, {
+      key: "response_preferences.language",
+      value: "zh",
+      label: "x",
+      hint: "y",
+    });
+    expect(out).toEqual({
+      response_preferences: { tone: "direct", language: "zh" },
+    });
+    // Original object must not be mutated.
+    expect(start).toEqual({ response_preferences: { tone: "direct" } });
+  });
+
+  it("creates the top-level block when missing", () => {
+    const out = applyPreferenceSuggestion(
+      {},
+      { key: "work_style.ask_before_destructive", value: true, label: "x", hint: "y" },
+    );
+    expect(out).toEqual({ work_style: { ask_before_destructive: true } });
+  });
+});

--- a/web/src/utils/preferenceHints.ts
+++ b/web/src/utils/preferenceHints.ts
@@ -1,0 +1,103 @@
+/**
+ * Lightweight detector that suggests when a user's chat message looks like a
+ * lasting preference worth saving into UserMemory (V0.0.4 track B).
+ *
+ * Used by ``ProjectChatMessageBubble`` to surface a small "💡 记住为偏好"
+ * affordance under the user's own message — clicking it opens a focused modal
+ * pre-filled with the suggested key/value. The detector is intentionally
+ * conservative so it does not pop up on every message.
+ */
+
+export type PreferenceKey =
+  | "response_preferences.language"
+  | "response_preferences.tone"
+  | "response_preferences.format"
+  | "work_style.ask_before_destructive";
+
+export interface PreferenceSuggestion {
+  key: PreferenceKey;
+  value: string | boolean;
+  label: string;
+  hint: string;
+}
+
+const PHRASES: Array<{
+  pattern: RegExp;
+  build: (match: RegExpMatchArray) => PreferenceSuggestion;
+}> = [
+  // 语言偏好
+  {
+    pattern: /(以后|从现在开始|默认)[^。\n]{0,12}(中文|用中文|讲中文|回中文)/i,
+    build: () => ({
+      key: "response_preferences.language",
+      value: "zh",
+      label: "回复语言：中文优先",
+      hint: "AI 在所有项目里默认用中文回复。",
+    }),
+  },
+  {
+    pattern: /(以后|从现在开始|默认|reply in english)[^。\n]{0,30}(english|英文|用英文|讲英文|回英文)/i,
+    build: () => ({
+      key: "response_preferences.language",
+      value: "en",
+      label: "回复语言：English first",
+      hint: "AI 在所有项目里默认用英文回复。",
+    }),
+  },
+  // 回复结构 — "先给结论 / 结论先行"
+  {
+    pattern: /(先(?:给|讲|说)?)?(结论|结论先行|结论优先|conclusion[\s-]?first)/i,
+    build: () => ({
+      key: "response_preferences.format",
+      value: "conclusion_first",
+      label: "回复结构：先给结论再展开",
+      hint: "AI 会先点结论再列依据,避免长铺垫。",
+    }),
+  },
+  // 语气
+  {
+    pattern: /(以后|从现在开始|默认)?[^。\n]{0,8}(直接(?:点)?|不要客气|别绕弯|直接说重点)/i,
+    build: () => ({
+      key: "response_preferences.tone",
+      value: "direct",
+      label: "回复语气：直接、协作",
+      hint: "AI 会更直接,省略铺垫和客套。",
+    }),
+  },
+  // 写入/删除确认
+  {
+    pattern: /(写入|改写|删除|覆盖)[^。\n]{0,12}(前|时|请|要|都)[^。\n]{0,10}(确认|问我|再(?:问|确认))/i,
+    build: () => ({
+      key: "work_style.ask_before_destructive",
+      value: true,
+      label: "写入/删除前再确认我一下",
+      hint: "AI 在执行不可逆动作前会先弹确认。",
+    }),
+  },
+];
+
+export function detectPreferenceSuggestion(text: string): PreferenceSuggestion | null {
+  if (!text || typeof text !== "string") return null;
+  const trimmed = text.trim();
+  if (trimmed.length < 4 || trimmed.length > 300) return null;
+  for (const { pattern, build } of PHRASES) {
+    const match = trimmed.match(pattern);
+    if (match) return build(match);
+  }
+  return null;
+}
+
+/**
+ * Merge a key/value pair onto the existing preferences object using the same
+ * dotted-key convention the backend formatter expects.
+ */
+export function applyPreferenceSuggestion(
+  current: Record<string, unknown>,
+  suggestion: PreferenceSuggestion,
+): Record<string, unknown> {
+  const [top, sub] = suggestion.key.split(".") as [string, string];
+  const next: Record<string, unknown> = { ...current };
+  const existingBlock = (next[top] && typeof next[top] === "object") ? (next[top] as Record<string, unknown>) : {};
+  next[top] = { ...existingBlock, [sub]: suggestion.value };
+  return next;
+}


### PR DESCRIPTION
## Summary
Closes the four remaining items on `docs/13` V0.0.4 plan in a single PR. All four are additive / forward-compatible and ship independently of the open A1/A2/A3 PRs (#8/#9/#10) and the user-memory injection PR (#11).

## D.3 — Run observability baseline
- `[run start]` structured log at every run open (run_id, conv, project, chat_mode, action_policy, skill, model).
- `[run done]` for both terminal paths (durable_task short-circuit + agent_loop happy path) carrying duration_ms / artifact count / tool-event count / step count.
- `[run failed]` log for every phase exception (durable_task / agent_loop / persist), tagged with run_id + exception class. Grep `run_id=run_…` correlates the whole pipeline.

## D.2 — Product Run Event v1 contract goldens
New `ProductRunEventV1ContractGoldens` class in `test_chat_end_to_end.py` pins the exact field shape of every v1 event the orchestrator emits today: `run_started` (no-skill + skill block), `message_persisted`, `run_done(completed)`, `run_failed` (LLM raises). Plus a `run_started → message_persisted → done(legacy) → run_done` ordering golden. Volatile fields (`run_id` / `timestamp`) are stripped before the equality check. **18 tests pass.** Wave 3-5 events from PR #8 will add their own goldens once that branch merges.

## A4 — PPT path visibility (backend + frontend)
- `persist.run_persist` now writes `metadata.route_decision` (`{method, reason, chat_mode}`) — surfaces the routing rule for the turn without a separate trace fetch.
- New `ProjectChatPptPathBadge` chip in `ProjectChatMessageBubble` shows beside every assistant message that produced a PPT:
  - "📊 PPT 按本次对话的大纲生成" when `reason === "rule:pptx_from_prior_outline"`
  - "🤖 PPT 自动从项目记忆生成" when `task_run.task_type === "generate_client_ppt"`
  - Neutral "已生成 PPT" otherwise.
  Stays silent on text-only / non-pptx turns.

## B — "记住这个偏好" mini-flow
- `utils/preferenceHints.ts` — conservative regex detector for preference-like user phrases (中文/English优先 / 先给结论 / 直接说重点 / 写入前先确认). Returns a `PreferenceSuggestion` with a stable dotted-key + value + UI label/hint. Plus a pure `applyPreferenceSuggestion` merger.
- `ProjectChatRememberPreferenceModal` — focused mini-modal: reads current `/user-memory`, merges the suggestion, PUT-writes the result. Errors surface inline.
- `ProjectChatMessageBubble` shows a small "💡 记住为偏好：…" affordance under any user message the detector matches. Once accepted it collapses to "已记住为偏好 ✓" for the session. Nothing renders on normal turns.
- 8 detector unit tests (`utils/preferenceHints.test.ts`) cover null on unrelated content, language phrases (中/英), conclusion-first, direct tone, the destructive-confirmation phrase, plus the pure merger.

## Test plan
- [x] tsc clean; vite build ok.
- [x] Frontend vitest: 63 files / 409 tests pass (+8 detector tests).
- [x] Backend chat regression: 329 tests pass (test_chat_end_to_end + chat_streaming + sse_events + chat_multiturn_golden + chat_flow).
- [ ] After all V0.0.4 PRs land: set `localStorage['aria.run_harness_v1']='true'`, send a PPT request based on a conversation outline, verify the "📊 按本次对话的大纲生成" badge shows up. Send "以后请用中文回复" → click "💡 记住为偏好" → confirm → verify the preference appears in `/settings/profile`.

## What this closes
| docs/13 item | branch | status |
|---|---|---|
| A1 inside-event wiring | #8 | open |
| A2 timeline UI consumer | #9 | open |
| A3 persist timeline snapshot | #10 | open |
| A4 PPT path visibility | this PR | ✅ |
| B user-memory injection + UI | #11 | open |
| B "记住偏好" flow | this PR | ✅ |
| D.2 event protocol goldens | this PR | ✅ |
| D.3 run observability | this PR | ✅ |

Once #8, #9, #10, #11 and this PR are merged, the V0.0.4 docs/13 acceptance checklist clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)