### PR TITLE
Fix chat 8-hour offset + render briefing AI script as Markdown

### DIFF
--- a/web/src/pages/chat/Chat.tsx
+++ b/web/src/pages/chat/Chat.tsx
@@ -41,14 +41,18 @@ import { PageTitle } from '../../components/PageTitle'
 import { downloadArtifact } from '../projects/downloadArtifact'
 import type { Conversation, GeneratedArtifact, Message, Project, Skill } from '../../types/api'
 import { useAppTimeZone } from '../../hooks/useAppTimeZone'
-import { formatDateOnly, formatDatePartsKey, formatTimeOnly } from '../../utils/timezone'
+import { formatDateOnly, formatDatePartsKey, formatTimeOnly, parseAppDateTime } from '../../utils/timezone'
 
 const PAGE_SIZE = 20
 
 // ─── helpers ───────────────────────────────────────────────────────────────
 
 function formatTime(dateStr: string, timeZone?: string) {
-  const d = new Date(dateStr)
+  // Backend timestamps are tz-naive UTC ("2026-05-28T13:22:00", no Z); plain
+  // ``new Date(...)`` would treat them as browser-local and skew by the local
+  // offset. ``parseAppDateTime`` appends Z so the same string parses as UTC,
+  // which is what the timezone formatters below expect.
+  const d = parseAppDateTime(dateStr)
   const now = new Date()
   const todayKey = formatDatePartsKey(now, timeZone)
   const targetKey = formatDatePartsKey(d, timeZone)

--- a/web/src/pages/projects/ProjectBriefingTab.tsx
+++ b/web/src/pages/projects/ProjectBriefingTab.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { AlertTriangle, CalendarDays, CheckCircle2, Clock3, ExternalLink, FileText, Loader2, MessageSquare, RefreshCw, Sparkles, Users } from "lucide-react";
 import { api } from "../../api/client";
+import { MarkdownRenderer } from "../../components/MarkdownRenderer";
 import type { ProjectDetail, ProjectMeetingBriefing, ProjectMeetingBriefingRefineResponse } from "../../types/api";
 import { resolveProjectStage } from "../../types/enums";
 import { useAppTimeZone } from "../../hooks/useAppTimeZone";
@@ -330,7 +331,9 @@ export function ProjectBriefingTab({ projectDetail, projectId }: ProjectBriefing
                   {isZh ? "重新生成" : "Regenerate"}
                 </button>
               </div>
-              <div className="whitespace-pre-wrap text-sm leading-7 text-slate-800">{refinedBriefing.content}</div>
+              <div className="text-sm leading-7 text-slate-800">
+                <MarkdownRenderer content={refinedBriefing.content} />
+              </div>
             </section>
           ) : null}
 


### PR DESCRIPTION
## Summary
Two unrelated user-reported bugs in one targeted fix (both visible on the same screenshot).

**1. Chat timestamps off by 8 hours** ([Chat.tsx:51](web/src/pages/chat/Chat.tsx#L51))
- Sidebar: `01:22 PM`. Just-sent bubble: `09:22 PM`. Same conversation.
- Root cause: the local `formatTime` helper used `new Date(dateStr)`, which interprets the backend's tz-naive UTC strings (`"2026-05-28T13:22:00"`, no `Z`) as **browser-local**. The downstream `formatTimeOnly` then re-projected to `Asia/Shanghai`, skewing by the local offset.
- Fix: route through `parseAppDateTime` (already exported from `utils/timezone` for exactly this case).
- Why just-sent bubbles looked correct: they used `new Date().toISOString()` (Z-suffixed) — parsed correctly. The bug only surfaced for backend-loaded data (sidebar list + historical bubbles after refresh).

**2. "可直接使用的话术" rendered as raw Markdown** ([ProjectBriefingTab.tsx:333](web/src/pages/projects/ProjectBriefingTab.tsx#L333))
- The AI-refined briefing came back with `### 30 秒会议判断`, `**项目临近决策窗口**`, `- ...` — but the panel was a `whitespace-pre-wrap` plain text div, so users saw literal hash marks and asterisks.
- Fix: route content through the existing `MarkdownRenderer` (react-markdown + remark-gfm + the security sanitizers in `markdownSecurity`) — same renderer chat bubbles use.

## Follow-up flag (not in this PR)
The same `new Date(string)` pattern exists in `DailyBriefHero`, `Workspace`, `Welcome`, `Clients` relative-time calculations and `~6` other files. Real bugs but out-of-scope here — proposing a small dedicated audit + fix PR after this one lands.

## Test plan
- [x] `tsc --noEmit` → clean
- [x] `vitest run MarkdownRenderer Layout` → 28/28
- [ ] Manual: open /chat → sidebar time matches bubble time
- [ ] Manual: open /projects/:id/briefing → click 更新话术 → AI 话术 renders with proper H3 / bold / list

🤖 Generated with [Claude Code](https://claude.com/claude-code)