### PR TITLE
HOT FIX: drop stray knowledge_retrieval import that broke prod deploy

### DIFF
--- a/backend/app/services/chat/__init__.py
+++ b/backend/app/services/chat/__init__.py
@@ -42,7 +42,6 @@ from app.services.chat.product_run_events import (
     ErrorCode,
     RunFinalStatus,
     make_run_id,
-    knowledge_retrieval as _knowledge_retrieval_event,
     run_done,
     run_failed,
     run_started,
@@ -205,18 +204,6 @@ async def stream_chat_events(
 
     if runtime.rag_sources:
         yield sse_event({"type": "references", "references": runtime.rag_sources})
-    knowledge_metric = (runtime.prepare_metrics or {}).get("knowledge_retrieval") if runtime.prepare_metrics else None
-    if isinstance(knowledge_metric, dict):
-        yield sse_event(
-            _knowledge_retrieval_event(
-                state.run_id,
-                status=str(knowledge_metric.get("status") or "completed"),
-                query=str(knowledge_metric.get("query") or ""),
-                source_count=int(knowledge_metric.get("source_count") or 0),
-                chunk_count=int(knowledge_metric.get("chunk_count") or 0),
-                low_confidence=bool(knowledge_metric.get("low_confidence")),
-            )
-        )
 
     for metric_key in (
         "conversation_ready_ms",


### PR DESCRIPTION
## What
Backend failed to start after PR #20 with:
\`\`\`
ImportError: cannot import name 'knowledge_retrieval' from 'app.services.chat.product_run_events'
\`\`\`

## Root cause
PR #20 (badba40) accidentally included two hunks from in-progress V0.0.5 knowledge-base work that lives in the user's local working tree only. Those hunks reference \`knowledge_retrieval\` in \`product_run_events\` — a function the user added locally but hasn't committed yet. Main never had it.

## Fix
Removed from \`backend/app/services/chat/__init__.py\`:
- The \`knowledge_retrieval as _knowledge_retrieval_event\` import.
- The 12-line block in \`stream_chat_events\` that yielded \`_knowledge_retrieval_event(...)\` after the references frame.

**Left intact** (the actual PR #20 changes):
- \`status: "context_ready"\` event after prepare metrics
- Heartbeat interval 8s → 2s
- Timing chips in \`ProjectChatTracePanel\`

## Why this slipped through
I was staging \`__init__.py\` by file path expecting that to be a safe whitelist. It isn't — \`git add <path>\` includes all pending hunks in the file. When a file has mixed-authorship WIP, only \`git add -p\` (hunk-level) is safe. Adding to my running discipline.

## Verification
- \`python -c "from app.services.chat import *"\` → OK
- \`python -c "from app.routers import chat"\` → OK
- \`pytest tests/test_chat_end_to_end.py\` → 23/23 pass

Merging immediately to restore the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)