### PR TITLE
Apply parseAppDateTime across all backend-timestamp consumers

### DIFF
--- a/web/src/components/DailyBriefHero.tsx
+++ b/web/src/components/DailyBriefHero.tsx
@@ -2,7 +2,7 @@ import { useNavigate } from 'react-router-dom'
 import { ChevronDown, ListFilter, RefreshCw, Sparkles } from 'lucide-react'
 
 import type { MyProjectTodo } from '../types/api'
-import { formatDateOnly, getResolvedAppTimeZone } from '../utils/timezone'
+import { formatDateOnly, getResolvedAppTimeZone, parseAppDateTime } from '../utils/timezone'
 
 export type BriefTone = 'red' | 'amber' | 'green'
 
@@ -47,7 +47,7 @@ export interface BriefClientInput {
 const ONE_DAY = 24 * 60 * 60 * 1000
 
 function formatRelative(updatedAt: string, isZh: boolean): string {
-  const hoursAgo = Math.max(1, Math.floor((Date.now() - new Date(updatedAt).getTime()) / (60 * 60 * 1000)))
+  const hoursAgo = Math.max(1, Math.floor((Date.now() - parseAppDateTime(updatedAt).getTime()) / (60 * 60 * 1000)))
   if (hoursAgo < 24) {
     return isZh ? `${hoursAgo} 小时前` : `${hoursAgo}h ago`
   }
@@ -68,17 +68,17 @@ export function buildDailyBrief({
 }): DailyBrief {
   const now = Date.now()
 
-  const overdueTodos = todos.filter((t) => t.due_date && new Date(t.due_date).getTime() < now)
+  const overdueTodos = todos.filter((t) => t.due_date && parseAppDateTime(t.due_date).getTime() < now)
   const todayTodos = todos.filter((t) => {
     if (!t.due_date) return false
-    const due = new Date(t.due_date).getTime()
+    const due = parseAppDateTime(t.due_date).getTime()
     return due >= now && due <= now + ONE_DAY
   })
 
   const recentlyMovedProjects = [...projects]
     .filter((p) => p.status !== 'archived')
-    .filter((p) => now - new Date(p.updated_at).getTime() <= 3 * ONE_DAY)
-    .sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime())
+    .filter((p) => now - parseAppDateTime(p.updated_at).getTime() <= 3 * ONE_DAY)
+    .sort((a, b) => parseAppDateTime(b.updated_at).getTime() - parseAppDateTime(a.updated_at).getTime())
 
   const staleMemoryClients = clients.filter(
     (c) => c.project_names.length > 0 && (c.client_memory_stale || (c.client_memory_version ?? 0) === 0),
@@ -86,8 +86,8 @@ export function buildDailyBrief({
 
   const longSilentClients = clients
     .filter((c) => c.project_names.length > 0 && c.client_memory_updated_at)
-    .filter((c) => now - new Date(c.client_memory_updated_at!).getTime() >= 14 * ONE_DAY)
-    .sort((a, b) => new Date(a.client_memory_updated_at!).getTime() - new Date(b.client_memory_updated_at!).getTime())
+    .filter((c) => now - parseAppDateTime(c.client_memory_updated_at!).getTime() >= 14 * ONE_DAY)
+    .sort((a, b) => parseAppDateTime(a.client_memory_updated_at!).getTime() - parseAppDateTime(b.client_memory_updated_at!).getTime())
 
   const actionRequired: BriefItem[] = []
 
@@ -151,7 +151,7 @@ export function buildDailyBrief({
   const quietWatch: BriefItem[] = []
 
   longSilentClients.slice(0, 2).forEach((client) => {
-    const daysAgo = Math.floor((now - new Date(client.client_memory_updated_at!).getTime()) / ONE_DAY)
+    const daysAgo = Math.floor((now - parseAppDateTime(client.client_memory_updated_at!).getTime()) / ONE_DAY)
     quietWatch.push({
       key: `silent-${client.id}`,
       tone: 'green',

--- a/web/src/pages/Welcome.tsx
+++ b/web/src/pages/Welcome.tsx
@@ -24,7 +24,7 @@ import { PageTitle } from '../components/PageTitle'
 import { ServiceErrorState } from '../components/ServiceErrorState'
 import type { Conversation, MyProjectTodo, Project, SkillSummary, SystemMessage, User } from '../types/api'
 import { resolveProjectStage } from '../types/enums'
-import { formatDateOnly, getResolvedAppTimeZone } from '../utils/timezone'
+import { formatDateOnly, getResolvedAppTimeZone, parseAppDateTime } from '../utils/timezone'
 
 interface ErrorResponsePayload {
   detail?: string
@@ -65,7 +65,7 @@ function readCachedUser() {
 
 function formatRelativeTime(value?: string | null, isZh = true) {
   if (!value) return isZh ? '暂无记录' : 'No recent activity'
-  const diffMinutes = Math.floor((Date.now() - new Date(value).getTime()) / 60000)
+  const diffMinutes = Math.floor((Date.now() - parseAppDateTime(value).getTime()) / 60000)
   if (diffMinutes < 1) return isZh ? '刚刚' : 'Just now'
   if (diffMinutes < 60) return isZh ? `${diffMinutes} 分钟前` : `${diffMinutes} min ago`
   if (diffMinutes < 1440) return isZh ? `${Math.floor(diffMinutes / 60)} 小时前` : `${Math.floor(diffMinutes / 60)} h ago`
@@ -210,29 +210,29 @@ export function Welcome() {
   }, [isZh, t])
 
   const activeProjects = useMemo(() => projects.filter((project) => project.status !== 'archived'), [projects])
-  const recentConversations = useMemo(() => [...conversations].sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()).slice(0, 4), [conversations])
+  const recentConversations = useMemo(() => [...conversations].sort((a, b) => parseAppDateTime(b.updated_at).getTime() - parseAppDateTime(a.updated_at).getTime()).slice(0, 4), [conversations])
   const memoryHealth = useMemo(() => ({
     clientNeedWork: clients.filter((client) => client.client_memory_stale || (client.client_memory_version || 0) === 0).length,
     projectNeedWork: projects.filter((project) => project.memory_stale || (project.memory_version || 0) === 0).length,
   }), [clients, projects])
   const overdueTodos = useMemo(() => {
     const now = new Date()
-    return myTodos.filter((todo) => todo.due_date && new Date(todo.due_date) < now)
+    return myTodos.filter((todo) => todo.due_date && parseAppDateTime(todo.due_date) < now)
   }, [myTodos])
   const dueSoonTodos = useMemo(() => {
     const now = Date.now()
     const inThreeDays = now + 3 * 24 * 60 * 60 * 1000
     return myTodos.filter((todo) => {
       if (!todo.due_date) return false
-      const due = new Date(todo.due_date).getTime()
+      const due = parseAppDateTime(todo.due_date).getTime()
       return due >= now && due <= inThreeDays
     })
   }, [myTodos])
   const projectQueue = useMemo(() => {
     return [...activeProjects]
       .sort((a, b) => {
-        const aScore = (a.memory_stale || (a.memory_version || 0) === 0 ? 100 : 0) + new Date(a.updated_at).getTime() / 1_000_000_000
-        const bScore = (b.memory_stale || (b.memory_version || 0) === 0 ? 100 : 0) + new Date(b.updated_at).getTime() / 1_000_000_000
+        const aScore = (a.memory_stale || (a.memory_version || 0) === 0 ? 100 : 0) + parseAppDateTime(a.updated_at).getTime() / 1_000_000_000
+        const bScore = (b.memory_stale || (b.memory_version || 0) === 0 ? 100 : 0) + parseAppDateTime(b.updated_at).getTime() / 1_000_000_000
         return bScore - aScore
       })
       .slice(0, 6)
@@ -290,7 +290,7 @@ export function Welcome() {
   const judgementQueue = useMemo(() => {
     const todoItems = [...overdueTodos, ...dueSoonTodos].slice(0, 2).map((todo) => ({
       key: `todo-${todo.id}`,
-      label: todo.due_date && new Date(todo.due_date) < new Date() ? (isZh ? '逾期' : 'Overdue') : (isZh ? '临期' : 'Due soon'),
+      label: todo.due_date && parseAppDateTime(todo.due_date) < new Date() ? (isZh ? '逾期' : 'Overdue') : (isZh ? '临期' : 'Due soon'),
       title: todo.content,
       meta: todo.project_name,
       path: `/projects/${todo.project_id}/todos`,

--- a/web/src/pages/Workspace.tsx
+++ b/web/src/pages/Workspace.tsx
@@ -17,7 +17,7 @@ import { api } from '../api/client'
 import { PageTitle } from '../components/PageTitle'
 import type { Conversation, SkillSummary } from '../types/api'
 import { resolveProjectStage } from '../types/enums'
-import { formatDateOnly, getResolvedAppTimeZone } from '../utils/timezone'
+import { formatDateOnly, getResolvedAppTimeZone, parseAppDateTime } from '../utils/timezone'
 
 interface DashboardProjectSummary {
   id: number
@@ -34,7 +34,7 @@ const panelClass = 'rounded-2xl border border-slate-200/80 bg-white/95 shadow-[0
 
 function formatRelativeTime(value?: string | null, isZh = true) {
   if (!value) return isZh ? '暂无记录' : 'No recent activity'
-  const diffMinutes = Math.floor((Date.now() - new Date(value).getTime()) / 60000)
+  const diffMinutes = Math.floor((Date.now() - parseAppDateTime(value).getTime()) / 60000)
   if (diffMinutes < 1) return isZh ? '刚刚' : 'Just now'
   if (diffMinutes < 60) return isZh ? `${diffMinutes} 分钟前` : `${diffMinutes} min ago`
   if (diffMinutes < 1440) return isZh ? `${Math.floor(diffMinutes / 60)} 小时前` : `${Math.floor(diffMinutes / 60)} h ago`
@@ -117,7 +117,7 @@ export function Workspace() {
   )
 
   const recentConversations = useMemo(
-    () => [...conversations].sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()).slice(0, 5),
+    () => [...conversations].sort((a, b) => parseAppDateTime(b.updated_at).getTime() - parseAppDateTime(a.updated_at).getTime()).slice(0, 5),
     [conversations],
   )
 

--- a/web/src/pages/clients/Clients.tsx
+++ b/web/src/pages/clients/Clients.tsx
@@ -20,7 +20,7 @@ import {
 
 import { api } from '../../api/client'
 import { PageTitle } from '../../components/PageTitle'
-import { formatDateOnly, getResolvedAppTimeZone } from '../../utils/timezone'
+import { formatDateOnly, getResolvedAppTimeZone, parseAppDateTime } from '../../utils/timezone'
 
 interface Client {
   id: number
@@ -46,7 +46,7 @@ interface ClientSuggestion {
 }
 
 function formatRelativeDate(value: string, isZh: boolean) {
-  const diffHours = Math.floor((Date.now() - new Date(value).getTime()) / (1000 * 60 * 60))
+  const diffHours = Math.floor((Date.now() - parseAppDateTime(value).getTime()) / (1000 * 60 * 60))
   if (diffHours < 24) return isZh ? '今天创建' : 'Created today'
   if (diffHours < 48) return isZh ? '昨天创建' : 'Created yesterday'
   return formatDateOnly(value, {

--- a/web/src/pages/projects/ProjectTaskRunsDrawer.tsx
+++ b/web/src/pages/projects/ProjectTaskRunsDrawer.tsx
@@ -6,7 +6,7 @@ import { useToast } from "../../contexts/ToastContext";
 import type { GeneratedArtifact, TaskRun, TaskRunEvent, TaskRunStep } from "../../types/api";
 import { ProjectChatArtifactCard } from "./ProjectChatArtifactCard";
 import { artifactFromTaskRunArtifact } from "./projectChatWorkflow";
-import { formatDateTime } from "../../utils/timezone";
+import { formatDateTime, parseAppDateTime } from "../../utils/timezone";
 
 type ProjectTaskRunsDrawerProps = {
   isOpen: boolean;
@@ -46,7 +46,7 @@ function StatusIcon({ status }: { status: string }) {
 
 function formatTime(value?: string | null) {
   if (!value) return "";
-  const date = new Date(value);
+  const date = parseAppDateTime(value);
   if (Number.isNaN(date.getTime())) return value.slice(0, 19);
   return formatDateTime(date, "zh-CN", {
     month: "2-digit",

--- a/web/src/pages/projects/projectChatWorkflow.ts
+++ b/web/src/pages/projects/projectChatWorkflow.ts
@@ -6,11 +6,11 @@ import type {
   TaskRunStep,
   ToolCallEvent,
 } from "../../types/api";
-import { formatTimeOnly } from "../../utils/timezone";
+import { formatTimeOnly, parseAppDateTime } from "../../utils/timezone";
 
 export function formatTaskEventTime(value?: string) {
   if (!value) return "";
-  const date = new Date(value);
+  const date = parseAppDateTime(value);
   if (Number.isNaN(date.getTime())) return value.slice(11, 19);
   return formatTimeOnly(value, { hour: "2-digit", minute: "2-digit", second: "2-digit", hour12: false });
 }

--- a/web/src/pages/projects/useProjectOverviewData.ts
+++ b/web/src/pages/projects/useProjectOverviewData.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { api } from "../../api/client";
+import { parseAppDateTime } from "../../utils/timezone";
 import type {
   ProjectDetail as ProjectDetailType,
   ProjectMemory,
@@ -166,7 +167,7 @@ export function useProjectOverviewData({
       [...milestones]
         .sort(
           (a, b) =>
-            new Date(b.due_date || "").getTime() - new Date(a.due_date || "").getTime(),
+            parseAppDateTime(b.due_date || "").getTime() - parseAppDateTime(a.due_date || "").getTime(),
         )
         .slice(0, 3),
     [milestones],
@@ -177,7 +178,7 @@ export function useProjectOverviewData({
       [...files]
         .sort(
           (a, b) =>
-            new Date(b.uploaded_at).getTime() - new Date(a.uploaded_at).getTime(),
+            parseAppDateTime(b.uploaded_at).getTime() - parseAppDateTime(a.uploaded_at).getTime(),
         )
         .slice(0, 5),
     [files],


### PR DESCRIPTION
## Summary
Follow-up to #17. Same root cause swept across the rest of the codebase: every place a frontend file reads a backend timestamp (`updated_at`, `due_date`, `uploaded_at`, etc.) for relative-time math, sorting, or comparison now routes through `parseAppDateTime` instead of raw `new Date(value)`.

## Why this matters
Backend timestamps come back as tz-naive UTC (`2026-05-28T13:22:00`, no `Z`). Plain `new Date(value)` interprets them as **browser-local**, so:
- Relative time shows "8 小时前" instead of "刚刚同步"
- Sorts by `updated_at` skew during DST transitions / cross-TZ users
- Filters like "overdue todos" or "due today" misclassify near midnight

## Files swept
- `components/DailyBriefHero.tsx` — `formatRelative` + 6 sites in the daily-brief filter/sort
- `pages/Workspace.tsx` — `formatRelativeTime` + recent-conversations sort
- `pages/Welcome.tsx` — 5 sites including overdue/due-soon filters and project-queue scoring
- `pages/clients/Clients.tsx` — `formatRelativeDate`
- `pages/projects/useProjectOverviewData.ts` — recent-milestones and recent-files sort
- `pages/projects/projectChatWorkflow.ts` — `formatTaskEventTime` validity check
- `pages/projects/ProjectTaskRunsDrawer.tsx` — drawer `formatTime`

## Intentionally untouched
- `utils/timezone.ts` — the source of truth.
- `pages/projects/Projects.tsx` — already has an inline `Z`-normalize (`getTimestampValue`).
- `pages/projects/projectMemoryTime.ts` — already inline-normalizes.

Could refactor those two to share `parseAppDateTime` for DRY, but that's beyond bug-fix scope.

## Test plan
- [x] `tsc --noEmit` → clean
- [x] `vitest run Welcome projectChatWorkflow DailyBriefHero` → all green
- [ ] Manual: `/` Workspace + Welcome → "刚刚" / "X 分钟前" reads correctly
- [ ] Manual: `/clients` → relative date matches the actual creation time
- [ ] Manual: project files list → most-recent-first ordering correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)