### PR TITLE
First-run 称呼 onboarding + preferred-name promotion in prompt

### DIFF
--- a/backend/app/services/chat/user_memory_prompt.py
+++ b/backend/app/services/chat/user_memory_prompt.py
@@ -71,8 +71,28 @@ def _format_value(value: Any) -> str:
     return str(value).strip()
 
 
+def _extract_preferred_name(preferences: dict[str, Any]) -> str:
+    """Return the user's preferred form of address (称呼) or empty string.
+
+    Pulled out of the generic bullet flow so it can be promoted to a dedicated
+    lead line — "address the user as X" is a different kind of signal from
+    "user prefers conclusion-first replies" and deserves emphasis.
+    """
+    info = preferences.get("personal_info")
+    if not isinstance(info, dict):
+        return ""
+    name = info.get("preferred_name")
+    if not isinstance(name, str):
+        return ""
+    return name.strip()[: _MAX_BULLET_CHARS]
+
+
 def _flatten_bullets(preferences: dict[str, Any]) -> list[str]:
-    """Walk one level of nesting and produce ``key: value`` bullets."""
+    """Walk one level of nesting and produce ``key: value`` bullets.
+
+    ``personal_info.preferred_name`` is intentionally excluded — it's rendered
+    separately as a lead line in :func:`format_user_memory_for_prompt`.
+    """
     bullets: list[str] = []
     for top_key, top_val in preferences.items():
         if not _is_meaningful(top_val):
@@ -81,6 +101,8 @@ def _flatten_bullets(preferences: dict[str, Any]) -> list[str]:
             for sub_key, sub_val in top_val.items():
                 if not _is_meaningful(sub_val):
                     continue
+                if top_key == "personal_info" and sub_key == "preferred_name":
+                    continue  # promoted to lead line
                 line = f"{top_key}.{sub_key}: {_format_value(sub_val)}"
                 if len(line) > _MAX_BULLET_CHARS:
                     line = line[: _MAX_BULLET_CHARS - 1] + "…"
@@ -101,16 +123,20 @@ def format_user_memory_for_prompt(preferences: dict[str, Any] | None) -> str:
     """Render a compact prompt section from a preferences dict, or empty string."""
     if not isinstance(preferences, dict) or not preferences:
         return ""
+    preferred_name = _extract_preferred_name(preferences)
     bullets = _flatten_bullets(preferences)
-    if not bullets:
+    if not preferred_name and not bullets:
         return ""
-    body = "\n".join(f"- {b}" for b in bullets)
-    section = (
-        "## 当前用户偏好（User Memory）\n"
+    parts: list[str] = [
+        "## 当前用户偏好（User Memory）",
         "用户已显式声明的工作方式与回复偏好。除非用户在本轮明确说明相反，"
-        "请在不影响项目事实与客户事实的前提下尽量遵循。\n"
-        f"{body}"
-    )
+        "请在不影响项目事实与客户事实的前提下尽量遵循。",
+    ]
+    if preferred_name:
+        parts.append(f"用户希望被称呼为：{preferred_name}。请在回复中自然使用这一称呼。")
+    if bullets:
+        parts.append("\n".join(f"- {b}" for b in bullets))
+    section = "\n".join(parts)
     if len(section) > _MAX_PROMPT_CHARS:
         section = section[: _MAX_PROMPT_CHARS - 1] + "…"
     return section

--- a/backend/tests/test_user_memory_prompt.py
+++ b/backend/tests/test_user_memory_prompt.py
@@ -65,6 +65,50 @@ class FormatUserMemoryTest(unittest.TestCase):
         # _MAX_PROMPT_CHARS is 1200; allow a tiny tail for the ellipsis.
         self.assertLessEqual(len(out), 1201)
 
+    def test_preferred_name_is_promoted_to_lead_line_not_bullet(self):
+        """``personal_info.preferred_name`` must render as a dedicated lead line
+        ("用户希望被称呼为：X") so the model treats it as a profile fact, not a
+        generic preference toggle. It must NOT also appear as a bullet."""
+        out = format_user_memory_for_prompt(
+            {
+                "personal_info": {"preferred_name": "李总"},
+                "response_preferences": {"tone": "direct"},
+            }
+        )
+        self.assertIn("用户希望被称呼为：李总", out)
+        self.assertIn("- response_preferences.tone: direct", out)
+        # Promoted, not duplicated as a bullet.
+        self.assertNotIn("- personal_info.preferred_name:", out)
+        self.assertNotIn("personal_info.preferred_name: 李总", out)
+
+    def test_preferred_name_alone_still_renders_section(self):
+        """A user who only set 称呼 (no other preferences) should still get the
+        section emitted so the model knows how to address them."""
+        out = format_user_memory_for_prompt({"personal_info": {"preferred_name": "小高"}})
+        self.assertIn("User Memory", out)
+        self.assertIn("用户希望被称呼为：小高", out)
+
+    def test_empty_preferred_name_does_not_emit_lead_line(self):
+        """Whitespace/empty values must not produce a dangling
+        "用户希望被称呼为：" with nothing after it."""
+        out = format_user_memory_for_prompt(
+            {
+                "personal_info": {"preferred_name": "   "},
+                "response_preferences": {"tone": "direct"},
+            }
+        )
+        self.assertNotIn("用户希望被称呼为", out)
+        self.assertIn("- response_preferences.tone: direct", out)
+
+    def test_other_personal_info_keys_still_become_bullets(self):
+        """Only ``preferred_name`` is promoted — sibling personal_info keys keep
+        the bullet path so we don't accidentally hide them."""
+        out = format_user_memory_for_prompt(
+            {"personal_info": {"preferred_name": "李总", "title": "CEO"}}
+        )
+        self.assertIn("用户希望被称呼为：李总", out)
+        self.assertIn("- personal_info.title: CEO", out)
+
 
 class LoadUserMemoryFromDbTest(unittest.TestCase):
     def setUp(self):

--- a/web/src/components/FirstRunPreferredNameModal.test.tsx
+++ b/web/src/components/FirstRunPreferredNameModal.test.tsx
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import { FirstRunPreferredNameModal, __test__ } from "./FirstRunPreferredNameModal";
+
+const putMock = vi.fn();
+vi.mock("../api/client", () => ({
+  api: {
+    put: (...args: unknown[]) => putMock(...args),
+  },
+}));
+
+beforeEach(() => {
+  putMock.mockReset();
+  putMock.mockResolvedValue({
+    preferences: { personal_info: { preferred_name: "李总" } },
+    version: 1,
+    updated_at: "",
+  });
+});
+
+describe("mergePreferredName", () => {
+  it("preserves existing non-conflicting preferences", () => {
+    const result = __test__.mergePreferredName(
+      { response_preferences: { tone: "direct" } },
+      "李总",
+    );
+    expect(result).toEqual({
+      response_preferences: { tone: "direct" },
+      personal_info: { preferred_name: "李总" },
+    });
+  });
+
+  it("preserves sibling personal_info fields (e.g. title)", () => {
+    const result = __test__.mergePreferredName(
+      { personal_info: { title: "CEO" } },
+      "李总",
+    );
+    expect(result).toEqual({
+      personal_info: { title: "CEO", preferred_name: "李总" },
+    });
+  });
+
+  it("overwrites a prior preferred_name", () => {
+    const result = __test__.mergePreferredName(
+      { personal_info: { preferred_name: "旧称呼" } },
+      "新称呼",
+    );
+    expect(result.personal_info).toEqual({ preferred_name: "新称呼" });
+  });
+});
+
+describe("FirstRunPreferredNameModal", () => {
+  it("renders the dialog with input focused", () => {
+    render(<FirstRunPreferredNameModal existingPreferences={{}} onSaved={() => {}} />);
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(screen.getByTestId("preferred-name-input")).toHaveFocus();
+  });
+
+  it("disables the save button until a non-empty name is typed", () => {
+    render(<FirstRunPreferredNameModal existingPreferences={{}} onSaved={() => {}} />);
+
+    const save = screen.getByTestId("preferred-name-save") as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
+
+    const input = screen.getByTestId("preferred-name-input");
+    fireEvent.change(input, { target: { value: "   " } });
+    expect(save.disabled).toBe(true);
+
+    fireEvent.change(input, { target: { value: "李总" } });
+    expect(save.disabled).toBe(false);
+  });
+
+  it("PUTs the merged preferences and calls onSaved with the server response", async () => {
+    const onSaved = vi.fn();
+    render(
+      <FirstRunPreferredNameModal
+        existingPreferences={{ response_preferences: { tone: "direct" } }}
+        onSaved={onSaved}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId("preferred-name-input"), {
+      target: { value: "李总" },
+    });
+    fireEvent.click(screen.getByTestId("preferred-name-save"));
+
+    await waitFor(() => {
+      expect(putMock).toHaveBeenCalledWith("/user-memory", {
+        preferences: {
+          response_preferences: { tone: "direct" },
+          personal_info: { preferred_name: "李总" },
+        },
+      });
+    });
+    await waitFor(() => {
+      expect(onSaved).toHaveBeenCalledWith({
+        personal_info: { preferred_name: "李总" },
+      });
+    });
+  });
+
+  it("Enter key triggers save just like the button", async () => {
+    const onSaved = vi.fn();
+    render(<FirstRunPreferredNameModal existingPreferences={{}} onSaved={onSaved} />);
+
+    const input = screen.getByTestId("preferred-name-input");
+    fireEvent.change(input, { target: { value: "小高" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => expect(putMock).toHaveBeenCalled());
+    await waitFor(() => expect(onSaved).toHaveBeenCalled());
+  });
+
+  it("surfaces a server error and keeps the modal open", async () => {
+    putMock.mockRejectedValueOnce(new Error("boom"));
+    const onSaved = vi.fn();
+    render(<FirstRunPreferredNameModal existingPreferences={{}} onSaved={onSaved} />);
+
+    fireEvent.change(screen.getByTestId("preferred-name-input"), {
+      target: { value: "李总" },
+    });
+    fireEvent.click(screen.getByTestId("preferred-name-save"));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("boom");
+    expect(onSaved).not.toHaveBeenCalled();
+    // Modal still present so the user can retry.
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("trims whitespace before saving", async () => {
+    render(<FirstRunPreferredNameModal existingPreferences={{}} onSaved={() => {}} />);
+    fireEvent.change(screen.getByTestId("preferred-name-input"), {
+      target: { value: "  小李  " },
+    });
+    fireEvent.click(screen.getByTestId("preferred-name-save"));
+
+    await waitFor(() =>
+      expect(putMock).toHaveBeenCalledWith("/user-memory", {
+        preferences: { personal_info: { preferred_name: "小李" } },
+      }),
+    );
+  });
+});

--- a/web/src/components/FirstRunPreferredNameModal.tsx
+++ b/web/src/components/FirstRunPreferredNameModal.tsx
@@ -1,0 +1,150 @@
+/**
+ * First-run onboarding modal — capture the user's preferred form of address (称呼).
+ *
+ * Non-dismissible: no backdrop click, no Escape close, no skip button. The user
+ * must save a non-empty 称呼 before the rest of the app becomes interactive.
+ * The decision behind this is in the V0.0.4 user-memory work: the first thing
+ * a new user does on entry is tell us how to address them, so every subsequent
+ * chat reply can use the name naturally.
+ *
+ * On save: PUT /user-memory with the existing preferences merged + new
+ * ``personal_info.preferred_name``. The caller (Layout) decides when to mount
+ * this — typically after /auth/me and /user-memory both load and we see no
+ * preferred_name yet.
+ */
+import { useEffect, useRef, useState } from "react";
+import { Loader2, UserRound } from "lucide-react";
+
+import { api } from "../api/client";
+
+interface UserMemoryResponse {
+  preferences: Record<string, unknown>;
+  version: number;
+  updated_at: string;
+}
+
+interface Props {
+  existingPreferences: Record<string, unknown>;
+  onSaved: (next: Record<string, unknown>) => void;
+}
+
+function mergePreferredName(
+  existing: Record<string, unknown>,
+  name: string,
+): Record<string, unknown> {
+  const next: Record<string, unknown> = { ...existing };
+  const personalRaw = next.personal_info;
+  const personal: Record<string, unknown> =
+    personalRaw && typeof personalRaw === "object"
+      ? { ...(personalRaw as Record<string, unknown>) }
+      : {};
+  personal.preferred_name = name;
+  next.personal_info = personal;
+  return next;
+}
+
+export function FirstRunPreferredNameModal({ existingPreferences, onSaved }: Props) {
+  const [name, setName] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const trimmed = name.trim();
+  const canSave = trimmed.length > 0 && trimmed.length <= 40 && !saving;
+
+  const handleSave = async () => {
+    if (!canSave) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const merged = mergePreferredName(existingPreferences, trimmed);
+      const response = await api.put<UserMemoryResponse>("/user-memory", {
+        preferences: merged,
+      });
+      onSaved(response.preferences ?? merged);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "保存失败，请重试");
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="first-run-preferred-name-title"
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      data-testid="first-run-preferred-name-modal"
+    >
+      <div className="mx-4 w-full max-w-md rounded-2xl border border-outline/10 bg-surface-container-lowest p-6 shadow-2xl">
+        <div className="mb-3 flex items-center gap-3">
+          <span className="flex h-10 w-10 items-center justify-center rounded-full bg-gradient-primary text-white">
+            <UserRound className="h-5 w-5" aria-hidden="true" />
+          </span>
+          <div>
+            <h2
+              id="first-run-preferred-name-title"
+              className="text-lg font-semibold text-on-surface"
+            >
+              请告诉 Aria 怎么称呼你
+            </h2>
+            <p className="text-xs text-on-surface-muted">
+              这是开始使用前的第一步，之后每一轮回复都会用到。
+            </p>
+          </div>
+        </div>
+
+        <label className="mt-4 block text-sm font-medium text-on-surface" htmlFor="preferred-name-input">
+          你希望 Aria 怎么称呼你？
+        </label>
+        <input
+          id="preferred-name-input"
+          ref={inputRef}
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              void handleSave();
+            }
+          }}
+          placeholder="例如：李总、小李、Liang"
+          maxLength={40}
+          disabled={saving}
+          className="mt-2 w-full rounded-lg border border-outline/20 bg-surface-container px-3 py-2 text-sm text-on-surface outline-none focus:border-primary focus:ring-2 focus:ring-primary/20 disabled:opacity-60"
+          autoComplete="off"
+          data-testid="preferred-name-input"
+        />
+        <p className="mt-1.5 text-[11px] text-on-surface-muted">
+          最长 40 个字。之后可以在「设置 → AI 个人偏好」中随时修改。
+        </p>
+
+        {error ? (
+          <p className="mt-3 rounded-md bg-error/10 px-3 py-2 text-xs text-error" role="alert">
+            {error}
+          </p>
+        ) : null}
+
+        <div className="mt-5 flex justify-end">
+          <button
+            type="button"
+            onClick={() => void handleSave()}
+            disabled={!canSave}
+            className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-on-primary transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+            data-testid="preferred-name-save"
+          >
+            {saving ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : null}
+            {saving ? "保存中…" : "保存并开始"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const __test__ = { mergePreferredName };

--- a/web/src/components/Layout.test.tsx
+++ b/web/src/components/Layout.test.tsx
@@ -13,8 +13,17 @@ vi.mock('../api/client', () => ({
       if (url === '/auth/me') return Promise.resolve({ display_name: 'John Doe', email: 'john@example.com' })
       if (url === '/settings/') return Promise.resolve({ timezone: 'UTC' })
       if (url === '/messages/unread-count') return Promise.resolve({ unread_count: 7 })
+      if (url === '/user-memory')
+        // Default: name already set → the first-run modal stays closed and
+        // existing tests below don't have to know about it.
+        return Promise.resolve({
+          preferences: { personal_info: { preferred_name: '李总' } },
+          version: 1,
+          updated_at: '',
+        })
       return Promise.resolve({})
     }),
+    put: vi.fn(() => Promise.resolve({ preferences: {}, version: 1, updated_at: '' })),
     post: vi.fn(() => Promise.resolve({})),
   },
 }))
@@ -101,6 +110,37 @@ describe('Layout', () => {
     renderLayout()
     await waitFor(() => {
       expect(screen.getByText('7')).toBeInTheDocument()
+    })
+  })
+
+  it('does not show the first-run modal when a preferred name is already set', async () => {
+    renderLayout()
+    // Modal must not appear after the (mocked) /user-memory resolves with a name.
+    await waitFor(() => {
+      expect(screen.getByText('Aria AI')).toBeInTheDocument()
+    })
+    expect(screen.queryByTestId('first-run-preferred-name-modal')).not.toBeInTheDocument()
+  })
+
+  it('shows the first-run modal when /user-memory has no preferred_name', async () => {
+    // Override the default mock for this one test: empty preferences.
+    const { api } = await import('../api/client')
+    const getMock = api.get as unknown as ReturnType<typeof vi.fn>
+    getMock.mockImplementationOnce(async (url: string) => {
+      // /auth/me fires first
+      return { display_name: 'John Doe', email: 'john@example.com' }
+    })
+    getMock.mockImplementationOnce(async () => ({ timezone: 'UTC' }))
+    getMock.mockImplementationOnce(async () => ({
+      preferences: {},
+      version: 0,
+      updated_at: '',
+    }))
+    getMock.mockImplementationOnce(async () => ({ unread_count: 0 }))
+
+    renderLayout()
+    await waitFor(() => {
+      expect(screen.getByTestId('first-run-preferred-name-modal')).toBeInTheDocument()
     })
   })
 })

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -18,6 +18,26 @@ import { api } from '../api/client'
 import type { User } from '../types/api'
 import { primaryRouteLoaders, warmPrimaryRoutes } from '../routeLoaders'
 import { DEFAULT_APP_TIMEZONE, setAppTimeZone } from '../utils/timezone'
+import { FirstRunPreferredNameModal } from './FirstRunPreferredNameModal'
+
+interface UserMemoryFetchResponse {
+  preferences: Record<string, unknown>
+  version: number
+  updated_at: string
+}
+
+/**
+ * Returns the saved 称呼 from a user-memory preferences blob, or "" if missing
+ * / non-string / whitespace. Pulled out so the gating decision in Layout is a
+ * single expression rather than nested optional chains.
+ */
+function readPreferredName(preferences: Record<string, unknown> | null): string {
+  if (!preferences || typeof preferences !== 'object') return ''
+  const personal = (preferences as { personal_info?: unknown }).personal_info
+  if (!personal || typeof personal !== 'object') return ''
+  const name = (personal as { preferred_name?: unknown }).preferred_name
+  return typeof name === 'string' ? name.trim() : ''
+}
 
 function getStoredUser(): User | null {
   try {
@@ -62,6 +82,9 @@ export function Layout() {
   const [showUserMenu, setShowUserMenu] = useState(false)
   const [user, setUser] = useState<User | null>(() => getStoredUser())
   const [unreadCount, setUnreadCount] = useState(0)
+  // ``null`` = haven't checked yet (don't render gate). Once loaded we know
+  // whether the user has set 称呼 — if not, the modal blocks the UI.
+  const [userMemoryPrefs, setUserMemoryPrefs] = useState<Record<string, unknown> | null>(null)
   const isProjectDetailRoute = /^\/projects\/(?!new(?:\/|$))[^/]+/.test(location.pathname)
 
   const navItems = [
@@ -89,6 +112,20 @@ export function Layout() {
         setAppTimeZone(settings.timezone || DEFAULT_APP_TIMEZONE)
       })
       .catch(() => {})
+  }, [])
+
+  // First-run gate: fetch /user-memory once so we can decide whether to mount
+  // the 称呼 modal. On fetch failure we fail open (empty prefs) — locking the
+  // entire app out because of an API hiccup is worse than skipping onboarding.
+  useEffect(() => {
+    api
+      .get<UserMemoryFetchResponse>('/user-memory')
+      .then((response) => {
+        setUserMemoryPrefs(response.preferences || {})
+      })
+      .catch(() => {
+        setUserMemoryPrefs({})
+      })
   }, [])
 
   useEffect(() => {
@@ -128,6 +165,12 @@ export function Layout() {
 
   const initials = getUserInitials(user)
   const initialsScale = initials.length > 2 ? 0.85 : 1
+
+  // We've fetched user-memory AND the user hasn't set a preferred name yet →
+  // block the UI with the onboarding modal. ``null`` means still loading, so
+  // we don't flash the modal during the initial fetch.
+  const shouldShowFirstRunModal =
+    userMemoryPrefs !== null && readPreferredName(userMemoryPrefs) === ''
 
   return (
     <div className="flex h-full flex-col bg-surface">
@@ -276,6 +319,12 @@ export function Layout() {
       <main className="app-ui flex-1 overflow-auto">
         <Outlet />
       </main>
+      {shouldShowFirstRunModal && userMemoryPrefs ? (
+        <FirstRunPreferredNameModal
+          existingPreferences={userMemoryPrefs}
+          onSaved={(next) => setUserMemoryPrefs(next)}
+        />
+      ) : null}
     </div>
   )
 }

--- a/web/src/pages/settings/UserMemorySettingsCard.tsx
+++ b/web/src/pages/settings/UserMemorySettingsCard.tsx
@@ -29,6 +29,9 @@ interface UserMemoryResponse {
 }
 
 interface PreferencesShape {
+  personal_info?: {
+    preferred_name?: string;
+  };
   response_preferences?: {
     language?: Language;
     tone?: Tone;
@@ -61,6 +64,11 @@ const FORMAT_OPTIONS: { value: FormatShape; label: string }[] = [
 
 function compactPreferences(prefs: PreferencesShape): Record<string, unknown> {
   const compact: PreferencesShape = {};
+  const preferredName = prefs.personal_info?.preferred_name?.trim() ?? "";
+  if (preferredName) {
+    compact.personal_info = { preferred_name: preferredName };
+  }
+
   const rp = prefs.response_preferences ?? {};
   const rpOut: PreferencesShape["response_preferences"] = {};
   if (rp.language) rpOut.language = rp.language;
@@ -77,9 +85,15 @@ function compactPreferences(prefs: PreferencesShape): Record<string, unknown> {
 
 function readShape(raw: Record<string, unknown> | undefined): PreferencesShape {
   if (!raw || typeof raw !== "object") return {};
+  const pi = (raw as { personal_info?: unknown }).personal_info;
   const rp = (raw as { response_preferences?: unknown }).response_preferences;
   const ws = (raw as { work_style?: unknown }).work_style;
   const out: PreferencesShape = {};
+  if (pi && typeof pi === "object") {
+    const block = pi as Partial<Record<string, unknown>>;
+    const name = typeof block.preferred_name === "string" ? block.preferred_name : "";
+    if (name) out.personal_info = { preferred_name: name };
+  }
   if (rp && typeof rp === "object") {
     const block = rp as Partial<Record<string, unknown>>;
     out.response_preferences = {
@@ -198,6 +212,25 @@ export function UserMemorySettingsCard() {
       ) : (
         <>
           <div className="space-y-3">
+            <div className="space-y-1.5">
+              <label className="text-label-sm text-on-surface-muted">Aria 怎么称呼你</label>
+              <input
+                type="text"
+                value={prefs.personal_info?.preferred_name ?? ""}
+                onChange={(e) => {
+                  setPrefs((cur) => ({
+                    ...cur,
+                    personal_info: { preferred_name: e.target.value },
+                  }));
+                  setMsg(null);
+                }}
+                placeholder="例如：李总、小李、Liang"
+                maxLength={40}
+                className={selectCls + " w-full"}
+                autoComplete="off"
+              />
+            </div>
+
             <div className="space-y-1.5">
               <label className="text-label-sm text-on-surface-muted">回复语言</label>
               <select


### PR DESCRIPTION
## Summary
Every authenticated user lands on a **non-dismissible modal** that captures how Aria should address them (称呼). Until the name is saved into `UserMemory.personal_info.preferred_name`, the rest of the UI stays blocked behind the overlay. Once saved, the modal disappears and every subsequent chat reply naturally uses the name (promoted to a lead line in the system prompt, not a generic bullet).

## What changes

**Backend** — `user_memory_prompt.py`
- `personal_info.preferred_name` promoted from a generic bullet (`- personal_info.preferred_name: 李总`) to a dedicated lead line (`用户希望被称呼为：李总。请在回复中自然使用这一称呼。`). This is profile information, semantically distinct from preference toggles, so the model treats it as a fact rather than an ignorable knob.
- Whitespace/empty preferred_name does not emit a dangling lead line.
- Other `personal_info.*` keys (e.g. `title`) still render as bullets.

**Frontend**
- `FirstRunPreferredNameModal` — blocking modal, autofocus input, Enter to submit, 40-char cap, retry-on-error. Mounted by `Layout`.
- `Layout.tsx` — fetches `/user-memory` once on mount; if `personal_info.preferred_name` is empty, renders the modal. Fetch failure fails open (locking the app on an API hiccup is worse than skipping onboarding once).
- `UserMemorySettingsCard` — adds a 称呼 input at the top so users can edit/clear it later via Settings → AI 个人偏好.

## Decisions made

- **Non-dismissible modal** (no skip button): user explicitly requested "进门第一件事就是设置". The trade-off is that anyone who refuses to share a 称呼 is stuck, which is intentional friction.
- **Fail-open on /user-memory fetch error**: protects the app from being locked out by a transient backend issue. The probability of "/user-memory is down" is non-zero; "no user can do anything until it recovers" is unacceptable.
- **Promoted to lead line rather than bullet**: matches the semantic difference between a profile fact (who you are) and a preference (how you like replies shaped).

## Test plan
- [x] `pytest tests/test_user_memory_prompt.py` → 15/15 pass (incl. 4 new promotion cases)
- [x] `vitest run src/components/FirstRunPreferredNameModal.test.tsx` → 9/9 pass
- [x] `vitest run src/components/Layout.test.tsx` → 9/9 pass (incl. new gate positive/negative cases)
- [x] `tsc --noEmit` → clean
- [ ] Manual: login as a user with no preferred_name → modal appears, save → modal disappears, refresh → no modal
- [ ] Manual: chat with that user → reply uses the 称呼

🤖 Generated with [Claude Code](https://claude.com/claude-code)