### PR TITLE
Polish 可直接使用的话术 card with a dedicated typographic style

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -610,6 +610,122 @@ samp {
   font-style: italic;
 }
 
+/* === Briefing AI script ("可直接使用的话术") === */
+/* A polished variant of the markdown styling tuned for the briefing tab's
+   AI-refined script card. The deterministic briefing above uses bullet
+   chips and stat tiles; this section gets typographic hierarchy that
+   reads as an authoritative one-pager rather than a chat reply. */
+
+.briefing-script {
+  font-size: 0.9375rem;
+  line-height: 1.85;
+  color: var(--color-on-surface);
+}
+
+.briefing-script .md-paragraph {
+  margin: 0.5rem 0 0.85rem;
+}
+
+.briefing-script .md-paragraph:last-child {
+  margin-bottom: 0;
+}
+
+.briefing-script .md-heading {
+  font-family: var(--font-display);
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  margin: 1.5rem 0 0.6rem;
+  font-weight: 650;
+  color: var(--color-on-surface);
+  letter-spacing: 0.01em;
+}
+
+.briefing-script > .md-heading:first-child,
+.briefing-script > :first-child .md-heading:first-child {
+  margin-top: 0;
+}
+
+.briefing-script .md-heading::before {
+  content: "";
+  display: inline-block;
+  width: 3px;
+  height: 0.95em;
+  border-radius: 9999px;
+  background: linear-gradient(
+    to bottom,
+    var(--color-primary),
+    color-mix(in srgb, var(--color-primary) 55%, transparent)
+  );
+  flex-shrink: 0;
+}
+
+.briefing-script .md-h1 {
+  font-size: 1.125rem;
+}
+
+.briefing-script .md-h2 {
+  font-size: 1.0625rem;
+}
+
+.briefing-script .md-h3 {
+  font-size: 1rem;
+}
+
+.briefing-script .md-h4 {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--color-on-surface-variant);
+}
+
+.briefing-script .md-list {
+  margin: 0.4rem 0 0.9rem;
+  padding-left: 1.35rem;
+}
+
+.briefing-script .md-list-ul {
+  list-style-type: disc !important;
+}
+
+.briefing-script .md-list-ol {
+  list-style-type: decimal !important;
+}
+
+.briefing-script .md-list-item {
+  margin: 0.35rem 0;
+  line-height: 1.8;
+}
+
+.briefing-script .md-list-item::marker {
+  color: color-mix(in srgb, var(--color-primary) 70%, transparent);
+}
+
+.briefing-script .md-strong {
+  font-weight: 600;
+  color: color-mix(in srgb, var(--color-primary) 70%, var(--color-on-surface));
+}
+
+.briefing-script .md-em {
+  font-style: italic;
+  color: var(--color-on-surface-variant);
+}
+
+.briefing-script .md-blockquote {
+  border-left: 3px solid var(--color-primary);
+  padding: 0.25rem 0 0.25rem 0.9rem;
+  margin: 0.75rem 0;
+  color: var(--color-on-surface-variant);
+  background: color-mix(in srgb, var(--color-primary) 4%, transparent);
+  border-radius: 0 0.375rem 0.375rem 0;
+}
+
+.briefing-script .md-hr {
+  border: none;
+  border-top: 1px dashed
+    color-mix(in srgb, var(--color-outline) 60%, transparent);
+  margin: 1.25rem 0;
+}
+
 /* === Table Styles === */
 .md-root .md-table-wrapper {
   overflow-x: auto;

--- a/web/src/pages/projects/ProjectBriefingTab.tsx
+++ b/web/src/pages/projects/ProjectBriefingTab.tsx
@@ -311,13 +311,19 @@ export function ProjectBriefingTab({ projectDetail, projectId }: ProjectBriefing
           ) : null}
 
           {refinedBriefing ? (
-            <section className="rounded-lg border border-primary/20 bg-white p-4 shadow-sm">
-              <div className="mb-3 flex flex-wrap items-center gap-2">
+            <section className="relative overflow-hidden rounded-2xl border border-primary/15 bg-gradient-to-br from-white via-white to-primary/[0.03] p-6 shadow-sm ring-1 ring-primary/5">
+              <div
+                aria-hidden="true"
+                className="pointer-events-none absolute -top-12 -right-12 h-40 w-40 rounded-full bg-primary/5 blur-3xl"
+              />
+              <div className="relative mb-4 flex flex-wrap items-center gap-2">
                 <div className="flex items-center gap-2 text-sm font-semibold text-slate-950">
-                  <Sparkles className="h-4 w-4 text-primary" />
+                  <span className="inline-flex h-7 w-7 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                    <Sparkles className="h-3.5 w-3.5" />
+                  </span>
                   {isZh ? "可直接使用的话术" : "Ready-to-use script"}
                 </div>
-                <span className="rounded-md bg-slate-100 px-2 py-1 text-xs text-slate-600">
+                <span className="rounded-md bg-slate-100 px-2 py-0.5 text-xs text-slate-600">
                   {refinedBriefing.cached ? (isZh ? "缓存命中" : "Cache hit") : isZh ? "刚刚生成" : "Generated"}
                 </span>
                 {refinedGeneratedAt ? <span className="text-xs text-slate-400">{refinedGeneratedAt}</span> : null}
@@ -325,13 +331,13 @@ export function ProjectBriefingTab({ projectDetail, projectId }: ProjectBriefing
                   type="button"
                   onClick={() => void refineBriefing(true)}
                   disabled={isRefining}
-                  className="ml-auto inline-flex items-center gap-1.5 rounded-md border border-slate-200 px-2.5 py-1 text-xs font-medium text-slate-600 hover:bg-slate-50 disabled:opacity-60"
+                  className="ml-auto inline-flex items-center gap-1.5 rounded-md border border-slate-200 bg-white/70 px-2.5 py-1 text-xs font-medium text-slate-600 transition hover:bg-white disabled:opacity-60"
                 >
                   <RefreshCw className="h-3.5 w-3.5" />
                   {isZh ? "重新生成" : "Regenerate"}
                 </button>
               </div>
-              <div className="text-sm leading-7 text-slate-800">
+              <div className="briefing-script md-root relative">
                 <MarkdownRenderer content={refinedBriefing.content} />
               </div>
             </section>


### PR DESCRIPTION
## Summary
PR #17 made the AI-refined briefing script render as Markdown (fixing the literal `###` / `**` leaks), but the rendered output still read as a flat wall of text — H3 sections collapsed into body, list bullets were missing, and no visual hierarchy separated "30 秒会议判断" from the prose under it.

This is a CSS + container polish pass. No JS / state / API touched.

## What changes

**`index.css`** — new `.briefing-script` scope (lives next to `.md-root`):
- H1/H2/H3 get a small primary-colored **vertical accent bar** (`::before` gradient pseudo-element) and tightened margins. First heading's top margin zeroes so the card opens cleanly.
- Lists render with proper disc/decimal markers tinted to `primary/60`.
- `<strong>` is reweighted + tinted (mix of primary 70% / on-surface 30%) so keywords pop without becoming aggressive.
- Blockquotes get a soft primary-tinted background.
- Body line-height bumped to **1.85** for a one-pager feel.

**`ProjectBriefingTab.tsx`** — container polish:
- `rounded-lg` → `rounded-2xl`, `p-4` → `p-6`.
- Background: soft white → `primary/[0.03]` gradient.
- A faint blurred primary blob in the top-right corner for warmth.
- Sparkles icon moved into a small tinted square chip.
- Wrapper div carries both `briefing-script` (new) and `md-root` (so inline code, tables, links inherit existing styles).

## What's unchanged
- The deterministic briefing chips above (建议说什么 / 尽量避开什么 / etc.) are untouched.
- The Markdown sanitization layer (`markdownSecurity`) is untouched.
- Other Markdown consumers (chat bubbles, project chat preview) are untouched — they use their own scopes (`.project-chat-answer`, `.project-chat-preview-md`).

## Test plan
- [x] `tsc --noEmit` → clean
- [x] `vitest run MarkdownRenderer` → 19/19
- [ ] **Manual (after deploy):** Visit `/projects/:id/briefing` with a generated AI script. Verify H3s have the primary accent bar; bullets render; `**bold**` keywords have the primary tint; sections breathe.

⚠️ Did not visually verify locally — relying on prod deploy for the user to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)