### PR TITLE
Welcome / PreferenceOnboarding — Codex (V0.0.6 redesign · PR 4/N)

### DIFF
--- a/web/src/pages/PreferenceOnboarding.test.tsx
+++ b/web/src/pages/PreferenceOnboarding.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 
 const navigateMock = vi.fn();
@@ -30,7 +30,7 @@ beforeEach(() => {
 async function renderPage() {
   // PreferenceOnboarding is imported dynamically so the mocks above are in
   // place before the module evaluates.
-  const { PreferenceOnboarding, __test__ } = await import("./PreferenceOnboarding");
+  const { PreferenceOnboarding } = await import("./PreferenceOnboarding");
   const utils = render(
     <MemoryRouter>
       <PreferenceOnboarding />
@@ -39,7 +39,14 @@ async function renderPage() {
   await waitFor(() =>
     expect(screen.getByTestId("preference-onboarding-page")).toBeInTheDocument(),
   );
-  return { ...utils, __test__ };
+  return utils;
+}
+
+// Codex chip groups render as ``<div role=radiogroup><button role=radio>…``,
+// not native ``<select>``. Pick a chip by its visible label.
+function selectChip(groupTestId: string, label: string) {
+  const group = screen.getByTestId(groupTestId);
+  fireEvent.click(within(group).getByRole("radio", { name: label }));
 }
 
 describe("PreferenceOnboarding payload helpers", () => {
@@ -99,22 +106,43 @@ describe("PreferenceOnboarding payload helpers", () => {
 });
 
 describe("PreferenceOnboarding rendered behaviour", () => {
-  it("renders both columns once loaded", async () => {
+  it("renders the form column, chip groups, and the preview column", async () => {
     await renderPage();
     expect(screen.getByTestId("onb-preferred-name")).toBeInTheDocument();
     expect(screen.getByTestId("onb-language")).toBeInTheDocument();
+    expect(screen.getByTestId("onb-tone")).toBeInTheDocument();
+    expect(screen.getByTestId("onb-format")).toBeInTheDocument();
+    expect(screen.getByTestId("onb-ask")).toBeInTheDocument();
     expect(screen.getByTestId("preview-aria-reply")).toBeInTheDocument();
   });
 
-  it("preview re-renders as the user changes settings", async () => {
+  it("clicking a chip toggles aria-checked on the radio and re-renders the preview", async () => {
     await renderPage();
     const reply = screen.getByTestId("preview-aria-reply");
     const before = reply.textContent;
 
-    fireEvent.change(screen.getByTestId("onb-tone"), { target: { value: "friendly" } });
+    const toneGroup = screen.getByTestId("onb-tone");
+    const friendly = within(toneGroup).getByRole("radio", { name: "温和" });
+    expect(friendly).toHaveAttribute("aria-checked", "false");
+
+    fireEvent.click(friendly);
+
+    expect(friendly).toHaveAttribute("aria-checked", "true");
     await waitFor(() => {
       expect(screen.getByTestId("preview-aria-reply").textContent).not.toBe(before);
     });
+  });
+
+  it("clicking the active chip again clears the selection", async () => {
+    await renderPage();
+    const toneGroup = screen.getByTestId("onb-tone");
+    const direct = within(toneGroup).getByRole("radio", { name: "直接" });
+
+    fireEvent.click(direct);
+    expect(direct).toHaveAttribute("aria-checked", "true");
+
+    fireEvent.click(direct);
+    expect(direct).toHaveAttribute("aria-checked", "false");
   });
 
   it('"完成设置" PUTs the draft + stamps onboarding_seen + navigates to "/"', async () => {
@@ -122,7 +150,7 @@ describe("PreferenceOnboarding rendered behaviour", () => {
     fireEvent.change(screen.getByTestId("onb-preferred-name"), {
       target: { value: "李总" },
     });
-    fireEvent.change(screen.getByTestId("onb-language"), { target: { value: "zh" } });
+    selectChip("onb-language", "中文");
     fireEvent.click(screen.getByTestId("complete-onboarding"));
 
     await waitFor(() => expect(apiPut).toHaveBeenCalled());
@@ -141,7 +169,7 @@ describe("PreferenceOnboarding rendered behaviour", () => {
     fireEvent.change(screen.getByTestId("onb-preferred-name"), {
       target: { value: "Liang" },
     });
-    fireEvent.change(screen.getByTestId("onb-language"), { target: { value: "en" } });
+    selectChip("onb-language", "English");
 
     fireEvent.click(screen.getByTestId("skip-onboarding"));
 
@@ -159,5 +187,18 @@ describe("PreferenceOnboarding rendered behaviour", () => {
 
     expect(await screen.findByRole("alert")).toHaveTextContent("boom");
     expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("renders a setting → effect chip row once a tone is picked", async () => {
+    await renderPage();
+    // No effect rows visible before any chip is selected.
+    expect(screen.queryByText(/省去客套寒暄/)).not.toBeInTheDocument();
+
+    selectChip("onb-tone", "直接");
+
+    await waitFor(() => {
+      expect(screen.getByText("语气 · 直接")).toBeInTheDocument();
+      expect(screen.getByText(/省去客套寒暄/)).toBeInTheDocument();
+    });
   });
 });

--- a/web/src/pages/PreferenceOnboarding.tsx
+++ b/web/src/pages/PreferenceOnboarding.tsx
@@ -1,23 +1,29 @@
 /**
- * Post-login onboarding page (V0.0.4 follow-up).
+ * Post-login onboarding page — V0.0.6 Codex redesign (PR 4/N).
  *
- * Two-column layout:
- *   - Left: all AI personal preferences (称呼 / 语言 / 语气 / 结构 / 写入确认).
- *   - Right: a live "Aria 示范回复" card that re-renders as the user adjusts
- *     settings, so they feel the difference instead of guessing at it.
+ * Visual layout per
+ * ``design_handoff_aria_codex_redesign/direction-codex-more-2.jsx:158``:
  *
- * Gating:
- *   - All fields are optional.
- *   - "完成设置" saves whatever the user filled in + marks the onboarding as
- *     seen, then navigates to the workspace.
- *   - "稍后再说" saves only the onboarding-seen flag and navigates away.
- *   - Either way, the user is not redirected back here on the next login.
+ *   - Top bar: ``CxLogo`` left + "稍后再说 →" link right (no border row).
+ *   - Body grid 1fr | 1fr:
+ *     LEFT  — personalization form. 30s headline + 称呼 input + 4 chip
+ *             groups (语言 / 语气 / 结构 / 写入确认). Footer with
+ *             "完成设置" CTA.
+ *     RIGHT — live preview card with a faint dot grid, "Aria 会这样回应你"
+ *             header + pulse status, user bubble + Aria bubble with
+ *             cursor blink, "setting → effect" chip rows, and a dashed
+ *             accent-tinted footer note.
+ *
+ * The state machine, ``buildPayloadFromDraft`` / ``readDraftFromPreferences``,
+ * ``generatePreview``, and the /user-memory PUT semantics are unchanged
+ * from V0.0.4. Only the rendering layer was rewritten.
  */
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { ArrowRight, Loader2, MessageSquare, Sparkles } from "lucide-react";
+import { ArrowRight, Loader2, MessageSquare } from "lucide-react";
 
 import { api } from "../api/client";
+import { CxLogo, CxStatus } from "../components/codex";
 import { generatePreview } from "./preferenceOnboardingPreview";
 import type {
   PreviewFormat,
@@ -47,30 +53,34 @@ const EMPTY_DRAFT: DraftPreferences = {
   ask_before_destructive: "",
 };
 
-const LANGUAGE_OPTIONS: { value: PreviewLanguage; label: string }[] = [
-  { value: "", label: "未设置（由模型判断）" },
-  { value: "zh", label: "中文优先" },
-  { value: "en", label: "English first" },
-  { value: "auto", label: "跟随对话语言" },
+// Chip option lists — short labels per the Codex prototype so they fit
+// inside the pill button without wrapping. The underlying values stay
+// the same as V0.0.4 so persisted preferences round-trip cleanly.
+type LangValue = Exclude<PreviewLanguage, "">;
+type ToneValue = Exclude<PreviewTone, "">;
+type FormatValue = Exclude<PreviewFormat, "">;
+type AskValue = "true" | "false";
+
+const LANGUAGE_CHIPS: { value: LangValue; label: string }[] = [
+  { value: "auto", label: "跟你一致" },
+  { value: "zh", label: "中文" },
+  { value: "en", label: "English" },
 ];
 
-const TONE_OPTIONS: { value: PreviewTone; label: string }[] = [
-  { value: "", label: "未设置" },
-  { value: "direct", label: "直接、协作" },
-  { value: "friendly", label: "友好、亲和" },
-  { value: "formal", label: "正式、客户场合" },
+const TONE_CHIPS: { value: ToneValue; label: string }[] = [
+  { value: "direct", label: "直接" },
+  { value: "friendly", label: "温和" },
+  { value: "formal", label: "严谨" },
 ];
 
-const FORMAT_OPTIONS: { value: PreviewFormat; label: string }[] = [
-  { value: "", label: "未设置" },
-  { value: "conclusion_first", label: "先给结论再展开" },
-  { value: "free", label: "由模型自由判断" },
+const FORMAT_CHIPS: { value: FormatValue; label: string }[] = [
+  { value: "conclusion_first", label: "先结论" },
+  { value: "free", label: "自由" },
 ];
 
-const ASK_OPTIONS: { value: DraftPreferences["ask_before_destructive"]; label: string }[] = [
-  { value: "", label: "未设置" },
-  { value: "true", label: "是（更稳）" },
-  { value: "false", label: "否（更顺畅）" },
+const ASK_CHIPS: { value: AskValue; label: string }[] = [
+  { value: "true", label: "总是确认" },
+  { value: "false", label: "不必确认" },
 ];
 
 function readDraftFromPreferences(preferences: Record<string, unknown>): DraftPreferences {
@@ -183,208 +193,494 @@ export function PreferenceOnboarding() {
 
   if (loading) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-surface text-on-surface-muted">
+      <div
+        className="theme-codex flex min-h-screen items-center justify-center"
+        style={{ background: "var(--color-codex-bg)", color: "var(--color-codex-ink-mute)" }}
+      >
         <Loader2 className="h-6 w-6 animate-spin" />
       </div>
     );
   }
 
+  // Effect chips derived from the current draft — match the prototype's
+  // "setting · choice → impact on reply" row.
+  const effectRows = [
+    draft.tone === "direct"
+      ? { k: "语气 · 直接", e: "省去客套寒暄，直接给判断" }
+      : draft.tone === "friendly"
+        ? { k: "语气 · 温和", e: "保留同理心 + 简短背景，再给判断" }
+        : draft.tone === "formal"
+          ? { k: "语气 · 严谨", e: "用正式书面语，列出关键节点与依据" }
+          : null,
+    draft.format === "conclusion_first"
+      ? { k: "结构 · 先结论", e: "结论在前，理由在后" }
+      : draft.format === "free"
+        ? { k: "结构 · 自由", e: "由模型按场景自然展开" }
+        : null,
+    draft.language === "auto"
+      ? { k: "语言 · 跟你一致", e: "你用什么语言，它就用什么" }
+      : draft.language === "zh"
+        ? { k: "语言 · 中文", e: "默认用中文回答" }
+        : draft.language === "en"
+          ? { k: "语言 · English", e: "Defaults to English replies" }
+          : null,
+  ].filter((row): row is { k: string; e: string } => row !== null);
+
   return (
     <div
-      className="min-h-screen bg-gradient-to-br from-surface via-surface-container-lowest to-surface-container-low"
+      className="theme-codex flex min-h-screen flex-col"
+      style={{ background: "var(--color-codex-bg)", overflow: "hidden" }}
       data-testid="preference-onboarding-page"
     >
-      <header className="mx-auto flex max-w-6xl items-center justify-between px-6 py-5">
-        <div className="flex items-center gap-2 text-primary">
-          <Sparkles className="h-4 w-4" aria-hidden="true" />
-          <span className="font-manrope text-base font-semibold">Aria AI</span>
-        </div>
+      {/* Top bar — logo left, skip-link right. No bottom border. */}
+      <header
+        className="flex flex-shrink-0 items-center justify-between"
+        style={{ height: 56, padding: "0 36px" }}
+      >
+        <CxLogo size={22} />
         <button
           type="button"
           onClick={() => void handleSave("skipping")}
           disabled={saving !== null}
-          className="text-xs text-on-surface-muted underline-offset-4 transition hover:text-on-surface hover:underline disabled:opacity-50"
+          className="transition disabled:opacity-50"
+          style={{ fontSize: 12.5, color: "var(--color-codex-ink-mute)" }}
           data-testid="skip-onboarding"
         >
-          稍后再说
+          稍后再说 →
         </button>
       </header>
 
-      <main className="mx-auto grid max-w-6xl gap-8 px-6 pb-16 pt-2 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
-        {/* Left: settings */}
-        <section className="rounded-3xl border border-outline/10 bg-surface-container-lowest/80 p-7 shadow-sm backdrop-blur">
-          <div className="mb-5">
-            <h1 className="text-2xl font-semibold text-on-surface">
-              一起花 30 秒，把 Aria 调到顺手
+      {/* Split body — left form, right live preview. */}
+      <div
+        className="grid flex-1 lg:grid-cols-2"
+        style={{ padding: "8px 36px 36px", gap: 20, minHeight: 0 }}
+      >
+        {/* ---- LEFT — personalization form ---- */}
+        <section
+          className="flex flex-col overflow-hidden"
+          style={{
+            background: "var(--color-codex-bg-elev)",
+            border: "1px solid var(--color-codex-line)",
+            borderRadius: "var(--codex-r-lg, 10px)",
+            padding: "36px 40px",
+          }}
+        >
+          <div style={{ marginBottom: 24 }}>
+            <h1
+              style={{
+                margin: 0,
+                fontSize: 26,
+                fontWeight: 500,
+                color: "var(--color-codex-ink)",
+                letterSpacing: "-0.02em",
+                lineHeight: 1.3,
+              }}
+            >
+              一起花{" "}
+              <span
+                className="font-mono"
+                style={{ color: "var(--color-codex-accent)", fontVariantNumeric: "tabular-nums" }}
+              >
+                30
+              </span>{" "}
+              秒，把 Aria 调到顺手
             </h1>
-            <p className="mt-1.5 text-sm text-on-surface-muted">
+            <p
+              style={{
+                margin: "10px 0 0",
+                fontSize: 13.5,
+                color: "var(--color-codex-ink-mute)",
+                lineHeight: 1.65,
+              }}
+            >
               全部可选，之后随时可以在「设置 → AI 个人偏好」里调。
             </p>
           </div>
 
-          <div className="space-y-5">
-            <div>
-              <label
-                htmlFor="onb-preferred-name"
-                className="block text-sm font-medium text-on-surface"
-              >
-                Aria 怎么称呼你
-              </label>
-              <input
-                id="onb-preferred-name"
-                type="text"
-                value={draft.preferred_name}
-                onChange={(e) =>
-                  setDraft((cur) => ({ ...cur, preferred_name: e.target.value }))
-                }
-                placeholder="例如：李总、小李、Liang"
-                maxLength={40}
-                className="mt-1.5 w-full rounded-xl border border-outline/15 bg-surface-container-lowest px-3 py-2 text-sm text-on-surface outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/15"
-                autoComplete="off"
-                data-testid="onb-preferred-name"
-              />
-              <p className="mt-1 text-[11px] text-on-surface-muted">
-                最长 40 个字。留空也行，后续可以补。
-              </p>
-            </div>
-
-            <PrefSelect
-              label="回复语言"
-              value={draft.language}
-              onChange={(v) => setDraft((cur) => ({ ...cur, language: v as PreviewLanguage }))}
-              options={LANGUAGE_OPTIONS}
-              testId="onb-language"
-            />
-
-            <PrefSelect
-              label="回复语气"
-              value={draft.tone}
-              onChange={(v) => setDraft((cur) => ({ ...cur, tone: v as PreviewTone }))}
-              options={TONE_OPTIONS}
-              testId="onb-tone"
-            />
-
-            <PrefSelect
-              label="回复结构"
-              value={draft.format}
-              onChange={(v) => setDraft((cur) => ({ ...cur, format: v as PreviewFormat }))}
-              options={FORMAT_OPTIONS}
-              testId="onb-format"
-            />
-
-            <PrefSelect
-              label="写入/删除前是否再次确认"
-              value={draft.ask_before_destructive}
-              onChange={(v) =>
-                setDraft((cur) => ({
-                  ...cur,
-                  ask_before_destructive: v as DraftPreferences["ask_before_destructive"],
-                }))
+          {/* 称呼 input */}
+          <div style={{ marginBottom: 20 }}>
+            <label
+              htmlFor="onb-preferred-name"
+              style={{
+                fontSize: 13,
+                color: "var(--color-codex-ink)",
+                fontWeight: 500,
+                display: "block",
+                marginBottom: 8,
+              }}
+            >
+              Aria 怎么称呼你
+            </label>
+            <input
+              id="onb-preferred-name"
+              type="text"
+              value={draft.preferred_name}
+              onChange={(e) =>
+                setDraft((cur) => ({ ...cur, preferred_name: e.target.value }))
               }
-              options={ASK_OPTIONS}
-              testId="onb-ask"
+              placeholder="例如：李总、小李、Liang"
+              maxLength={40}
+              autoComplete="off"
+              className="codex-input"
+              style={{
+                width: "100%",
+                padding: "10px 14px",
+                fontSize: 13.5,
+                background: "var(--color-codex-bg)",
+                border: "1px solid var(--color-codex-line)",
+                borderRadius: "var(--codex-r-sm, 3px)",
+                color: "var(--color-codex-ink)",
+              }}
+              data-testid="onb-preferred-name"
             />
+            <div
+              style={{
+                fontSize: 11.5,
+                color: "var(--color-codex-ink-mute)",
+                marginTop: 6,
+              }}
+            >
+              最长 40 个字 · 留空也行，后续可以补
+            </div>
           </div>
+
+          {/* Chip groups */}
+          <PrefChips
+            label="回复语言"
+            value={draft.language}
+            options={LANGUAGE_CHIPS}
+            onChange={(v) => setDraft((cur) => ({ ...cur, language: v as PreviewLanguage }))}
+            groupTestId="onb-language"
+          />
+          <PrefChips
+            label="回复语气"
+            value={draft.tone}
+            options={TONE_CHIPS}
+            onChange={(v) => setDraft((cur) => ({ ...cur, tone: v as PreviewTone }))}
+            groupTestId="onb-tone"
+          />
+          <PrefChips
+            label="回复结构"
+            value={draft.format}
+            options={FORMAT_CHIPS}
+            onChange={(v) => setDraft((cur) => ({ ...cur, format: v as PreviewFormat }))}
+            groupTestId="onb-format"
+          />
+          <PrefChips
+            label="写入 / 删除前是否再次确认"
+            value={draft.ask_before_destructive}
+            options={ASK_CHIPS}
+            onChange={(v) =>
+              setDraft((cur) => ({
+                ...cur,
+                ask_before_destructive: v as DraftPreferences["ask_before_destructive"],
+              }))
+            }
+            groupTestId="onb-ask"
+          />
 
           {error ? (
             <p
               role="alert"
-              className="mt-4 rounded-lg bg-error/10 px-3 py-2 text-xs text-error"
+              style={{
+                marginTop: 16,
+                padding: "8px 12px",
+                background: "color-mix(in oklch, var(--color-codex-bad) 8%, transparent)",
+                border: "1px solid color-mix(in oklch, var(--color-codex-bad) 30%, transparent)",
+                borderRadius: "var(--codex-r-sm, 3px)",
+                color: "var(--color-codex-bad)",
+                fontSize: 12,
+              }}
             >
               {error}
             </p>
           ) : null}
 
-          <div className="mt-7 flex items-center justify-between">
-            <span className="text-[11px] text-on-surface-muted">所有设置仅对你自己生效</span>
+          {/* Footer — note left, CTA right */}
+          <div
+            className="mt-auto flex items-center justify-between"
+            style={{ paddingTop: 24 }}
+          >
+            <span style={{ fontSize: 12, color: "var(--color-codex-ink-mute)" }}>
+              所有设置仅对你自己生效
+            </span>
             <button
               type="button"
               onClick={() => void handleSave("completing")}
               disabled={saving !== null}
-              className="inline-flex items-center gap-2 rounded-xl bg-primary px-5 py-2.5 text-sm font-medium text-on-primary shadow-sm transition hover:shadow disabled:cursor-not-allowed disabled:opacity-50"
+              className="inline-flex items-center gap-2 transition disabled:cursor-not-allowed disabled:opacity-50"
+              style={{
+                padding: "10px 22px",
+                background: "var(--color-codex-ink)",
+                color: "var(--color-codex-bg-elev)",
+                borderRadius: "var(--codex-r-sm, 3px)",
+                fontSize: 13.5,
+                fontWeight: 500,
+              }}
               data-testid="complete-onboarding"
             >
               {saving === "completing" ? (
-                <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
               ) : (
-                <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                <>
+                  完成设置 <ArrowRight className="h-3 w-3" aria-hidden="true" />
+                </>
               )}
-              {saving === "completing" ? "保存中…" : "完成设置"}
+              {saving === "completing" ? "保存中…" : null}
             </button>
           </div>
         </section>
 
-        {/* Right: live preview */}
-        <section className="flex flex-col rounded-3xl border border-outline/10 bg-gradient-to-br from-primary/[0.04] via-surface-container-lowest/60 to-secondary-container/30 p-7 shadow-sm backdrop-blur">
-          <div className="mb-4 flex items-center gap-2 text-on-surface-muted">
-            <MessageSquare className="h-3.5 w-3.5" aria-hidden="true" />
-            <span className="text-xs font-medium uppercase tracking-wide">
+        {/* ---- RIGHT — live preview ---- */}
+        <section
+          className="relative flex flex-col overflow-hidden"
+          style={{
+            background: "var(--color-codex-bg-tint)",
+            border: "1px solid var(--color-codex-line-soft)",
+            borderRadius: "var(--codex-r-lg, 10px)",
+            padding: "32px 40px",
+            gap: 20,
+          }}
+        >
+          {/* Faint dot grid background */}
+          <div
+            aria-hidden="true"
+            style={{
+              position: "absolute",
+              inset: 0,
+              opacity: 0.35,
+              backgroundImage:
+                "radial-gradient(circle, var(--color-codex-line-strong) 1px, transparent 1px)",
+              backgroundSize: "22px 22px",
+              maskImage:
+                "radial-gradient(ellipse 80% 80% at 50% 30%, black 30%, transparent 90%)",
+              WebkitMaskImage:
+                "radial-gradient(ellipse 80% 80% at 50% 30%, black 30%, transparent 90%)",
+              pointerEvents: "none",
+            }}
+          />
+
+          {/* Header */}
+          <div
+            className="relative flex items-center gap-2"
+            style={{ color: "var(--color-codex-ink-mute)" }}
+          >
+            <MessageSquare className="h-3 w-3" aria-hidden="true" strokeWidth={1.5} />
+            <span
+              style={{
+                fontSize: 11.5,
+                fontWeight: 500,
+                letterSpacing: "0.06em",
+                textTransform: "uppercase",
+              }}
+            >
               Aria 会这样回应你
             </span>
+            <CxStatus tone="accent" pulse>
+              实时
+            </CxStatus>
           </div>
 
-          <div className="flex flex-1 flex-col gap-3" data-testid="preview-conversation">
+          <div
+            className="relative flex flex-col gap-4"
+            data-testid="preview-conversation"
+          >
+            {/* User bubble — right aligned */}
             <div className="flex justify-end">
-              <div className="max-w-[85%] rounded-2xl rounded-tr-sm bg-surface-container-low/80 px-4 py-2.5 text-sm text-on-surface shadow-sm">
+              <div
+                style={{
+                  maxWidth: "82%",
+                  background: "var(--color-codex-bg-elev)",
+                  border: "1px solid var(--color-codex-line)",
+                  padding: "10px 14px",
+                  borderRadius: "var(--codex-r-md, 6px)",
+                  fontSize: 13.5,
+                  color: "var(--color-codex-ink)",
+                  lineHeight: 1.6,
+                }}
+              >
                 {preview.userMessage}
               </div>
             </div>
 
-            <div className="flex items-start gap-2">
+            {/* Aria bubble — sparkle avatar + cursor blink */}
+            <div className="flex items-start gap-2.5">
               <span
-                className="mt-0.5 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-gradient-primary text-white"
                 aria-hidden="true"
+                className="codex-mono"
+                style={{
+                  width: 28,
+                  height: 28,
+                  borderRadius: 999,
+                  background: "var(--color-codex-accent)",
+                  color: "var(--color-codex-bg-elev)",
+                  display: "inline-flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  flexShrink: 0,
+                  fontSize: 13,
+                  fontWeight: 600,
+                  lineHeight: 1,
+                  letterSpacing: "-0.04em",
+                }}
               >
-                <Sparkles className="h-3.5 w-3.5" />
+                a
               </span>
               <div
-                className="max-w-[85%] whitespace-pre-line rounded-2xl rounded-tl-sm bg-surface-container-lowest px-4 py-3 text-sm leading-relaxed text-on-surface shadow-sm"
+                style={{
+                  flex: 1,
+                  maxWidth: "85%",
+                  background: "var(--color-codex-bg-elev)",
+                  border: "1px solid var(--color-codex-line)",
+                  padding: "12px 16px",
+                  borderRadius: "var(--codex-r-md, 6px)",
+                }}
                 data-testid="preview-aria-reply"
               >
-                {preview.ariaReply}
+                <p
+                  className="codex-cursor"
+                  style={{
+                    margin: 0,
+                    fontSize: 14,
+                    color: "var(--color-codex-ink)",
+                    lineHeight: 1.75,
+                    whiteSpace: "pre-line",
+                  }}
+                >
+                  {preview.ariaReply}
+                </p>
               </div>
             </div>
           </div>
 
-          <p className="mt-6 text-[11px] text-on-surface-muted">
-            这是示范，不是真的对话。改改左侧设置，右边会跟着变。
-          </p>
+          {/* Setting → effect chips — only rows for actively selected prefs */}
+          {effectRows.length > 0 && (
+            <div className="relative flex flex-col gap-2" style={{ marginTop: 4 }}>
+              {effectRows.map((row) => (
+                <div
+                  key={row.k}
+                  className="flex items-center gap-2.5"
+                  style={{ fontSize: 11.5, color: "var(--color-codex-ink-mute)" }}
+                >
+                  <span
+                    style={{
+                      padding: "2px 8px",
+                      background: "var(--color-codex-accent-bg)",
+                      color: "var(--color-codex-accent-ink)",
+                      borderRadius: "var(--codex-r-sm, 3px)",
+                      fontWeight: 500,
+                    }}
+                  >
+                    {row.k}
+                  </span>
+                  <ArrowRight
+                    className="h-2.5 w-2.5"
+                    aria-hidden="true"
+                    strokeWidth={1.5}
+                    style={{ color: "var(--color-codex-ink-faint)" }}
+                  />
+                  <span>{row.e}</span>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Footer note — dashed accent border */}
+          <div
+            className="relative mt-auto flex items-start gap-2"
+            style={{
+              padding: "10px 14px",
+              background:
+                "color-mix(in oklch, var(--color-codex-accent-bg) 50%, transparent)",
+              border:
+                "1px dashed color-mix(in oklch, var(--color-codex-accent) 35%, transparent)",
+              borderRadius: "var(--codex-r-sm, 3px)",
+              fontSize: 11.5,
+              color: "var(--color-codex-ink-mute)",
+            }}
+          >
+            <span
+              aria-hidden="true"
+              style={{
+                color: "var(--color-codex-accent)",
+                marginTop: 2,
+                flexShrink: 0,
+                fontSize: 11,
+              }}
+            >
+              ✦
+            </span>
+            <span>
+              这是示范，不是真的对话。改改左侧设置，右边会跟着变 — 你能看到每个偏好对回答的具体影响。
+            </span>
+          </div>
         </section>
-      </main>
+      </div>
     </div>
   );
 }
 
-interface PrefSelectProps<T extends string> {
+interface PrefChipsProps<T extends string> {
   label: string;
-  value: T;
+  value: T | "";
   options: { value: T; label: string }[];
-  onChange: (next: T) => void;
-  testId: string;
+  onChange: (next: T | "") => void;
+  groupTestId: string;
 }
 
-function PrefSelect<T extends string>({
+function PrefChips<T extends string>({
   label,
   value,
   options,
   onChange,
-  testId,
-}: PrefSelectProps<T>) {
+  groupTestId,
+}: PrefChipsProps<T>) {
   return (
-    <div>
-      <label className="block text-sm font-medium text-on-surface">{label}</label>
-      <select
-        value={value}
-        onChange={(e) => onChange(e.target.value as T)}
-        className="mt-1.5 w-full rounded-xl border border-outline/15 bg-surface-container-lowest px-3 py-2 text-sm text-on-surface outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/15"
-        data-testid={testId}
+    <div style={{ marginBottom: 18 }} data-testid={groupTestId}>
+      <div
+        style={{
+          fontSize: 13,
+          color: "var(--color-codex-ink)",
+          fontWeight: 500,
+          marginBottom: 8,
+        }}
       >
-        {options.map((o) => (
-          <option key={o.value} value={o.value}>
-            {o.label}
-          </option>
-        ))}
-      </select>
+        {label}
+      </div>
+      <div role="radiogroup" aria-label={label} className="flex flex-wrap gap-1.5">
+        {options.map((opt) => {
+          const active = value === opt.value;
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              role="radio"
+              aria-checked={active}
+              onClick={() => onChange(active ? "" : opt.value)}
+              className="transition"
+              style={{
+                padding: "6px 12px",
+                fontSize: 12.5,
+                color: active
+                  ? "var(--color-codex-accent-ink)"
+                  : "var(--color-codex-ink-soft)",
+                background: active
+                  ? "var(--color-codex-accent-bg)"
+                  : "var(--color-codex-bg)",
+                border: `1px solid ${
+                  active
+                    ? "color-mix(in oklch, var(--color-codex-accent) 50%, transparent)"
+                    : "var(--color-codex-line)"
+                }`,
+                borderRadius: "var(--codex-r-pill, 999px)",
+                fontWeight: active ? 500 : 400,
+              }}
+            >
+              {opt.label}
+            </button>
+          );
+        })}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## What
Refactors the post-login onboarding page to the Codex visual language per [direction-codex-more-2.jsx:158](design_handoff_aria_codex_redesign/direction-codex-more-2.jsx#L158).

Auth-adjacent, still low blast radius, **zero overlap with the V0.0.5 knowledge WIP** in the working tree.

## Layout
- **Top bar**: ``CxLogo`` left, "稍后再说 →" link right, no border row.
- **Body 2-col grid** (1fr | 1fr).
- **LEFT card**:
  - Headline "一起花 **30** 秒，把 Aria 调到顺手" — 30 in mono + accent.
  - 称呼 input with hint copy.
  - **Four chip groups** instead of selects (语言 / 语气 / 结构 / 写入确认). Each chip is ``<button role="radio">`` inside ``<div role="radiogroup">``. Active = accent-bg fill; click-again clears.
  - Footer: 12px note + dark "完成设置 →" button.
- **RIGHT card** (preview):
  - Faint dot grid background.
  - "ARIA 会这样回应你" + accent ``CxStatus`` pulse.
  - User bubble + Aria bubble with mono "a" avatar + ``codex-cursor`` blink.
  - **Setting · choice → impact** rows that render only for actively selected prefs.
  - Dashed-border accent footer note.

## What's unchanged
- ``buildPayloadFromDraft`` / ``readDraftFromPreferences`` / ``generatePreview`` / /user-memory PUT semantics / ``onboarding_seen`` stamping / skip-wipes-draft behavior.
- Underlying option values unchanged — only display labels shortened to fit chip pills. Existing saved preferences round-trip cleanly.

## Tests
Selector pattern updated for chip controls:
- Before: ``fireEvent.change(getByTestId, { target: { value } })`` (worked on ``<select>``)
- After: ``fireEvent.click(within(group).getByRole("radio", { name }))``

New assertions:
- chip click toggles ``aria-checked`` AND re-renders the preview;
- clicking active chip clears the selection;
- "setting → effect" preview row appears only after a choice is made.

## Test plan
- [x] ``vitest run src/pages/PreferenceOnboarding.test.tsx`` → 10/10 (was 7; +3 new)
- [x] ``vitest run`` (full) → 489/489 (was 487, +2 net)
- [x] ``tsc --noEmit`` clean
- [x] ``vite build`` clean
- [x] ``git diff --cached`` reviewed — only the 2 PreferenceOnboarding files staged. V0.0.5 WIP untouched
- [ ] **Manual after deploy**: open https://aria.d2cgo.co/onboarding as a user with no ``onboarding_seen`` flag → verify chip layout + preview behavior. Try picking + unpicking a tone chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)