### PR TITLE
Preserve personal_info.onboarding_seen on settings-card save

### DIFF
--- a/web/src/pages/settings/UserMemorySettingsCard.test.tsx
+++ b/web/src/pages/settings/UserMemorySettingsCard.test.tsx
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { __test__ } from "./UserMemorySettingsCard";
+
+const { compactPreferences, readShape } = __test__;
+
+describe("UserMemorySettingsCard helpers", () => {
+  describe("compactPreferences always stamps personal_info.onboarding_seen", () => {
+    it("preserves onboarding_seen even when the form is otherwise empty", () => {
+      // Reaching the settings card implies the user has been through the
+      // onboarding flow at least once. Whole-object PUT semantics on the
+      // backend (user_memory router) mean any field absent from the payload
+      // is dropped — so the save must restamp the flag every time.
+      const result = compactPreferences({});
+      expect(result).toEqual({ personal_info: { onboarding_seen: true } });
+    });
+
+    it("stamps onboarding_seen alongside an edited preferred_name", () => {
+      const result = compactPreferences({
+        personal_info: { preferred_name: "李总" },
+      });
+      expect(result).toEqual({
+        personal_info: { preferred_name: "李总", onboarding_seen: true },
+      });
+    });
+
+    it("trims whitespace and drops an empty preferred_name without losing the flag", () => {
+      const result = compactPreferences({
+        personal_info: { preferred_name: "   " },
+      });
+      expect(result).toEqual({ personal_info: { onboarding_seen: true } });
+    });
+
+    it("co-exists with response_preferences and work_style edits", () => {
+      const result = compactPreferences({
+        personal_info: { preferred_name: "Liang" },
+        response_preferences: { language: "en", tone: "direct", format: "" },
+        work_style: { ask_before_destructive: true },
+      });
+      expect(result).toEqual({
+        personal_info: { preferred_name: "Liang", onboarding_seen: true },
+        response_preferences: { language: "en", tone: "direct" },
+        work_style: { ask_before_destructive: true },
+      });
+    });
+  });
+
+  describe("readShape", () => {
+    it("loads preferred_name when present", () => {
+      const shape = readShape({ personal_info: { preferred_name: "李总" } });
+      expect(shape).toEqual({ personal_info: { preferred_name: "李总" } });
+    });
+
+    it("ignores empty preferred_name", () => {
+      const shape = readShape({ personal_info: { preferred_name: "" } });
+      expect(shape.personal_info).toBeUndefined();
+    });
+  });
+});

--- a/web/src/pages/settings/UserMemorySettingsCard.tsx
+++ b/web/src/pages/settings/UserMemorySettingsCard.tsx
@@ -31,6 +31,10 @@ interface UserMemoryResponse {
 interface PreferencesShape {
   personal_info?: {
     preferred_name?: string;
+    // Housekeeping flag (the post-login Welcome page sets this once). The
+    // settings card preserves it on every save so writes don't bounce users
+    // back to /onboarding — see compactPreferences.
+    onboarding_seen?: boolean;
   };
   response_preferences?: {
     language?: Language;
@@ -64,10 +68,17 @@ const FORMAT_OPTIONS: { value: FormatShape; label: string }[] = [
 
 function compactPreferences(prefs: PreferencesShape): Record<string, unknown> {
   const compact: PreferencesShape = {};
+
+  // The settings card is reachable only AFTER onboarding, so by definition the
+  // user has seen it. Re-stamp the flag on every save so the back-end PUT
+  // (whole-object replace, see backend/app/routers/user_memory.py) doesn't
+  // accidentally wipe it and bounce the user back to /onboarding next refresh.
   const preferredName = prefs.personal_info?.preferred_name?.trim() ?? "";
-  if (preferredName) {
-    compact.personal_info = { preferred_name: preferredName };
-  }
+  const personalOut: NonNullable<PreferencesShape["personal_info"]> = {
+    onboarding_seen: true,
+  };
+  if (preferredName) personalOut.preferred_name = preferredName;
+  compact.personal_info = personalOut;
 
   const rp = prefs.response_preferences ?? {};
   const rpOut: PreferencesShape["response_preferences"] = {};
@@ -323,3 +334,5 @@ export function UserMemorySettingsCard() {
     </div>
   );
 }
+
+export const __test__ = { compactPreferences, readShape };


### PR DESCRIPTION
## Problem
User reported: "AI 个人偏好 — 每次部署完都要来问我" — the onboarding 称呼 prompt keeps reappearing after each deploy.

## Root cause (not actually a deploy bug)
The onboarding gate fires whenever a save in **Settings → AI 个人偏好** happens to drop the \`personal_info.onboarding_seen\` flag from the saved blob:

1. Onboarding completes → \`personal_info.onboarding_seen = true\` lands in \`UserMemory.preferences_json\`. Gate passes.
2. User later opens Settings → AI 个人偏好.
3. \`readShape\` extracts only \`preferred_name\` from \`personal_info\`, silently dropping \`onboarding_seen\`.
4. \`compactPreferences\` re-emits a \`personal_info\` block with **only** \`preferred_name\`.
5. Backend [PUT /user-memory](backend/app/routers/user_memory.py#L124) is whole-object replace, not merge. The flag is now gone from DB.
6. Next page load → Layout sees no flag → redirect to /onboarding.

It correlates with "after deploy" because that's when the user happens to refresh + check Settings.

## Fix
\`compactPreferences\` now unconditionally stamps \`personal_info.onboarding_seen = true\` on every save. The settings card is reachable only **after** onboarding, so the assertion holds by construction.

The cleaner architectural fix (backend PUT-as-merge) would break the form's existing "unset a field by sending it empty" semantics, so restamping at the call site is the right scope here.

## Test plan
- [x] \`UserMemorySettingsCard.test.tsx\` (new): 4 cases on compactPreferences + 2 readShape cases — 6/6 pass
- [x] \`tsc --noEmit\` clean
- [ ] **Manual after deploy**: open Settings → AI 个人偏好 → 保存 → refresh → confirm no redirect to /onboarding

Staging discipline (from PR #21 lesson): \`git diff --cached\` verified before commit — staged set is exactly the 2 files in this PR, V0.0.5 WIP untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)