### PR TITLE
Settings · Profile + Language — Codex (V0.0.6 redesign · PR 6/N)

### DIFF
--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -437,6 +437,8 @@
   "language": {
     "title": "Language Settings",
     "description": "Select your preferred language",
+    "interfaceLanguage": "Interface language",
+    "interfaceLanguageHint": "Preview applies instantly. Save persists to the server and syncs across devices.",
     "save": "Save Settings",
     "saving": "Saving…",
     "saved": "Saved"

--- a/web/src/i18n/locales/zh.json
+++ b/web/src/i18n/locales/zh.json
@@ -436,6 +436,8 @@
   "language": {
     "title": "语言设置",
     "description": "选择您的首选语言",
+    "interfaceLanguage": "界面语言",
+    "interfaceLanguageHint": "切换后立即预览，保存后写入服务器并同步到其他设备。",
     "save": "保存设置",
     "saving": "保存中…",
     "saved": "已保存"

--- a/web/src/pages/settings/LanguageSettings.tsx
+++ b/web/src/pages/settings/LanguageSettings.tsx
@@ -1,148 +1,253 @@
-import { useState, useEffect } from 'react'
-import { Check, Loader2, AlertCircle } from 'lucide-react'
-import { useTranslation } from 'react-i18next'
-import { api } from '../../api/client'
-import { changeLanguage } from '../../i18n'
+/**
+ * Settings → 语言 — V0.0.6 Codex redesign (PR 6/N).
+ *
+ * Visual layout per
+ * ``design_handoff_aria_codex_redesign/direction-codex-settings.jsx:118``
+ * (the "界面语言" section of the prototype's CxSettingsLanguage —
+ * timezone, date format, and week-start are deliberately kept on the
+ * Profile page where they already live to avoid scope churn).
+ *
+ * State machine unchanged: ``selectedLanguage`` mirrors i18n + backend
+ * ``/settings/language``, ``handleLanguageChange`` previews immediately,
+ * ``handleSave`` PUTs to the backend.
+ */
+import { useEffect, useState } from "react";
+import { AlertCircle, Check, Loader2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
 
-const languages = [
-  { code: 'zh-CN', name: '简体中文', flag: '🇨🇳' },
-  { code: 'en-US', name: 'English', flag: '🇺🇸' },
-]
+import { api } from "../../api/client";
+import { CxFormRow } from "../../components/codex";
+import { changeLanguage } from "../../i18n";
+
+const LANGUAGES: { code: string; name: string; flag: string }[] = [
+  { code: "zh-CN", name: "简体中文", flag: "🇨🇳" },
+  { code: "en-US", name: "English", flag: "🇺🇸" },
+];
 
 export function LanguageSettings() {
-  const { t, i18n } = useTranslation()
-  const [selectedLanguage, setSelectedLanguage] = useState(i18n.language || 'zh-CN')
-  const [saved, setSaved] = useState(false)
-  const [loading, setLoading] = useState(false)
-  const [initialLoading, setInitialLoading] = useState(true)
-  const [error, setError] = useState('')
+  const { t, i18n } = useTranslation();
+  const [selectedLanguage, setSelectedLanguage] = useState(i18n.language || "zh-CN");
+  const [saved, setSaved] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [initialLoading, setInitialLoading] = useState(true);
+  const [error, setError] = useState("");
 
-  // Load settings on mount
   useEffect(() => {
-    loadSettings()
-  }, [])
+    void loadSettings();
+    // loadSettings has no React deps; intentional empty array.
+  }, []);
 
   const loadSettings = async () => {
     try {
-      setInitialLoading(true)
-      setError('')
-      
-      const settings = await api.get<Record<string, string>>('/settings/')
-      
+      setInitialLoading(true);
+      setError("");
+      const settings = await api.get<Record<string, string>>("/settings/");
       if (settings.language) {
-        setSelectedLanguage(settings.language)
-        // Apply loaded language immediately
-        changeLanguage(settings.language)
+        setSelectedLanguage(settings.language);
+        changeLanguage(settings.language);
       }
     } catch {
-      // Silent fail - use default or localStorage
-      const savedLang = localStorage.getItem('language')
+      const savedLang = typeof window !== "undefined" ? window.localStorage.getItem("language") : null;
       if (savedLang) {
-        setSelectedLanguage(savedLang)
-        changeLanguage(savedLang)
+        setSelectedLanguage(savedLang);
+        changeLanguage(savedLang);
       }
     } finally {
-      setInitialLoading(false)
+      setInitialLoading(false);
     }
-  }
+  };
 
   const handleLanguageChange = (langCode: string) => {
-    setSelectedLanguage(langCode)
-    // Apply language immediately for preview
-    changeLanguage(langCode)
-  }
+    setSelectedLanguage(langCode);
+    changeLanguage(langCode);
+  };
 
   const handleSave = async () => {
-    setLoading(true)
-    setSaved(false)
-    setError('')
-
+    setLoading(true);
+    setSaved(false);
+    setError("");
     try {
-      // Save to backend
-      await api.put('/settings/language', { value: selectedLanguage })
-      
-      // Apply language
-      changeLanguage(selectedLanguage)
-      
-      setSaved(true)
-      setTimeout(() => setSaved(false), 2000)
-    } catch (err: any) {
-      setError(err.response?.data?.detail || err.message || 'Failed to save settings')
-      // Still apply language locally even if backend fails
-      changeLanguage(selectedLanguage)
+      await api.put("/settings/language", { value: selectedLanguage });
+      changeLanguage(selectedLanguage);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch (err) {
+      const detail =
+        (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
+      setError(detail || (err instanceof Error ? err.message : "Failed to save settings"));
+      changeLanguage(selectedLanguage);
     } finally {
-      setLoading(false)
+      setLoading(false);
     }
-  }
+  };
 
   if (initialLoading) {
     return (
-      <div className="flex items-center justify-center py-12">
-        <Loader2 className="w-6 h-6 text-primary animate-spin" />
+      <div
+        className="theme-codex flex items-center justify-center"
+        style={{ padding: "48px 0", color: "var(--color-codex-ink-mute)" }}
+      >
+        <Loader2 className="h-5 w-5 animate-spin" />
       </div>
-    )
+    );
   }
 
   return (
-    <div>
-      <h2 className="text-lg font-semibold text-on-surface mb-1">{t('language.title')}</h2>
-      <p className="text-sm text-on-surface-muted mb-6">{t('language.description')}</p>
+    <div
+      className="theme-codex"
+      data-testid="language-settings"
+      style={{
+        background: "var(--color-codex-bg)",
+        color: "var(--color-codex-ink)",
+        padding: "8px 4px 32px",
+      }}
+    >
+      <header style={{ marginBottom: 16 }}>
+        <h1
+          style={{
+            margin: 0,
+            fontSize: 22,
+            fontWeight: 500,
+            color: "var(--color-codex-ink)",
+            letterSpacing: "-0.015em",
+          }}
+        >
+          {t("language.title")}
+        </h1>
+        <p
+          style={{
+            margin: "6px 0 0",
+            fontSize: 13,
+            color: "var(--color-codex-ink-mute)",
+            lineHeight: 1.6,
+          }}
+        >
+          {t("language.description")}
+        </p>
+      </header>
 
       {error && (
-        <div className="mb-4 p-3 bg-error/10 border border-error/20 rounded-lg flex items-center gap-2 text-error text-sm">
-          <AlertCircle className="w-4 h-4" />
+        <div
+          role="alert"
+          className="mb-4 flex items-center gap-2"
+          style={{
+            padding: "9px 12px",
+            background: "color-mix(in oklch, var(--color-codex-bad) 8%, transparent)",
+            border: "1px solid color-mix(in oklch, var(--color-codex-bad) 30%, transparent)",
+            borderRadius: "var(--codex-r-sm, 3px)",
+            color: "var(--color-codex-bad)",
+            fontSize: 12,
+          }}
+        >
+          <AlertCircle className="h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />
           {error}
         </div>
       )}
 
-      <div className="space-y-3">
-        {languages.map(lang => (
-          <div
-            key={lang.code}
-            onClick={() => handleLanguageChange(lang.code)}
-            className={`flex items-center justify-between p-4 rounded-xl border-2 cursor-pointer transition-all ${
-              selectedLanguage === lang.code
-                ? 'border-primary bg-secondary-container/30'
-                : 'border-outline/20 hover:border-outline/50'
-            }`}
-          >
-            <div className="flex items-center gap-3">
-              <span className="text-2xl">{lang.flag}</span>
-              <div>
-                <span className="font-medium text-on-surface">{lang.name}</span>
-                <p className="text-xs text-on-surface-muted">{lang.code}</p>
-              </div>
-            </div>
-            {selectedLanguage === lang.code && (
-              <div className="w-6 h-6 bg-primary rounded-full flex items-center justify-center">
-                <Check className="w-3.5 h-3.5 text-white" />
-              </div>
-            )}
-          </div>
-        ))}
-      </div>
+      <CxFormRow
+        label={t("language.interfaceLanguage") || "界面语言"}
+        hint={t("language.interfaceLanguageHint") || "切换后立即预览，保存后写入服务器并同步到其他设备。"}
+        divider={false}
+      >
+        <div
+          role="radiogroup"
+          aria-label={t("language.interfaceLanguage") || "界面语言"}
+          className="flex flex-wrap gap-2"
+          data-testid="language-options"
+        >
+          {LANGUAGES.map((lang) => {
+            const active = selectedLanguage === lang.code;
+            return (
+              <button
+                key={lang.code}
+                type="button"
+                role="radio"
+                aria-checked={active}
+                aria-label={lang.name}
+                onClick={() => handleLanguageChange(lang.code)}
+                className="inline-flex items-center gap-2 transition"
+                style={{
+                  padding: "8px 14px",
+                  border: `1px solid ${
+                    active
+                      ? "var(--color-codex-accent)"
+                      : "var(--color-codex-line)"
+                  }`,
+                  background: active
+                    ? "var(--color-codex-accent-bg)"
+                    : "var(--color-codex-bg-elev)",
+                  borderRadius: "var(--codex-r-sm, 3px)",
+                  color: active
+                    ? "var(--color-codex-accent-ink)"
+                    : "var(--color-codex-ink-soft)",
+                  fontSize: 13,
+                  fontWeight: active ? 500 : 400,
+                  cursor: "pointer",
+                }}
+              >
+                <span
+                  aria-hidden="true"
+                  className="inline-flex items-center justify-center"
+                  style={{
+                    width: 14,
+                    height: 14,
+                    borderRadius: 999,
+                    border: `1.5px solid ${
+                      active
+                        ? "var(--color-codex-accent)"
+                        : "var(--color-codex-line-strong)"
+                    }`,
+                  }}
+                >
+                  {active && (
+                    <span
+                      style={{
+                        width: 6,
+                        height: 6,
+                        borderRadius: 999,
+                        background: "var(--color-codex-accent)",
+                      }}
+                    />
+                  )}
+                </span>
+                <span aria-hidden="true">{lang.flag}</span>
+                {lang.name}
+              </button>
+            );
+          })}
+        </div>
+      </CxFormRow>
 
-      <div className="mt-6 pt-4 border-t border-outline/10">
+      <div style={{ marginTop: 24 }}>
         <button
-          onClick={handleSave}
+          type="button"
+          onClick={() => void handleSave()}
           disabled={loading}
-          className="flex items-center gap-2 px-4 py-2.5 bg-primary hover:bg-primary/90 disabled:opacity-50 text-white rounded-xl font-medium transition-all"
+          className="inline-flex items-center gap-2 transition disabled:cursor-not-allowed disabled:opacity-60"
+          style={{
+            padding: "9px 18px",
+            background: "var(--color-codex-ink)",
+            color: "var(--color-codex-bg-elev)",
+            borderRadius: "var(--codex-r-sm, 3px)",
+            fontSize: 13,
+            fontWeight: 500,
+          }}
         >
           {loading ? (
             <>
-              <Loader2 className="w-4 h-4 animate-spin" />
-              {t('language.saving')}
+              <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+              {t("language.saving")}
             </>
           ) : saved ? (
             <>
-              <Check className="w-4 h-4" />
-              {t('language.saved')}
+              <Check className="h-3.5 w-3.5" aria-hidden="true" />
+              {t("language.saved")}
             </>
           ) : (
-            t('language.save')
+            t("language.save")
           )}
         </button>
       </div>
     </div>
-  )
+  );
 }

--- a/web/src/pages/settings/ProfileSettings.tsx
+++ b/web/src/pages/settings/ProfileSettings.tsx
@@ -1,455 +1,814 @@
-import { useState, useEffect } from 'react'
-import { User, Mail, KeyRound, Check, Loader2, AlertCircle, X, Lock, Clock3, Type } from 'lucide-react'
-import { api } from '../../api/client'
-import type { User as UserType } from '../../types/api'
-import { BROWSER_TIMEZONE_VALUE, DEFAULT_APP_TIMEZONE, getBrowserTimeZone, setAppTimeZone } from '../../utils/timezone'
-import { UserMemorySettingsCard } from './UserMemorySettingsCard'
+/**
+ * Settings → 个人资料 — V0.0.6 Codex redesign (PR 6/N).
+ *
+ * Visual layout per
+ * ``design_handoff_aria_codex_redesign/direction-codex-settings.jsx:90``,
+ * extended to keep the existing app's additional fields (时区, 字体大小,
+ * 密码修改, AI 个人偏好). Every CxFormRow renders one field; the per-row
+ * save buttons sit in the value column next to the control they save.
+ *
+ * State machine + API surface unchanged: ``/auth/me``, ``/settings/``,
+ * ``/auth/users/:id`` (PATCH display_name), ``/settings/timezone``,
+ * ``/settings/${APP_FONT_SIZE_SETTING_KEY}``, ``/auth/change-password``.
+ * The UserMemorySettingsCard remains a self-contained card embedded
+ * below — its own visual refactor will be a later PR.
+ */
+import { useEffect, useState, type FormEvent } from "react";
+import {
+  AlertCircle,
+  Check,
+  Clock3,
+  KeyRound,
+  Loader2,
+  Lock,
+  Mail,
+  Type,
+  User as UserIcon,
+  X,
+} from "lucide-react";
+
+import { api } from "../../api/client";
+import { CxFormRow } from "../../components/codex";
+import type { User as UserType } from "../../types/api";
+import {
+  BROWSER_TIMEZONE_VALUE,
+  DEFAULT_APP_TIMEZONE,
+  getBrowserTimeZone,
+  setAppTimeZone,
+} from "../../utils/timezone";
+import { UserMemorySettingsCard } from "./UserMemorySettingsCard";
 import {
   APP_FONT_SIZE_SETTING_KEY,
   getStoredAppFontSize,
   isAppFontSize,
   setAppFontSize,
   type AppFontSize,
-} from '../../utils/fontSize'
+} from "../../utils/fontSize";
 
-const fontSizeOptions: { value: AppFontSize; label: string; previewClass: string }[] = [
-  { value: 'small', label: '小', previewClass: 'text-[13px]' },
-  { value: 'medium', label: '中', previewClass: 'text-[15px]' },
-  { value: 'large', label: '大', previewClass: 'text-[17px]' },
-]
+interface SavedMessage {
+  type: "success" | "error";
+  text: string;
+}
 
-const timezoneOptions = [
-  { value: 'Asia/Shanghai', label: '中国标准时间', hint: 'UTC+08:00' },
-  { value: BROWSER_TIMEZONE_VALUE, label: '跟随浏览器', hint: '' },
-  { value: 'UTC', label: '协调世界时', hint: 'UTC+00:00' },
-  { value: 'Asia/Tokyo', label: '日本标准时间', hint: 'UTC+09:00' },
-  { value: 'America/Los_Angeles', label: '洛杉矶时间', hint: 'UTC-08:00 / -07:00' },
-  { value: 'America/New_York', label: '纽约时间', hint: 'UTC-05:00 / -04:00' },
-  { value: 'Europe/London', label: '伦敦时间', hint: 'UTC+00:00 / +01:00' },
-]
+const FONT_SIZE_OPTIONS: { value: AppFontSize; label: string; previewClass: string }[] = [
+  { value: "small", label: "小", previewClass: "text-[13px]" },
+  { value: "medium", label: "中", previewClass: "text-[15px]" },
+  { value: "large", label: "大", previewClass: "text-[17px]" },
+];
+
+const TIMEZONE_OPTIONS = [
+  { value: "Asia/Shanghai", label: "中国标准时间", hint: "UTC+08:00" },
+  { value: BROWSER_TIMEZONE_VALUE, label: "跟随浏览器", hint: "" },
+  { value: "UTC", label: "协调世界时", hint: "UTC+00:00" },
+  { value: "Asia/Tokyo", label: "日本标准时间", hint: "UTC+09:00" },
+  { value: "America/Los_Angeles", label: "洛杉矶时间", hint: "UTC-08:00 / -07:00" },
+  { value: "America/New_York", label: "纽约时间", hint: "UTC-05:00 / -04:00" },
+  { value: "Europe/London", label: "伦敦时间", hint: "UTC+00:00 / +01:00" },
+];
+
+const INPUT_STYLE = {
+  width: "100%",
+  padding: "8px 12px",
+  fontSize: 13.5,
+  background: "var(--color-codex-bg)",
+  border: "1px solid var(--color-codex-line)",
+  borderRadius: "var(--codex-r-sm, 3px)",
+  color: "var(--color-codex-ink)",
+};
+
+const SAVE_BUTTON_STYLE = {
+  padding: "8px 16px",
+  background: "var(--color-codex-ink)",
+  color: "var(--color-codex-bg-elev)",
+  borderRadius: "var(--codex-r-sm, 3px)",
+  fontSize: 13,
+  fontWeight: 500,
+};
+
+const GHOST_BUTTON_STYLE = {
+  padding: "7px 14px",
+  fontSize: 12.5,
+  color: "var(--color-codex-ink-soft)",
+  border: "1px solid var(--color-codex-line)",
+  borderRadius: "var(--codex-r-sm, 3px)",
+  background: "var(--color-codex-bg-elev)",
+};
 
 export function ProfileSettings() {
-  const [user, setUser] = useState<UserType | null>(null)
-  const [displayName, setDisplayName] = useState('')
-  const [savingName, setSavingName] = useState(false)
-  const [nameMsg, setNameMsg] = useState<{ type: 'success' | 'error'; text: string } | null>(null)
-  const [selectedTimeZone, setSelectedTimeZone] = useState(DEFAULT_APP_TIMEZONE)
-  const [savingTimeZone, setSavingTimeZone] = useState(false)
-  const [timeZoneMsg, setTimeZoneMsg] = useState<{ type: 'success' | 'error'; text: string } | null>(null)
-  const [selectedFontSize, setSelectedFontSize] = useState<AppFontSize>(getStoredAppFontSize)
-  const [savingFontSize, setSavingFontSize] = useState(false)
-  const [fontSizeMsg, setFontSizeMsg] = useState<{ type: 'success' | 'error'; text: string } | null>(null)
+  const [user, setUser] = useState<UserType | null>(null);
+  const [displayName, setDisplayName] = useState("");
+  const [savingName, setSavingName] = useState(false);
+  const [nameMsg, setNameMsg] = useState<SavedMessage | null>(null);
 
-  // Password dialog state
-  const [showPasswordDialog, setShowPasswordDialog] = useState(false)
-  const [currentPassword, setCurrentPassword] = useState('')
-  const [newPassword, setNewPassword] = useState('')
-  const [confirmPassword, setConfirmPassword] = useState('')
-  const [savingPwd, setSavingPwd] = useState(false)
-  const [pwdMsg, setPwdMsg] = useState<{ type: 'success' | 'error'; text: string } | null>(null)
+  const [selectedTimeZone, setSelectedTimeZone] = useState(DEFAULT_APP_TIMEZONE);
+  const [savingTimeZone, setSavingTimeZone] = useState(false);
+  const [timeZoneMsg, setTimeZoneMsg] = useState<SavedMessage | null>(null);
+
+  const [selectedFontSize, setSelectedFontSize] = useState<AppFontSize>(getStoredAppFontSize);
+  const [savingFontSize, setSavingFontSize] = useState(false);
+  const [fontSizeMsg, setFontSizeMsg] = useState<SavedMessage | null>(null);
+
+  // Password dialog
+  const [showPasswordDialog, setShowPasswordDialog] = useState(false);
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [savingPwd, setSavingPwd] = useState(false);
+  const [pwdMsg, setPwdMsg] = useState<SavedMessage | null>(null);
 
   useEffect(() => {
     Promise.all([
-      api.get<UserType>('/auth/me'),
-      api.get<Record<string, string>>('/settings/').catch(() => ({} as Record<string, string>)),
-    ]).then(([u, settings]) => {
-      setUser(u)
-      setDisplayName(u.display_name)
-      setSelectedTimeZone(settings.timezone || DEFAULT_APP_TIMEZONE)
-      const remoteFontSize = settings[APP_FONT_SIZE_SETTING_KEY]
-      if (isAppFontSize(remoteFontSize)) {
-        // Sync the server value down to this device (apply + persist locally).
-        setSelectedFontSize(remoteFontSize)
-        setAppFontSize(remoteFontSize)
-      }
-    }).catch(() => {})
-  }, [])
-
-  const handleSelectFontSize = (value: AppFontSize) => {
-    setSelectedFontSize(value)
-    setAppFontSize(value) // live preview + local persistence
-    setFontSizeMsg(null)
-  }
-
-  const handleSaveFontSize = async () => {
-    setSavingFontSize(true)
-    setFontSizeMsg(null)
-    try {
-      await api.put(`/settings/${APP_FONT_SIZE_SETTING_KEY}`, { value: selectedFontSize })
-      setAppFontSize(selectedFontSize)
-      setFontSizeMsg({ type: 'success', text: '字体大小已保存' })
-      setTimeout(() => setFontSizeMsg(null), 3000)
-    } catch (err: any) {
-      setFontSizeMsg({ type: 'error', text: err.response?.data?.detail || '保存字体大小失败' })
-    } finally {
-      setSavingFontSize(false)
-    }
-  }
+      api.get<UserType>("/auth/me"),
+      api.get<Record<string, string>>("/settings/").catch(() => ({}) as Record<string, string>),
+    ])
+      .then(([u, settings]) => {
+        setUser(u);
+        setDisplayName(u.display_name);
+        setSelectedTimeZone(settings.timezone || DEFAULT_APP_TIMEZONE);
+        const remoteFontSize = settings[APP_FONT_SIZE_SETTING_KEY];
+        if (isAppFontSize(remoteFontSize)) {
+          setSelectedFontSize(remoteFontSize);
+          setAppFontSize(remoteFontSize);
+        }
+      })
+      .catch(() => {});
+  }, []);
 
   const handleSaveName = async () => {
-    if (!user || !displayName.trim()) return
-    setSavingName(true)
-    setNameMsg(null)
+    if (!user || !displayName.trim()) return;
+    setSavingName(true);
+    setNameMsg(null);
     try {
-      await api.patch(`/auth/users/${user.id}`, { display_name: displayName.trim() })
-      setNameMsg({ type: 'success', text: '已保存' })
-      setTimeout(() => setNameMsg(null), 3000)
-    } catch (err: any) {
-      setNameMsg({ type: 'error', text: err.response?.data?.detail || '保存失败' })
+      await api.patch(`/auth/users/${user.id}`, { display_name: displayName.trim() });
+      setNameMsg({ type: "success", text: "已保存" });
+      setTimeout(() => setNameMsg(null), 3000);
+    } catch (err) {
+      const detail =
+        (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
+      setNameMsg({ type: "error", text: detail || "保存失败" });
     } finally {
-      setSavingName(false)
+      setSavingName(false);
     }
-  }
+  };
 
   const handleSaveTimeZone = async () => {
-    setSavingTimeZone(true)
-    setTimeZoneMsg(null)
+    setSavingTimeZone(true);
+    setTimeZoneMsg(null);
     try {
-      await api.put('/settings/timezone', { value: selectedTimeZone })
-      setAppTimeZone(selectedTimeZone)
-      setTimeZoneMsg({ type: 'success', text: '时区已保存' })
-      setTimeout(() => setTimeZoneMsg(null), 3000)
-    } catch (err: any) {
-      setTimeZoneMsg({ type: 'error', text: err.response?.data?.detail || '保存时区失败' })
+      await api.put("/settings/timezone", { value: selectedTimeZone });
+      setAppTimeZone(selectedTimeZone);
+      setTimeZoneMsg({ type: "success", text: "时区已保存" });
+      setTimeout(() => setTimeZoneMsg(null), 3000);
+    } catch (err) {
+      const detail =
+        (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
+      setTimeZoneMsg({ type: "error", text: detail || "保存时区失败" });
     } finally {
-      setSavingTimeZone(false)
+      setSavingTimeZone(false);
     }
-  }
+  };
+
+  const handleSelectFontSize = (value: AppFontSize) => {
+    setSelectedFontSize(value);
+    setAppFontSize(value); // live preview + local persistence
+    setFontSizeMsg(null);
+  };
+
+  const handleSaveFontSize = async () => {
+    setSavingFontSize(true);
+    setFontSizeMsg(null);
+    try {
+      await api.put(`/settings/${APP_FONT_SIZE_SETTING_KEY}`, { value: selectedFontSize });
+      setAppFontSize(selectedFontSize);
+      setFontSizeMsg({ type: "success", text: "字体大小已保存" });
+      setTimeout(() => setFontSizeMsg(null), 3000);
+    } catch (err) {
+      const detail =
+        (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
+      setFontSizeMsg({ type: "error", text: detail || "保存字体大小失败" });
+    } finally {
+      setSavingFontSize(false);
+    }
+  };
 
   const openPasswordDialog = () => {
-    setCurrentPassword('')
-    setNewPassword('')
-    setConfirmPassword('')
-    setPwdMsg(null)
-    setShowPasswordDialog(true)
-  }
+    setCurrentPassword("");
+    setNewPassword("");
+    setConfirmPassword("");
+    setPwdMsg(null);
+    setShowPasswordDialog(true);
+  };
 
   const closePasswordDialog = () => {
-    if (savingPwd) return
-    setShowPasswordDialog(false)
-    setCurrentPassword('')
-    setNewPassword('')
-    setConfirmPassword('')
-    setPwdMsg(null)
-  }
+    if (savingPwd) return;
+    setShowPasswordDialog(false);
+    setCurrentPassword("");
+    setNewPassword("");
+    setConfirmPassword("");
+    setPwdMsg(null);
+  };
 
-  const handleChangePassword = async (e: React.FormEvent) => {
-    e.preventDefault()
+  const handleChangePassword = async (event: FormEvent) => {
+    event.preventDefault();
     if (newPassword !== confirmPassword) {
-      setPwdMsg({ type: 'error', text: '两次输入的新密码不一致' })
-      return
+      setPwdMsg({ type: "error", text: "两次输入的新密码不一致" });
+      return;
     }
     if (newPassword.length < 6) {
-      setPwdMsg({ type: 'error', text: '新密码至少需要6位' })
-      return
+      setPwdMsg({ type: "error", text: "新密码至少需要6位" });
+      return;
     }
-    setSavingPwd(true)
-    setPwdMsg(null)
+    setSavingPwd(true);
+    setPwdMsg(null);
     try {
-      await api.post('/auth/change-password', {
+      await api.post("/auth/change-password", {
         current_password: currentPassword,
         new_password: newPassword,
-      })
-      setCurrentPassword('')
-      setNewPassword('')
-      setConfirmPassword('')
-      setPwdMsg({ type: 'success', text: '密码已修改成功' })
+      });
+      setCurrentPassword("");
+      setNewPassword("");
+      setConfirmPassword("");
+      setPwdMsg({ type: "success", text: "密码已修改成功" });
       setTimeout(() => {
-        setShowPasswordDialog(false)
-        setPwdMsg(null)
-      }, 1500)
-    } catch (err: any) {
-      setPwdMsg({ type: 'error', text: err.response?.data?.detail || '修改密码失败' })
+        setShowPasswordDialog(false);
+        setPwdMsg(null);
+      }, 1500);
+    } catch (err) {
+      const detail =
+        (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
+      setPwdMsg({ type: "error", text: detail || "修改密码失败" });
     } finally {
-      setSavingPwd(false)
+      setSavingPwd(false);
     }
-  }
+  };
 
-  const inputCls = 'w-full px-4 py-2.5 bg-surface-container-lowest border border-outline/20 rounded-xl text-on-surface placeholder:text-on-surface-muted focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40 transition-all'
+  const initials =
+    displayName.trim()
+      ?.split(/\s+/)
+      .map((w) => w[0] ?? "")
+      .join("")
+      .toUpperCase()
+      .slice(0, 2) || "";
 
   return (
-    <div className="space-y-6">
-      <div>
-        <h2 className="text-label-lg text-on-surface mb-1">个人信息</h2>
-        <p className="text-body-sm text-on-surface-muted">管理你的个人资料</p>
-      </div>
+    <div
+      className="theme-codex"
+      data-testid="profile-settings"
+      style={{
+        background: "var(--color-codex-bg)",
+        color: "var(--color-codex-ink)",
+        padding: "8px 4px 32px",
+      }}
+    >
+      <header style={{ marginBottom: 16 }}>
+        <h1
+          style={{
+            margin: 0,
+            fontSize: 22,
+            fontWeight: 500,
+            color: "var(--color-codex-ink)",
+            letterSpacing: "-0.015em",
+          }}
+        >
+          个人资料
+        </h1>
+        <p
+          style={{
+            margin: "6px 0 0",
+            fontSize: 13,
+            color: "var(--color-codex-ink-mute)",
+            lineHeight: 1.6,
+          }}
+        >
+          这些信息会出现在团队视图中，以及对话发送者标识。
+        </p>
+      </header>
 
-      {/* Profile Card */}
-      <div className="card space-y-4">
-        {/* Avatar placeholder */}
-        <div className="flex items-center gap-4 pb-4 border-b border-outline/10">
-          <div className="w-14 h-14 rounded-full bg-gradient-primary flex items-center justify-center text-white font-semibold text-lg">
-            {displayName ? displayName.split(' ').map(w => w[0]).join('').toUpperCase().slice(0, 2) : <User className="w-6 h-6" />}
-          </div>
-          <div>
-            <p className="font-medium text-on-surface">{displayName || '—'}</p>
-            <p className="text-sm text-on-surface-muted">{user?.email || '…'}</p>
-          </div>
-        </div>
-
-        {/* Display Name */}
-        <div className="space-y-2">
-          <label className="text-label-sm text-on-surface-muted flex items-center gap-1.5">
-            <User className="w-3.5 h-3.5" />
-            显示名称
-          </label>
-          <div className="flex gap-3">
-            <input
-              type="text"
-              value={displayName}
-              onChange={(e) => setDisplayName(e.target.value)}
-              placeholder="你的显示名称"
-              className={inputCls + ' flex-1'}
-            />
-            <button
-              onClick={handleSaveName}
-              disabled={savingName || displayName.trim() === (user?.display_name ?? '')}
-              className="btn-primary flex items-center gap-2 px-4 disabled:opacity-40"
-            >
-              {savingName ? <Loader2 className="w-4 h-4 animate-spin" /> : <Check className="w-4 h-4" />}
-              保存
-            </button>
-          </div>
-          {nameMsg && (
-            <p className={`text-xs flex items-center gap-1 ${nameMsg.type === 'success' ? 'text-active' : 'text-error'}`}>
-              {nameMsg.type === 'error' && <AlertCircle className="w-3 h-3" />}
-              {nameMsg.text}
-            </p>
-          )}
-        </div>
-
-        {/* Email (read-only) */}
-        <div className="space-y-2">
-          <label className="text-label-sm text-on-surface-muted flex items-center gap-1.5">
-            <Mail className="w-3.5 h-3.5" />
-            邮箱地址
-          </label>
-          <input
-            type="email"
-            value={user?.email ?? ''}
-            readOnly
-            className={inputCls + ' opacity-60 cursor-not-allowed'}
-          />
-        </div>
-
-        <div className="space-y-2">
-          <label className="text-label-sm text-on-surface-muted flex items-center gap-1.5">
-            <Clock3 className="w-3.5 h-3.5" />
-            时区
-          </label>
-          <div className="flex gap-3">
-            <select
-              value={selectedTimeZone}
-              onChange={(e) => setSelectedTimeZone(e.target.value)}
-              className={inputCls + ' flex-1'}
-            >
-              {timezoneOptions.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                  {option.value === BROWSER_TIMEZONE_VALUE ? `（当前：${getBrowserTimeZone()}）` : option.hint ? `（${option.hint}）` : ''}
-                </option>
-              ))}
-            </select>
-            <button
-              onClick={handleSaveTimeZone}
-              disabled={savingTimeZone}
-              className="btn-primary flex items-center gap-2 px-4 disabled:opacity-40"
-            >
-              {savingTimeZone ? <Loader2 className="w-4 h-4 animate-spin" /> : <Check className="w-4 h-4" />}
-              保存
-            </button>
-          </div>
-          <p className="text-xs text-on-surface-muted">
-            默认使用北京时间（UTC+08:00）。对话、项目、知识库和任务记录等时间显示会优先使用这里的时区。
-          </p>
-          {timeZoneMsg && (
-            <p className={`text-xs flex items-center gap-1 ${timeZoneMsg.type === 'success' ? 'text-active' : 'text-error'}`}>
-              {timeZoneMsg.type === 'error' && <AlertCircle className="w-3 h-3" />}
-              {timeZoneMsg.text}
-            </p>
-          )}
-        </div>
-
-        {/* Font size */}
-        <div className="space-y-2">
-          <label className="text-label-sm text-on-surface-muted flex items-center gap-1.5">
-            <Type className="w-3.5 h-3.5" />
-            字体大小
-          </label>
-          <div className="flex gap-3">
-            <div className="flex flex-1 gap-2 rounded-xl border border-outline/20 bg-surface-container-lowest p-1">
-              {fontSizeOptions.map((option) => {
-                const active = selectedFontSize === option.value
-                return (
-                  <button
-                    key={option.value}
-                    type="button"
-                    onClick={() => handleSelectFontSize(option.value)}
-                    aria-pressed={active}
-                    className={`flex flex-1 items-center justify-center gap-1.5 rounded-lg px-3 py-2 transition-all ${
-                      active
-                        ? 'bg-primary text-white shadow-sm'
-                        : 'text-on-surface-variant hover:bg-surface-container-low'
-                    }`}
-                  >
-                    <span className={option.previewClass}>Aa</span>
-                    <span className="text-sm font-medium">{option.label}</span>
-                  </button>
-                )
-              })}
-            </div>
-            <button
-              onClick={handleSaveFontSize}
-              disabled={savingFontSize}
-              className="btn-primary flex items-center gap-2 px-4 disabled:opacity-40"
-            >
-              {savingFontSize ? <Loader2 className="w-4 h-4 animate-spin" /> : <Check className="w-4 h-4" />}
-              保存
-            </button>
-          </div>
-          <p className="text-xs text-on-surface-muted">
-            调整后整个界面的文字会按比例缩放，点击即可即时预览，保存后在其他设备同步。默认为「中」。
-          </p>
-          {fontSizeMsg && (
-            <p className={`text-xs flex items-center gap-1 ${fontSizeMsg.type === 'success' ? 'text-active' : 'text-error'}`}>
-              {fontSizeMsg.type === 'error' && <AlertCircle className="w-3 h-3" />}
-              {fontSizeMsg.text}
-            </p>
-          )}
-        </div>
-      </div>
-
-      {/* User Memory (AI 个人偏好) Card */}
-      <UserMemorySettingsCard />
-
-      {/* Password Card */}
-      <div className="card space-y-4">
-        <div className="flex items-center justify-between">
-          <div>
-            <h3 className="text-label-lg text-on-surface flex items-center gap-2 mb-1">
-              <KeyRound className="w-4 h-4 text-primary" />
-              密码安全
-            </h3>
-            <p className="text-body-sm text-on-surface-muted">定期更换密码可以保护你的账户安全</p>
-          </div>
+      {/* Avatar row — no CxFormRow because the layout doesn't follow the
+          label / control split. Standalone, matches the prototype. */}
+      <div
+        className="flex items-center gap-5"
+        style={{
+          padding: "20px 0",
+          borderBottom: "1px solid var(--color-codex-line-soft)",
+        }}
+      >
+        <span
+          aria-hidden={!initials}
+          aria-label={initials ? `${displayName} avatar` : undefined}
+          className="inline-flex items-center justify-center"
+          style={{
+            width: 64,
+            height: 64,
+            borderRadius: 999,
+            background: "var(--color-codex-accent-bg)",
+            color: "var(--color-codex-accent-ink)",
+            fontSize: 24,
+            fontWeight: 500,
+          }}
+        >
+          {initials || <UserIcon className="h-6 w-6" aria-hidden="true" />}
+        </span>
+        <div>
           <button
-            onClick={openPasswordDialog}
-            className="btn-secondary flex items-center gap-2"
+            type="button"
+            style={GHOST_BUTTON_STYLE}
+            disabled
+            title="头像上传暂未开放"
           >
-            <Lock className="w-4 h-4" />
-            修改密码
+            上传头像
+          </button>
+          <div
+            style={{
+              fontSize: 11.5,
+              color: "var(--color-codex-ink-mute)",
+              marginTop: 6,
+            }}
+          >
+            PNG / JPG · 最大 2 MB · 暂未开放
+          </div>
+        </div>
+      </div>
+
+      {/* Display name */}
+      <CxFormRow
+        label={
+          <span className="inline-flex items-center gap-1.5">
+            <UserIcon className="h-3.5 w-3.5" aria-hidden="true" />
+            显示名称
+          </span>
+        }
+        htmlFor="profile-display-name"
+      >
+        <div className="flex gap-3">
+          <input
+            id="profile-display-name"
+            type="text"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            placeholder="你的显示名称"
+            className="codex-input"
+            style={{ ...INPUT_STYLE, flex: 1 }}
+          />
+          <button
+            type="button"
+            onClick={() => void handleSaveName()}
+            disabled={savingName || displayName.trim() === (user?.display_name ?? "")}
+            className="inline-flex items-center gap-1.5 disabled:cursor-not-allowed disabled:opacity-50"
+            style={SAVE_BUTTON_STYLE}
+          >
+            {savingName ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+            ) : (
+              <Check className="h-3.5 w-3.5" aria-hidden="true" />
+            )}
+            保存
           </button>
         </div>
+        <InlineMessage message={nameMsg} />
+      </CxFormRow>
+
+      {/* Email (read-only) */}
+      <CxFormRow
+        label={
+          <span className="inline-flex items-center gap-1.5">
+            <Mail className="h-3.5 w-3.5" aria-hidden="true" />
+            邮箱地址
+          </span>
+        }
+        hint="登录用，变更需联系管理员。"
+        htmlFor="profile-email"
+      >
+        <input
+          id="profile-email"
+          type="email"
+          value={user?.email ?? ""}
+          readOnly
+          className="codex-input"
+          style={{
+            ...INPUT_STYLE,
+            background: "var(--color-codex-bg-tint)",
+            color: "var(--color-codex-ink-mute)",
+            cursor: "not-allowed",
+          }}
+        />
+      </CxFormRow>
+
+      {/* Timezone */}
+      <CxFormRow
+        label={
+          <span className="inline-flex items-center gap-1.5">
+            <Clock3 className="h-3.5 w-3.5" aria-hidden="true" />
+            时区
+          </span>
+        }
+        hint="默认使用北京时间（UTC+08:00）。对话、项目、知识库和任务记录等时间显示会优先使用这里的时区。"
+        htmlFor="profile-timezone"
+      >
+        <div className="flex gap-3">
+          <select
+            id="profile-timezone"
+            value={selectedTimeZone}
+            onChange={(e) => setSelectedTimeZone(e.target.value)}
+            className="codex-input"
+            style={{ ...INPUT_STYLE, flex: 1 }}
+          >
+            {TIMEZONE_OPTIONS.map((option) => {
+              const hint =
+                option.value === BROWSER_TIMEZONE_VALUE
+                  ? `（当前：${getBrowserTimeZone()}）`
+                  : option.hint
+                    ? `（${option.hint}）`
+                    : "";
+              return (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                  {hint}
+                </option>
+              );
+            })}
+          </select>
+          <button
+            type="button"
+            onClick={() => void handleSaveTimeZone()}
+            disabled={savingTimeZone}
+            className="inline-flex items-center gap-1.5 disabled:cursor-not-allowed disabled:opacity-50"
+            style={SAVE_BUTTON_STYLE}
+          >
+            {savingTimeZone ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+            ) : (
+              <Check className="h-3.5 w-3.5" aria-hidden="true" />
+            )}
+            保存
+          </button>
+        </div>
+        <InlineMessage message={timeZoneMsg} />
+      </CxFormRow>
+
+      {/* Font size */}
+      <CxFormRow
+        label={
+          <span className="inline-flex items-center gap-1.5">
+            <Type className="h-3.5 w-3.5" aria-hidden="true" />
+            字体大小
+          </span>
+        }
+        hint="调整后整个界面的文字会按比例缩放，点击即可即时预览。保存后在其他设备同步。默认为「中」。"
+      >
+        <div className="flex gap-3">
+          <div
+            className="flex flex-1 gap-2"
+            style={{
+              padding: 4,
+              background: "var(--color-codex-bg)",
+              border: "1px solid var(--color-codex-line)",
+              borderRadius: "var(--codex-r-sm, 3px)",
+            }}
+            role="radiogroup"
+            aria-label="字体大小"
+          >
+            {FONT_SIZE_OPTIONS.map((option) => {
+              const active = selectedFontSize === option.value;
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  role="radio"
+                  aria-checked={active}
+                  aria-label={option.label}
+                  onClick={() => handleSelectFontSize(option.value)}
+                  className="flex flex-1 items-center justify-center gap-1.5 transition"
+                  style={{
+                    padding: "6px 10px",
+                    background: active
+                      ? "var(--color-codex-accent-bg)"
+                      : "transparent",
+                    color: active
+                      ? "var(--color-codex-accent-ink)"
+                      : "var(--color-codex-ink-soft)",
+                    borderRadius: "calc(var(--codex-r-sm, 3px) - 1px)",
+                    fontWeight: active ? 500 : 400,
+                  }}
+                >
+                  <span className={option.previewClass}>Aa</span>
+                  <span className="text-[13px]">{option.label}</span>
+                </button>
+              );
+            })}
+          </div>
+          <button
+            type="button"
+            onClick={() => void handleSaveFontSize()}
+            disabled={savingFontSize}
+            className="inline-flex items-center gap-1.5 disabled:cursor-not-allowed disabled:opacity-50"
+            style={SAVE_BUTTON_STYLE}
+          >
+            {savingFontSize ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+            ) : (
+              <Check className="h-3.5 w-3.5" aria-hidden="true" />
+            )}
+            保存
+          </button>
+        </div>
+        <InlineMessage message={fontSizeMsg} />
+      </CxFormRow>
+
+      {/* Password */}
+      <CxFormRow
+        label={
+          <span className="inline-flex items-center gap-1.5">
+            <KeyRound className="h-3.5 w-3.5" aria-hidden="true" />
+            密码
+          </span>
+        }
+        hint="定期更换密码可以保护你的账户安全。"
+        divider={false}
+      >
+        <button
+          type="button"
+          onClick={openPasswordDialog}
+          className="inline-flex items-center gap-1.5"
+          style={GHOST_BUTTON_STYLE}
+        >
+          <Lock className="h-3.5 w-3.5" aria-hidden="true" />
+          修改密码
+        </button>
+      </CxFormRow>
+
+      {/* AI 个人偏好 (own card, unchanged) */}
+      <div style={{ marginTop: 28 }}>
+        <UserMemorySettingsCard />
       </div>
 
-      {/* Password Change Dialog */}
+      {/* Password dialog */}
       {showPasswordDialog && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="bg-surface-container-lowest rounded-2xl w-full max-w-md shadow-2xl border border-outline/10 overflow-hidden">
-            {/* Dialog Header */}
-            <div className="px-6 py-4 border-b border-outline/10 flex items-center justify-between">
-              <div className="flex items-center gap-3">
-                <div className="w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center">
-                  <Lock className="w-5 h-5 text-primary" />
-                </div>
-                <div>
-                  <h3 className="text-lg font-semibold text-on-surface">修改密码</h3>
-                  <p className="text-xs text-on-surface-muted">请输入当前密码和新密码</p>
-                </div>
-              </div>
-              <button
-                onClick={closePasswordDialog}
-                disabled={savingPwd}
-                className="p-2 rounded-xl hover:bg-surface-container-low text-on-surface-muted transition-colors disabled:opacity-50"
-              >
-                <X className="w-5 h-5" />
-              </button>
-            </div>
-
-            {/* Dialog Content */}
-            <form onSubmit={handleChangePassword} className="p-6 space-y-4">
-              <div className="space-y-1.5">
-                <label className="text-label-sm text-on-surface-muted">当前密码</label>
-                <input
-                  type="password"
-                  value={currentPassword}
-                  onChange={(e) => setCurrentPassword(e.target.value)}
-                  placeholder="请输入当前密码"
-                  className={inputCls}
-                  required
-                  autoFocus
-                />
-              </div>
-              <div className="space-y-1.5">
-                <label className="text-label-sm text-on-surface-muted">新密码</label>
-                <input
-                  type="password"
-                  value={newPassword}
-                  onChange={(e) => setNewPassword(e.target.value)}
-                  placeholder="至少6位"
-                  className={inputCls}
-                  required
-                />
-              </div>
-              <div className="space-y-1.5">
-                <label className="text-label-sm text-on-surface-muted">确认新密码</label>
-                <input
-                  type="password"
-                  value={confirmPassword}
-                  onChange={(e) => setConfirmPassword(e.target.value)}
-                  placeholder="再次输入新密码"
-                  className={inputCls}
-                  required
-                />
-              </div>
-              
-              {pwdMsg && (
-                <div className={`p-3 rounded-xl flex items-center gap-2 ${
-                  pwdMsg.type === 'success' 
-                    ? 'bg-success/10 text-success border border-success/20' 
-                    : 'bg-error/10 text-error border border-error/20'
-                }`}>
-                  {pwdMsg.type === 'error' ? (
-                    <AlertCircle className="w-4 h-4 flex-shrink-0" />
-                  ) : (
-                    <Check className="w-4 h-4 flex-shrink-0" />
-                  )}
-                  <p className="text-sm">{pwdMsg.text}</p>
-                </div>
-              )}
-
-              {/* Dialog Footer */}
-              <div className="flex justify-end gap-3 pt-2">
-                <button
-                  type="button"
-                  onClick={closePasswordDialog}
-                  disabled={savingPwd}
-                  className="px-4 py-2.5 text-on-surface-muted hover:bg-surface-container-low rounded-xl transition-colors disabled:opacity-50"
-                >
-                  取消
-                </button>
-                <button
-                  type="submit"
-                  disabled={savingPwd || !currentPassword || !newPassword || !confirmPassword}
-                  className="flex items-center gap-2 px-6 py-2.5 bg-primary hover:bg-primary/90 disabled:opacity-50 text-white rounded-xl font-medium transition-all"
-                >
-                  {savingPwd ? (
-                    <>
-                      <Loader2 className="w-4 h-4 animate-spin" />
-                      修改中...
-                    </>
-                  ) : (
-                    <>
-                      <KeyRound className="w-4 h-4" />
-                      确认修改
-                    </>
-                  )}
-                </button>
-              </div>
-            </form>
-          </div>
-        </div>
+        <PasswordDialog
+          currentPassword={currentPassword}
+          newPassword={newPassword}
+          confirmPassword={confirmPassword}
+          saving={savingPwd}
+          message={pwdMsg}
+          onChangeCurrent={setCurrentPassword}
+          onChangeNew={setNewPassword}
+          onChangeConfirm={setConfirmPassword}
+          onClose={closePasswordDialog}
+          onSubmit={handleChangePassword}
+        />
       )}
     </div>
-  )
+  );
+}
+
+// ----------------------------------------------------------------------------
+
+function InlineMessage({ message }: { message: SavedMessage | null }) {
+  if (!message) return null;
+  const color =
+    message.type === "success" ? "var(--color-codex-good)" : "var(--color-codex-bad)";
+  return (
+    <p
+      role={message.type === "error" ? "alert" : undefined}
+      className="mt-1.5 inline-flex items-center gap-1"
+      style={{ fontSize: 11.5, color }}
+    >
+      {message.type === "error" && (
+        <AlertCircle className="h-3 w-3" aria-hidden="true" />
+      )}
+      {message.text}
+    </p>
+  );
+}
+
+interface PasswordDialogProps {
+  currentPassword: string;
+  newPassword: string;
+  confirmPassword: string;
+  saving: boolean;
+  message: SavedMessage | null;
+  onChangeCurrent: (next: string) => void;
+  onChangeNew: (next: string) => void;
+  onChangeConfirm: (next: string) => void;
+  onClose: () => void;
+  onSubmit: (event: FormEvent) => void;
+}
+
+function PasswordDialog({
+  currentPassword,
+  newPassword,
+  confirmPassword,
+  saving,
+  message,
+  onChangeCurrent,
+  onChangeNew,
+  onChangeConfirm,
+  onClose,
+  onSubmit,
+}: PasswordDialogProps) {
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="profile-password-title"
+      className="fixed inset-0 z-[100] flex items-center justify-center"
+      style={{ background: "rgba(0, 0, 0, 0.4)", padding: 16 }}
+    >
+      <div
+        className="theme-codex w-full"
+        style={{
+          maxWidth: 420,
+          background: "var(--color-codex-bg-elev)",
+          border: "1px solid var(--color-codex-line)",
+          borderRadius: "var(--codex-r-md, 6px)",
+          overflow: "hidden",
+          boxShadow:
+            "0 12px 36px -8px rgba(0,0,0,0.18), 0 0 0 1px var(--color-codex-line)",
+        }}
+      >
+        <header
+          className="flex items-center justify-between"
+          style={{
+            padding: "14px 18px",
+            borderBottom: "1px solid var(--color-codex-line-soft)",
+          }}
+        >
+          <div className="flex items-center gap-2.5">
+            <span
+              aria-hidden="true"
+              className="inline-flex items-center justify-center"
+              style={{
+                width: 28,
+                height: 28,
+                borderRadius: "var(--codex-r-sm, 3px)",
+                background: "var(--color-codex-accent-bg)",
+                color: "var(--color-codex-accent-ink)",
+              }}
+            >
+              <Lock className="h-3.5 w-3.5" />
+            </span>
+            <div>
+              <h2
+                id="profile-password-title"
+                style={{
+                  margin: 0,
+                  fontSize: 15,
+                  fontWeight: 500,
+                  color: "var(--color-codex-ink)",
+                }}
+              >
+                修改密码
+              </h2>
+              <p
+                style={{
+                  margin: "2px 0 0",
+                  fontSize: 11.5,
+                  color: "var(--color-codex-ink-mute)",
+                }}
+              >
+                请输入当前密码和新密码
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={saving}
+            aria-label="关闭"
+            className="disabled:cursor-not-allowed disabled:opacity-50"
+            style={{ color: "var(--color-codex-ink-mute)" }}
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </header>
+
+        <form onSubmit={onSubmit} style={{ padding: 18, display: "grid", gap: 12 }}>
+          <PasswordField
+            id="pwd-current"
+            label="当前密码"
+            value={currentPassword}
+            onChange={onChangeCurrent}
+            autoFocus
+          />
+          <PasswordField
+            id="pwd-new"
+            label="新密码"
+            placeholder="至少 6 位"
+            value={newPassword}
+            onChange={onChangeNew}
+          />
+          <PasswordField
+            id="pwd-confirm"
+            label="确认新密码"
+            value={confirmPassword}
+            onChange={onChangeConfirm}
+          />
+
+          {message && (
+            <div
+              role={message.type === "error" ? "alert" : "status"}
+              className="flex items-center gap-1.5"
+              style={{
+                padding: "8px 10px",
+                fontSize: 12,
+                background:
+                  message.type === "success"
+                    ? "color-mix(in oklch, var(--color-codex-good) 8%, transparent)"
+                    : "color-mix(in oklch, var(--color-codex-bad) 8%, transparent)",
+                border: `1px solid color-mix(in oklch, var(${
+                  message.type === "success" ? "--color-codex-good" : "--color-codex-bad"
+                }) 30%, transparent)`,
+                borderRadius: "var(--codex-r-sm, 3px)",
+                color:
+                  message.type === "success"
+                    ? "var(--color-codex-good)"
+                    : "var(--color-codex-bad)",
+              }}
+            >
+              {message.type === "error" ? (
+                <AlertCircle className="h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />
+              ) : (
+                <Check className="h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />
+              )}
+              {message.text}
+            </div>
+          )}
+
+          <div className="flex justify-end gap-2" style={{ marginTop: 4 }}>
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={saving}
+              style={GHOST_BUTTON_STYLE}
+            >
+              取消
+            </button>
+            <button
+              type="submit"
+              disabled={
+                saving || !currentPassword || !newPassword || !confirmPassword
+              }
+              className="inline-flex items-center gap-1.5 disabled:cursor-not-allowed disabled:opacity-50"
+              style={SAVE_BUTTON_STYLE}
+            >
+              {saving ? (
+                <>
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+                  修改中…
+                </>
+              ) : (
+                <>
+                  <KeyRound className="h-3.5 w-3.5" aria-hidden="true" />
+                  确认修改
+                </>
+              )}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function PasswordField({
+  id,
+  label,
+  value,
+  placeholder,
+  autoFocus,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  placeholder?: string;
+  autoFocus?: boolean;
+  onChange: (next: string) => void;
+}) {
+  return (
+    <div>
+      <label
+        htmlFor={id}
+        style={{
+          fontSize: 12.5,
+          color: "var(--color-codex-ink-soft)",
+          display: "block",
+          marginBottom: 4,
+        }}
+      >
+        {label}
+      </label>
+      <input
+        id={id}
+        type="password"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        autoFocus={autoFocus}
+        required
+        className="codex-input"
+        style={INPUT_STYLE}
+      />
+    </div>
+  );
 }


### PR DESCRIPTION
## What
Refactors two existing settings pages to the Codex visual language. Profile is the larger of the two — 5 fields + avatar tile + modal password dialog + embedded UserMemorySettingsCard; Language is a focused single-control page.

Layout per [direction-codex-settings.jsx:90](design_handoff_aria_codex_redesign/direction-codex-settings.jsx#L90) (Profile) and [:118](design_handoff_aria_codex_redesign/direction-codex-settings.jsx#L118) (Language).

## Profile
- Page header (个人资料 + subtitle)
- Standalone avatar tile (64px accent-bg circle with initials) + "上传头像" ghost button — disabled today, mirrors the prototype's affordance without lying about a feature we haven't built
- 5 ``CxFormRow`` rows: 显示名称 / 邮箱地址 (read-only) / 时区 / 字体大小 / 密码 — each with its current inline save button + a per-field success/error message via the new ``InlineMessage`` atom
- ``UserMemorySettingsCard`` embedded below as a separate card (its visual refactor will be a later PR)
- Password change modal redesigned as a Codex ``role="dialog"``: hairline 1px border, soft 12px-radius card, accent-tinted lock icon header, labeled inputs, success/error chip, Codex ghost+primary footer

## Language
- One ``CxFormRow`` with a chip-radio for 中文 / English — ``<button role="radio">`` with the radio dot rendered as a tiny filled circle. Click previews immediately; ``handleSave`` PUTs to the backend
- Save button matches the Codex dark-ink CTA style

## What's unchanged
All hooks (``/auth/me``, ``/settings/``, ``/auth/users/:id`` PATCH, ``/settings/timezone``, ``/settings/${APP_FONT_SIZE_SETTING_KEY}``, ``/auth/change-password``, ``/settings/language``) round-trip identically. Inline preview behaviors (font-size, language, ``setAppTimeZone``) also unchanged.

## Test plan
- [x] ``vitest run`` (full) → 513/513 unchanged
- [x] ``tsc --noEmit`` clean
- [x] ``vite build`` clean
- [x] ``git diff --cached`` reviewed — 4 files staged via ``git add -p``; V0.0.5 knowledge-key hunks ~200 lines above mine in the locale files deliberately skipped
- [ ] **Manual after deploy**:
  - ``/settings`` (the index) → rename display name + save, change timezone + save, switch font size + save, open + cancel password dialog, open + try invalid password (mismatch) + try short password
  - ``/settings/language`` → switch language → preview applies → save → reload → persists

## Next
PR 7/N — Workspace 工作台. Likely split into a "chrome shell + tokens" PR and a "content rows" PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)