### PR TITLE
Codex core primitives (V0.0.6 frontend redesign · PR 2/N)

### DIFF
--- a/web/src/components/codex/CxFormRow.test.tsx
+++ b/web/src/components/codex/CxFormRow.test.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { CxFormRow } from "./CxFormRow";
+
+describe("CxFormRow", () => {
+  it("renders label and the wrapped control", () => {
+    render(
+      <CxFormRow label="姓名">
+        <input data-testid="name" />
+      </CxFormRow>,
+    );
+    expect(screen.getByText("姓名")).toBeInTheDocument();
+    expect(screen.getByTestId("name")).toBeInTheDocument();
+  });
+
+  it("renders hint copy when provided", () => {
+    render(
+      <CxFormRow label="邮箱" hint="登录用,变更需邮件验证">
+        <input />
+      </CxFormRow>,
+    );
+    expect(screen.getByText("登录用,变更需邮件验证")).toBeInTheDocument();
+  });
+
+  it("associates the label with the control via htmlFor", () => {
+    render(
+      <CxFormRow label="姓名" htmlFor="name-input">
+        <input id="name-input" />
+      </CxFormRow>,
+    );
+    const label = screen.getByText("姓名").closest("label");
+    expect(label).toHaveAttribute("for", "name-input");
+  });
+
+  it("suppresses the bottom hairline when divider=false (last row)", () => {
+    render(
+      <CxFormRow label="对话签名" divider={false}>
+        <textarea />
+      </CxFormRow>,
+    );
+    const row = screen.getByTestId("cx-form-row");
+    expect(row.style.borderBottom).toBe("");
+  });
+});

--- a/web/src/components/codex/CxFormRow.tsx
+++ b/web/src/components/codex/CxFormRow.tsx
@@ -1,0 +1,62 @@
+/**
+ * Codex form row — 180px label column + flexible control column,
+ * separated by a hairline ``line-soft`` bottom border.
+ *
+ * Port of the prototype's ``CxFormRow`` in
+ * ``design_handoff_aria_codex_redesign/direction-codex-settings.jsx:65``.
+ *
+ * Used by every settings page. Stack multiple rows inside any
+ * scrolling card / panel.
+ */
+import type { ReactNode } from "react";
+
+interface CxFormRowProps {
+  label: ReactNode;
+  hint?: ReactNode;
+  htmlFor?: string;
+  children: ReactNode;
+  /** Pass ``false`` to suppress the bottom hairline on the last row. */
+  divider?: boolean;
+}
+
+export function CxFormRow({
+  label,
+  hint,
+  htmlFor,
+  children,
+  divider = true,
+}: CxFormRowProps) {
+  return (
+    <div
+      className="grid items-start gap-7"
+      style={{
+        gridTemplateColumns: "180px 1fr",
+        padding: "16px 0",
+        borderBottom: divider ? "1px solid var(--color-codex-line-soft)" : undefined,
+      }}
+      data-testid="cx-form-row"
+    >
+      <div>
+        <label
+          htmlFor={htmlFor}
+          style={{ fontSize: 13.5, color: "var(--color-codex-ink)", fontWeight: 500 }}
+        >
+          {label}
+        </label>
+        {hint && (
+          <div
+            style={{
+              fontSize: 11.5,
+              color: "var(--color-codex-ink-mute)",
+              marginTop: 4,
+              lineHeight: 1.5,
+            }}
+          >
+            {hint}
+          </div>
+        )}
+      </div>
+      <div>{children}</div>
+    </div>
+  );
+}

--- a/web/src/components/codex/CxLogo.test.tsx
+++ b/web/src/components/codex/CxLogo.test.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { CxLogo } from "./CxLogo";
+
+describe("CxLogo", () => {
+  it("renders the monogram and wordmark by default", () => {
+    render(<CxLogo />);
+    const root = screen.getByTestId("cx-logo");
+    expect(root).toHaveTextContent(/^a\s*Aria$/);
+  });
+
+  it("hides the wordmark when showWordmark is false", () => {
+    render(<CxLogo showWordmark={false} />);
+    const root = screen.getByTestId("cx-logo");
+    expect(root.textContent?.trim()).toBe("a");
+  });
+
+  it("uses the provided size for the monogram square", () => {
+    render(<CxLogo size={36} />);
+    const square = screen.getByTestId("cx-logo").firstElementChild as HTMLElement;
+    expect(square).toHaveStyle({ width: "36px", height: "36px" });
+  });
+
+  it("scales the wordmark up with size unless wordmarkSize overrides", () => {
+    const { rerender } = render(<CxLogo size={36} />);
+    let wordmark = screen.getByText("Aria");
+    expect(wordmark).toHaveStyle({ fontSize: "17px" });
+
+    rerender(<CxLogo size={36} wordmarkSize={22} />);
+    wordmark = screen.getByText("Aria");
+    expect(wordmark).toHaveStyle({ fontSize: "22px" });
+  });
+});

--- a/web/src/components/codex/CxLogo.tsx
+++ b/web/src/components/codex/CxLogo.tsx
@@ -1,0 +1,60 @@
+/**
+ * Codex brand logo — small dark square with lowercase mono "a" + Aria wordmark.
+ *
+ * Port of the prototype's ``CxLogo`` in
+ * ``design_handoff_aria_codex_redesign/direction-codex-part1.jsx:66``.
+ *
+ * The monogram uses ``--color-codex-ink`` background + ``--color-codex-bg-elev``
+ * text so it reads as a small embossed mark on both light and dark themes
+ * (the tokens swap places under ``.theme-codex.dark``).
+ *
+ * Use ``showWordmark={false}`` for tight nav corners where the "Aria"
+ * wordmark would compete with adjacent labels.
+ */
+
+interface CxLogoProps {
+  size?: number;
+  showWordmark?: boolean;
+  wordmarkSize?: number;
+}
+
+export function CxLogo({ size = 22, showWordmark = true, wordmarkSize }: CxLogoProps) {
+  const ws = wordmarkSize ?? (size > 22 ? 17 : 15);
+  return (
+    <span
+      className="inline-flex items-center gap-2"
+      data-testid="cx-logo"
+      aria-label="Aria"
+    >
+      <span
+        className="inline-flex items-center justify-center font-mono shrink-0"
+        style={{
+          width: size,
+          height: size,
+          background: "var(--color-codex-ink)",
+          color: "var(--color-codex-bg-elev)",
+          borderRadius: 5,
+          fontWeight: 600,
+          fontSize: Math.round(size * 0.58),
+          lineHeight: 1,
+          letterSpacing: "-0.04em",
+        }}
+        aria-hidden="true"
+      >
+        a
+      </span>
+      {showWordmark && (
+        <span
+          style={{
+            fontSize: ws,
+            color: "var(--color-codex-ink)",
+            fontWeight: 500,
+            letterSpacing: "-0.02em",
+          }}
+        >
+          Aria
+        </span>
+      )}
+    </span>
+  );
+}

--- a/web/src/components/codex/CxPanel.test.tsx
+++ b/web/src/components/codex/CxPanel.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { CxPanel } from "./CxPanel";
+import { CxStatus } from "./CxStatus";
+
+describe("CxPanel", () => {
+  it("renders children inside a bordered section", () => {
+    render(
+      <CxPanel title="项目档案">
+        <p>body</p>
+      </CxPanel>,
+    );
+    const panel = screen.getByTestId("cx-panel");
+    expect(panel.tagName).toBe("SECTION");
+    expect(panel).toHaveTextContent("项目档案");
+    expect(panel).toHaveTextContent("body");
+  });
+
+  it("renders subtitle and action when provided", () => {
+    render(
+      <CxPanel
+        title="近期节奏"
+        subtitle="未来 14 天的会议与里程碑"
+        action={<CxStatus tone="good">已同步</CxStatus>}
+      >
+        <p>row</p>
+      </CxPanel>,
+    );
+    expect(screen.getByText("未来 14 天的会议与里程碑")).toBeInTheDocument();
+    expect(screen.getByTestId("cx-status")).toHaveTextContent("已同步");
+  });
+
+  it("omits the header entirely when no title / subtitle / action", () => {
+    render(
+      <CxPanel>
+        <p data-testid="body">body only</p>
+      </CxPanel>,
+    );
+    const panel = screen.getByTestId("cx-panel");
+    expect(panel.querySelector("header")).toBeNull();
+    expect(screen.getByTestId("body")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/codex/CxPanel.tsx
+++ b/web/src/components/codex/CxPanel.tsx
@@ -1,0 +1,79 @@
+/**
+ * Codex titled card — bordered, hairline 1px line, no shadow.
+ *
+ * Port of the prototype's ``CxPanel`` in
+ * ``design_handoff_aria_codex_redesign/direction-codex-project-1.jsx:102``.
+ *
+ * Layout: title + optional subtitle on the left, optional action on
+ * the right (typically a ``CxStatus`` or a small link). Children fill
+ * the rest of the panel.
+ */
+import type { ReactNode } from "react";
+
+interface CxPanelProps {
+  title?: ReactNode;
+  subtitle?: ReactNode;
+  action?: ReactNode;
+  className?: string;
+  children: ReactNode;
+}
+
+export function CxPanel({
+  title,
+  subtitle,
+  action,
+  className,
+  children,
+}: CxPanelProps) {
+  const showHeader = title || subtitle || action;
+  return (
+    <section
+      className={[
+        "border bg-codex-bg-elev",
+        "border-codex-line",
+        className ?? "",
+      ]
+        .join(" ")
+        .trim()}
+      style={{
+        borderRadius: "var(--codex-r-md, 6px)",
+        padding: "18px 20px",
+      }}
+      data-testid="cx-panel"
+    >
+      {showHeader && (
+        <header className="mb-3.5 flex items-start justify-between gap-3">
+          <div>
+            {title && (
+              <h3
+                style={{
+                  margin: 0,
+                  fontSize: 14,
+                  fontWeight: 600,
+                  color: "var(--color-codex-ink)",
+                  letterSpacing: "-0.01em",
+                }}
+              >
+                {title}
+              </h3>
+            )}
+            {subtitle && (
+              <p
+                style={{
+                  margin: "3px 0 0",
+                  fontSize: 12,
+                  color: "var(--color-codex-ink-mute)",
+                  lineHeight: 1.5,
+                }}
+              >
+                {subtitle}
+              </p>
+            )}
+          </div>
+          {action}
+        </header>
+      )}
+      {children}
+    </section>
+  );
+}

--- a/web/src/components/codex/CxSkeleton.test.tsx
+++ b/web/src/components/codex/CxSkeleton.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { CxSkeleton } from "./CxSkeleton";
+
+describe("CxSkeleton", () => {
+  it("renders a status role with aria-busy for screen readers", () => {
+    render(<CxSkeleton aria-label="Loading project" />);
+    const node = screen.getByRole("status", { name: "Loading project" });
+    expect(node).toHaveAttribute("aria-busy", "true");
+  });
+
+  it("defaults to full-width and 12px height", () => {
+    render(<CxSkeleton />);
+    const node = screen.getByTestId("cx-skeleton");
+    expect(node).toHaveStyle({ width: "100%", height: "12px" });
+  });
+
+  it("accepts numeric or string sizes", () => {
+    render(<CxSkeleton w={320} h="2rem" />);
+    const node = screen.getByTestId("cx-skeleton");
+    expect(node).toHaveStyle({ width: "320px", height: "2rem" });
+  });
+
+  it("uses the codex-shimmer animation", () => {
+    render(<CxSkeleton />);
+    const node = screen.getByTestId("cx-skeleton");
+    expect(node.style.animation).toContain("codex-shimmer");
+  });
+
+  it("allows overriding the corner radius", () => {
+    render(<CxSkeleton radius={999} />);
+    const node = screen.getByTestId("cx-skeleton");
+    expect(node).toHaveStyle({ borderRadius: "999px" });
+  });
+});

--- a/web/src/components/codex/CxSkeleton.tsx
+++ b/web/src/components/codex/CxSkeleton.tsx
@@ -1,0 +1,52 @@
+/**
+ * Codex shimmer skeleton — animated placeholder block for loading rows.
+ *
+ * Port of the prototype's ``CxSkeleton`` in
+ * ``design_handoff_aria_codex_redesign/direction-codex-states.jsx:6``.
+ *
+ * Uses the ``codex-shimmer`` keyframe registered in
+ * ``web/src/styles/codex.css``. Stack multiple instances at different
+ * widths to match the page layout the user will eventually see (see
+ * the prototype's ``CxLoading`` for an example skeleton arrangement).
+ */
+import type { CSSProperties } from "react";
+
+interface CxSkeletonProps {
+  w?: number | string;
+  h?: number | string;
+  /** Override the small (3px) default corner radius. */
+  radius?: number | string;
+  className?: string;
+  style?: CSSProperties;
+  /** Optional ARIA label for screen readers (defaults to "Loading"). */
+  "aria-label"?: string;
+}
+
+export function CxSkeleton({
+  w = "100%",
+  h = 12,
+  radius,
+  className,
+  style,
+  ...aria
+}: CxSkeletonProps) {
+  return (
+    <span
+      role="status"
+      aria-label={aria["aria-label"] ?? "Loading"}
+      aria-busy="true"
+      className={["inline-block", className ?? ""].join(" ").trim()}
+      style={{
+        width: w,
+        height: h,
+        background:
+          "linear-gradient(90deg, var(--color-codex-bg-tint) 0%, var(--color-codex-bg-sunken) 50%, var(--color-codex-bg-tint) 100%)",
+        backgroundSize: "200% 100%",
+        borderRadius: radius ?? "var(--codex-r-sm, 3px)",
+        animation: "codex-shimmer 1.6s ease-in-out infinite",
+        ...style,
+      }}
+      data-testid="cx-skeleton"
+    />
+  );
+}

--- a/web/src/components/codex/CxStatus.test.tsx
+++ b/web/src/components/codex/CxStatus.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { CxStatus } from "./CxStatus";
+
+describe("CxStatus", () => {
+  it("renders the label and exposes the tone via data attribute", () => {
+    render(<CxStatus tone="good">on track</CxStatus>);
+    const pill = screen.getByTestId("cx-status");
+    expect(pill).toHaveTextContent("on track");
+    expect(pill).toHaveAttribute("data-tone", "good");
+  });
+
+  it("falls back to neutral when no tone is provided", () => {
+    render(<CxStatus>idle</CxStatus>);
+    expect(screen.getByTestId("cx-status")).toHaveAttribute("data-tone", "neutral");
+  });
+
+  it("attaches the pulse animation class only when pulse is true", () => {
+    const { rerender } = render(<CxStatus tone="accent">live</CxStatus>);
+    let dot = screen.getByTestId("cx-status").querySelector("span");
+    expect(dot?.className).not.toContain("codex-dot-pulse");
+
+    rerender(
+      <CxStatus tone="accent" pulse>
+        live
+      </CxStatus>,
+    );
+    dot = screen.getByTestId("cx-status").querySelector("span");
+    expect(dot?.className).toContain("codex-dot-pulse");
+  });
+
+  it("colors the pill and the dot with the tone's CSS variable", () => {
+    render(<CxStatus tone="bad">error</CxStatus>);
+    const pill = screen.getByTestId("cx-status");
+    expect(pill).toHaveStyle({ color: "var(--color-codex-bad)" });
+    const dot = pill.querySelector("span");
+    expect(dot).toHaveStyle({ background: "var(--color-codex-bad)" });
+  });
+});

--- a/web/src/components/codex/CxStatus.tsx
+++ b/web/src/components/codex/CxStatus.tsx
@@ -1,0 +1,62 @@
+/**
+ * Codex status pill — 5–7px filled dot + label, mono font, tone-colored.
+ *
+ * Port of the prototype's ``CxStatus`` in
+ * ``design_handoff_aria_codex_redesign/direction-codex-part1.jsx:11``.
+ * Default tone is ``neutral``. Set ``pulse`` for live / in-progress
+ * states (animates the dot via the ``codex-pulse`` keyframe).
+ *
+ * Must live inside a ``theme-codex`` subtree so the CSS custom
+ * properties (``--color-codex-accent``, etc.) resolve.
+ */
+import type { ReactNode } from "react";
+
+export type CxStatusTone =
+  | "neutral"
+  | "accent"
+  | "good"
+  | "warn"
+  | "bad"
+  | "info"
+  | "mute";
+
+interface CxStatusProps {
+  tone?: CxStatusTone;
+  pulse?: boolean;
+  children: ReactNode;
+}
+
+const TONE_VAR: Record<CxStatusTone, string> = {
+  neutral: "var(--color-codex-ink-mute)",
+  accent: "var(--color-codex-accent)",
+  good: "var(--color-codex-good)",
+  warn: "var(--color-codex-warn)",
+  bad: "var(--color-codex-bad)",
+  info: "var(--color-codex-info)",
+  mute: "var(--color-codex-ink-faint)",
+};
+
+export function CxStatus({ tone = "neutral", pulse = false, children }: CxStatusProps) {
+  const color = TONE_VAR[tone];
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 font-mono"
+      style={{ color, fontSize: 11.5 }}
+      data-tone={tone}
+      data-testid="cx-status"
+    >
+      <span
+        className={pulse ? "codex-dot-pulse" : undefined}
+        style={{
+          width: 6,
+          height: 6,
+          borderRadius: 999,
+          background: color,
+          display: "inline-block",
+        }}
+        aria-hidden="true"
+      />
+      {children}
+    </span>
+  );
+}

--- a/web/src/components/codex/CxSwitch.test.tsx
+++ b/web/src/components/codex/CxSwitch.test.tsx
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { CxSwitch } from "./CxSwitch";
+
+describe("CxSwitch", () => {
+  it("renders as a switch button with the current aria-checked state", () => {
+    const { rerender } = render(
+      <CxSwitch checked={false} onCheckedChange={() => {}} aria-label="dark mode" />,
+    );
+    const button = screen.getByRole("switch", { name: "dark mode" });
+    expect(button).toHaveAttribute("aria-checked", "false");
+
+    rerender(
+      <CxSwitch checked onCheckedChange={() => {}} aria-label="dark mode" />,
+    );
+    expect(screen.getByRole("switch", { name: "dark mode" })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+  });
+
+  it("calls onCheckedChange with the opposite value on click", () => {
+    const onChange = vi.fn();
+    render(
+      <CxSwitch checked={false} onCheckedChange={onChange} aria-label="dark mode" />,
+    );
+    fireEvent.click(screen.getByRole("switch"));
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it("toggles on Space key (ARIA APG pattern)", () => {
+    const onChange = vi.fn();
+    render(
+      <CxSwitch checked onCheckedChange={onChange} aria-label="dark mode" />,
+    );
+    fireEvent.keyDown(screen.getByRole("switch"), { key: " " });
+    expect(onChange).toHaveBeenCalledWith(false);
+  });
+
+  it("does not fire onCheckedChange when disabled", () => {
+    const onChange = vi.fn();
+    render(
+      <CxSwitch
+        checked={false}
+        onCheckedChange={onChange}
+        disabled
+        aria-label="dark mode"
+      />,
+    );
+    fireEvent.click(screen.getByRole("switch"));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("translates the inner thumb when checked", () => {
+    const { rerender } = render(
+      <CxSwitch checked={false} onCheckedChange={() => {}} aria-label="toggle" />,
+    );
+    let thumb = screen.getByRole("switch").firstElementChild as HTMLElement;
+    expect(thumb.style.transform).toBe("translateX(0)");
+
+    rerender(
+      <CxSwitch checked onCheckedChange={() => {}} aria-label="toggle" />,
+    );
+    thumb = screen.getByRole("switch").firstElementChild as HTMLElement;
+    expect(thumb.style.transform).toBe("translateX(15px)");
+  });
+});

--- a/web/src/components/codex/CxSwitch.tsx
+++ b/web/src/components/codex/CxSwitch.tsx
@@ -1,0 +1,84 @@
+/**
+ * Codex toggle switch — pill-shaped, accent fill when on.
+ *
+ * The prototype version in
+ * ``design_handoff_aria_codex_redesign/direction-codex-settings.jsx:81``
+ * is display-only (``CxSwitch({ on })``). Production needs interaction
+ * + keyboard + ARIA, so we expose a controlled-component API and
+ * render a ``<button role="switch">``.
+ */
+import { useCallback, type KeyboardEvent } from "react";
+
+interface CxSwitchProps {
+  checked: boolean;
+  onCheckedChange: (next: boolean) => void;
+  disabled?: boolean;
+  /** Accessible label. Required when not paired with a visible label via id. */
+  "aria-label"?: string;
+  "aria-labelledby"?: string;
+  id?: string;
+}
+
+export function CxSwitch({
+  checked,
+  onCheckedChange,
+  disabled = false,
+  id,
+  ...aria
+}: CxSwitchProps) {
+  const handleClick = useCallback(() => {
+    if (disabled) return;
+    onCheckedChange(!checked);
+  }, [checked, disabled, onCheckedChange]);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLButtonElement>) => {
+      // ARIA APG: Space toggles a switch (Enter is also a click; the
+      // browser dispatches a click for that automatically).
+      if (event.key === " ") {
+        event.preventDefault();
+        handleClick();
+      }
+    },
+    [handleClick],
+  );
+
+  return (
+    <button
+      type="button"
+      role="switch"
+      id={id}
+      aria-checked={checked}
+      aria-label={aria["aria-label"]}
+      aria-labelledby={aria["aria-labelledby"]}
+      disabled={disabled}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      className="inline-flex items-center transition-colors"
+      style={{
+        width: 34,
+        height: 19,
+        padding: 2,
+        borderRadius: 999,
+        background: checked
+          ? "var(--color-codex-accent)"
+          : "var(--color-codex-line-strong)",
+        cursor: disabled ? "not-allowed" : "pointer",
+        opacity: disabled ? 0.5 : 1,
+      }}
+      data-testid="cx-switch"
+    >
+      <span
+        aria-hidden="true"
+        style={{
+          width: 15,
+          height: 15,
+          borderRadius: 999,
+          background: "var(--color-codex-bg-elev)",
+          transform: checked ? "translateX(15px)" : "translateX(0)",
+          transition: "transform 0.15s",
+        }}
+      />
+    </button>
+  );
+}

--- a/web/src/components/codex/index.ts
+++ b/web/src/components/codex/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Codex primitives barrel — import from a single path:
+ *
+ *   import { CxLogo, CxStatus, CxPanel, CxFormRow, CxSwitch, CxSkeleton }
+ *     from "../components/codex";
+ *
+ * All primitives expect to render inside a ``theme-codex`` subtree
+ * so the CSS custom properties resolve. See
+ * ``design_handoff_aria_codex_redesign/README.md`` §"Implementation Order"
+ * step 2 for the full primitive catalogue.
+ */
+export { CxLogo } from "./CxLogo";
+export { CxStatus, type CxStatusTone } from "./CxStatus";
+export { CxPanel } from "./CxPanel";
+export { CxFormRow } from "./CxFormRow";
+export { CxSwitch } from "./CxSwitch";
+export { CxSkeleton } from "./CxSkeleton";


### PR DESCRIPTION
## What
Step 2 of the redesign per [design_handoff_aria_codex_redesign/README.md](design_handoff_aria_codex_redesign/README.md) §"Implementation Order".

**Six reusable primitives** in ``web/src/components/codex/``, exported via a barrel ``index.ts``. Like PR #25, this is **additive** — no existing page imports them yet. They become callable from any page once the per-page migration starts (PR 3/N = Login POC).

## Primitives
- **``CxStatus``** — 5–7px filled dot + label, mono font, tone-colored (neutral / accent / good / warn / bad / info / mute). ``pulse`` prop animates the dot.
- **``CxLogo``** — brand mark (small dark square with mono "a" + optional "Aria" wordmark). Token swap means light/dark both render without a duplicate asset.
- **``CxPanel``** — bordered titled card. Hairline border, no shadow. Header optional.
- **``CxFormRow``** — settings page row primitive. 180px label column + flexible control column, ``line-soft`` bottom hairline. ``divider={false}`` for last-row.
- **``CxSwitch``** — interactive toggle. The prototype's display-only ``CxSwitch({ on })`` upgraded to a proper controlled ``<button role="switch">`` with ``aria-checked``, ARIA APG keyboard (Space toggle), and disabled state.
- **``CxSkeleton``** — shimmer loading block. Configurable width/height/radius, ARIA ``status`` role.

## Test plan
- [x] ``vitest run src/components/codex`` → 25/25
- [x] ``vitest run`` (full suite) → 484/484 (was 459, +25 new)
- [x] ``tsc --noEmit`` clean
- [x] ``vite build`` clean
- [x] ``git diff --cached`` verified — exactly 13 new files staged, V0.0.5 WIP untouched

## Usage (forthcoming PRs)
\`\`\`tsx
import { CxLogo, CxStatus, CxPanel, CxFormRow, CxSwitch, CxSkeleton }
  from "../../components/codex";

<div className="theme-codex">
  <CxPanel title="项目档案" action={<CxStatus tone="good">已同步</CxStatus>}>
    <CxFormRow label="姓名" hint="登录用">
      <input />
    </CxFormRow>
  </CxPanel>
</div>
\`\`\`

## Next
PR 3/N — Login POC. First page using these primitives end-to-end, validates the token system in the browser, gives a concrete "new look" reference for the rest of the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)