### PR TITLE
Settings · Migration + Server — Codex (V0.0.6 redesign · PR 7/N)

### DIFF
--- a/web/src/pages/settings/MigrationSettings.tsx
+++ b/web/src/pages/settings/MigrationSettings.tsx
@@ -1,193 +1,469 @@
-import { useEffect, useState } from 'react'
-import { useTranslation } from 'react-i18next'
-import { AlertTriangle, CheckCircle2, Database, GitBranch, Loader2, RefreshCw } from 'lucide-react'
-import { api } from '../../api/client'
+/**
+ * Settings → 迁移状态 — V0.0.6 Codex redesign (PR 7/N).
+ *
+ * Read-only status page for the database migration governance. All
+ * data + actions (refresh, fetch) are unchanged from the previous
+ * implementation; only the rendering layer was rewritten.
+ *
+ * Layout: header (title + refresh CTA) → status banner (good/warn) →
+ * 4-stat tile row → 2-col detail panels (pending revisions + ops
+ * commands) → known revisions chip list. Each tile uses the Codex
+ * stat-card pattern (bg-elev + hairline border, no shadow, mono-font
+ * value).
+ */
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Database,
+  GitBranch,
+  Loader2,
+  RefreshCw,
+} from "lucide-react";
+
+import { api } from "../../api/client";
+import { CxStatus } from "../../components/codex";
 
 interface MigrationGovernance {
-  mode: 'bootstrap' | 'lightweight' | 'alembic' | string
-  current_revision?: string | null
-  latest_revision?: string | null
-  known_revisions?: string[]
-  pending_revisions?: string[]
-  pending_count?: number
-  up_to_date?: boolean | null
-  idempotent_bootstrap?: boolean
-  notes?: Record<string, string>
+  mode: "bootstrap" | "lightweight" | "alembic" | string;
+  current_revision?: string | null;
+  latest_revision?: string | null;
+  known_revisions?: string[];
+  pending_revisions?: string[];
+  pending_count?: number;
+  up_to_date?: boolean | null;
+  idempotent_bootstrap?: boolean;
+  notes?: Record<string, string>;
 }
 
-function getModeTone(governance: MigrationGovernance | null) {
-  if (!governance) return 'neutral'
-  if (governance.mode === 'alembic' && governance.pending_count === 0) return 'ok'
-  if (governance.mode === 'lightweight') return 'warning'
-  if ((governance.pending_count ?? 0) > 0) return 'warning'
-  return 'neutral'
+type Tone = "neutral" | "ok" | "warning";
+
+function getModeTone(governance: MigrationGovernance | null): Tone {
+  if (!governance) return "neutral";
+  if (governance.mode === "alembic" && governance.pending_count === 0) return "ok";
+  if (governance.mode === "lightweight") return "warning";
+  if ((governance.pending_count ?? 0) > 0) return "warning";
+  return "neutral";
 }
 
-function StatCard({
+function StatTile({
   label,
   value,
-  tone = 'neutral',
+  tone = "neutral",
 }: {
-  label: string
-  value: string | number
-  tone?: 'neutral' | 'ok' | 'warning'
+  label: string;
+  value: string | number;
+  tone?: Tone;
 }) {
-  const toneClass =
-    tone === 'ok'
-      ? 'border-emerald-100 bg-emerald-50 text-emerald-900'
-      : tone === 'warning'
-        ? 'border-amber-100 bg-amber-50 text-amber-950'
-        : 'border-outline bg-surface-container-low text-on-surface'
-
+  const valueColor =
+    tone === "ok"
+      ? "var(--color-codex-good)"
+      : tone === "warning"
+        ? "var(--color-codex-warn)"
+        : "var(--color-codex-ink)";
   return (
-    <div className={`rounded-2xl border p-4 ${toneClass}`}>
-      <div className="text-xs font-medium opacity-70">{label}</div>
-      <div className="mt-2 break-all text-xl font-semibold">{value || '-'}</div>
+    <div
+      style={{
+        background: "var(--color-codex-bg-elev)",
+        border: "1px solid var(--color-codex-line)",
+        borderRadius: "var(--codex-r-md, 6px)",
+        padding: "14px 16px",
+      }}
+    >
+      <div
+        style={{
+          fontSize: 11.5,
+          fontWeight: 500,
+          color: "var(--color-codex-ink-mute)",
+          letterSpacing: "0.04em",
+          textTransform: "uppercase",
+        }}
+      >
+        {label}
+      </div>
+      <div
+        className="font-mono"
+        style={{
+          marginTop: 6,
+          fontSize: 18,
+          fontWeight: 500,
+          color: valueColor,
+          wordBreak: "break-all",
+          fontVariantNumeric: "tabular-nums",
+        }}
+      >
+        {value || "-"}
+      </div>
     </div>
-  )
+  );
 }
 
 export function MigrationSettings() {
-  const { i18n } = useTranslation()
-  const isZh = i18n.language.startsWith('zh')
-  const [loading, setLoading] = useState(true)
-  const [governance, setGovernance] = useState<MigrationGovernance | null>(null)
-  const [error, setError] = useState('')
+  const { i18n } = useTranslation();
+  const isZh = i18n.language.startsWith("zh");
+  const [loading, setLoading] = useState(true);
+  const [governance, setGovernance] = useState<MigrationGovernance | null>(null);
+  const [error, setError] = useState("");
 
   const loadGovernance = async () => {
     try {
-      setLoading(true)
-      setError('')
-      const data = await api.get<MigrationGovernance>('/health/db/migrations')
-      setGovernance(data)
-    } catch (err: any) {
-      console.error('Failed to load migration governance:', err)
-      setError(err?.response?.data?.detail || (isZh ? '加载迁移状态失败' : 'Failed to load migration status'))
+      setLoading(true);
+      setError("");
+      const data = await api.get<MigrationGovernance>("/health/db/migrations");
+      setGovernance(data);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error("Failed to load migration governance:", err);
+      const detail =
+        (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
+      setError(detail || (isZh ? "加载迁移状态失败" : "Failed to load migration status"));
     } finally {
-      setLoading(false)
+      setLoading(false);
     }
-  }
+  };
 
   useEffect(() => {
-    void loadGovernance()
-  }, [])
+    void loadGovernance();
+    // No deps — load once on mount. i18n changes don't refetch.
+  }, []);
 
   if (loading) {
     return (
-      <div className="flex min-h-[280px] items-center justify-center">
-        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      <div
+        className="theme-codex flex items-center justify-center"
+        style={{ padding: "48px 0", color: "var(--color-codex-ink-mute)" }}
+      >
+        <Loader2 className="h-5 w-5 animate-spin" />
       </div>
-    )
+    );
   }
 
-  const tone = getModeTone(governance)
-  const healthy = tone === 'ok'
+  const tone = getModeTone(governance);
+  const healthy = tone === "ok";
 
   return (
-    <div className="space-y-6 p-6">
-      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+    <div
+      className="theme-codex"
+      data-testid="migration-settings"
+      style={{
+        background: "var(--color-codex-bg)",
+        color: "var(--color-codex-ink)",
+        padding: "8px 4px 32px",
+      }}
+    >
+      {/* Header */}
+      <header
+        className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between"
+        style={{ marginBottom: 18 }}
+      >
         <div>
-          <h2 className="text-xl font-semibold text-on-surface">{isZh ? '数据库迁移状态' : 'Database Migrations'}</h2>
-          <p className="mt-1 text-sm text-on-surface-muted">
+          <h1
+            style={{
+              margin: 0,
+              fontSize: 22,
+              fontWeight: 500,
+              color: "var(--color-codex-ink)",
+              letterSpacing: "-0.015em",
+            }}
+          >
+            {isZh ? "数据库迁移状态" : "Database Migrations"}
+          </h1>
+          <p
+            style={{
+              margin: "6px 0 0",
+              fontSize: 13,
+              color: "var(--color-codex-ink-mute)",
+              lineHeight: 1.6,
+            }}
+          >
             {isZh
-              ? '只读查看当前数据库迁移治理状态，用于部署后校验和数据库类失败排查。'
-              : 'Read-only migration governance status for deployment checks and database failure triage.'}
+              ? "只读查看当前数据库迁移治理状态，用于部署后校验和数据库类失败排查。"
+              : "Read-only migration governance status for deployment checks and database failure triage."}
           </p>
         </div>
         <button
+          type="button"
           onClick={() => void loadGovernance()}
-          className="inline-flex items-center gap-2 rounded-xl border border-outline px-4 py-2 text-sm font-medium text-on-surface hover:bg-surface-container-low"
+          className="inline-flex items-center gap-1.5"
+          style={{
+            padding: "8px 14px",
+            background: "var(--color-codex-bg-elev)",
+            color: "var(--color-codex-ink-soft)",
+            border: "1px solid var(--color-codex-line)",
+            borderRadius: "var(--codex-r-sm, 3px)",
+            fontSize: 12.5,
+            fontWeight: 500,
+          }}
         >
-          <RefreshCw className="h-4 w-4" />
-          {isZh ? '刷新状态' : 'Refresh'}
+          <RefreshCw className="h-3.5 w-3.5" aria-hidden="true" />
+          {isZh ? "刷新状态" : "Refresh"}
         </button>
-      </div>
+      </header>
 
-      {error ? (
-        <div className="flex items-center gap-2 rounded-2xl border border-error/20 bg-error/10 p-4 text-sm text-error">
-          <AlertTriangle className="h-4 w-4" />
+      {/* Error alert */}
+      {error && (
+        <div
+          role="alert"
+          className="mb-4 flex items-center gap-2"
+          style={{
+            padding: "9px 12px",
+            background: "color-mix(in oklch, var(--color-codex-bad) 8%, transparent)",
+            border: "1px solid color-mix(in oklch, var(--color-codex-bad) 30%, transparent)",
+            borderRadius: "var(--codex-r-sm, 3px)",
+            color: "var(--color-codex-bad)",
+            fontSize: 12,
+          }}
+        >
+          <AlertTriangle className="h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />
           {error}
         </div>
-      ) : null}
+      )}
 
-      <div
-        className={`rounded-3xl border p-5 ${
-          healthy ? 'border-emerald-100 bg-emerald-50/70' : 'border-amber-100 bg-amber-50/70'
-        }`}
+      {/* Status banner */}
+      <section
+        className="mb-5"
+        style={{
+          padding: "16px 20px",
+          background: healthy
+            ? "color-mix(in oklch, var(--color-codex-good) 6%, transparent)"
+            : "color-mix(in oklch, var(--color-codex-warn) 6%, transparent)",
+          border: `1px solid color-mix(in oklch, var(${
+            healthy ? "--color-codex-good" : "--color-codex-warn"
+          }) 30%, transparent)`,
+          borderRadius: "var(--codex-r-md, 6px)",
+        }}
       >
-        <div className="flex items-start gap-4">
-          <div className={`rounded-2xl p-3 ${healthy ? 'bg-emerald-100 text-emerald-700' : 'bg-amber-100 text-amber-700'}`}>
-            {healthy ? <CheckCircle2 className="h-6 w-6" /> : <AlertTriangle className="h-6 w-6" />}
-          </div>
+        <div className="flex items-start gap-3">
+          <span
+            aria-hidden="true"
+            className="inline-flex items-center justify-center flex-shrink-0"
+            style={{
+              width: 36,
+              height: 36,
+              borderRadius: "var(--codex-r-sm, 3px)",
+              background: healthy
+                ? "color-mix(in oklch, var(--color-codex-good) 16%, transparent)"
+                : "color-mix(in oklch, var(--color-codex-warn) 16%, transparent)",
+              color: healthy
+                ? "var(--color-codex-good)"
+                : "var(--color-codex-warn)",
+            }}
+          >
+            {healthy ? (
+              <CheckCircle2 className="h-4 w-4" />
+            ) : (
+              <AlertTriangle className="h-4 w-4" />
+            )}
+          </span>
           <div>
-            <div className="text-lg font-semibold text-on-surface">
-              {healthy ? (isZh ? '迁移状态正常' : 'Migrations are healthy') : isZh ? '需要关注迁移状态' : 'Migration state needs attention'}
-            </div>
-            <p className="mt-1 text-sm leading-6 text-on-surface-muted">
+            <div
+              style={{
+                fontSize: 14,
+                fontWeight: 500,
+                color: "var(--color-codex-ink)",
+              }}
+            >
               {healthy
                 ? isZh
-                  ? '当前数据库由 Alembic 管理，且没有待执行迁移。'
-                  : 'The database is Alembic-managed and has no pending revisions.'
+                  ? "迁移状态正常"
+                  : "Migrations are healthy"
                 : isZh
-                  ? '如果这是线上环境，请先查看部署日志中的 migration_governance 输出，再决定是否执行 ensure 或 upgrade。'
-                  : 'For production, inspect migration_governance deployment logs before deciding whether to run ensure or upgrade.'}
+                  ? "需要关注迁移状态"
+                  : "Migration state needs attention"}
+            </div>
+            <p
+              style={{
+                margin: "4px 0 0",
+                fontSize: 12.5,
+                color: "var(--color-codex-ink-soft)",
+                lineHeight: 1.6,
+              }}
+            >
+              {healthy
+                ? isZh
+                  ? "当前数据库由 Alembic 管理，且没有待执行迁移。"
+                  : "The database is Alembic-managed and has no pending revisions."
+                : isZh
+                  ? "如果这是线上环境，请先查看部署日志中的 migration_governance 输出，再决定是否执行 ensure 或 upgrade。"
+                  : "For production, inspect migration_governance deployment logs before deciding whether to run ensure or upgrade."}
             </p>
           </div>
         </div>
+      </section>
+
+      {/* Stat tiles */}
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4 mb-5">
+        <StatTile
+          label={isZh ? "模式" : "Mode"}
+          value={governance?.mode || "-"}
+          tone={tone}
+        />
+        <StatTile
+          label={isZh ? "当前版本" : "Current revision"}
+          value={governance?.current_revision || "-"}
+        />
+        <StatTile
+          label={isZh ? "最新版本" : "Latest revision"}
+          value={governance?.latest_revision || "-"}
+        />
+        <StatTile
+          label={isZh ? "待执行数量" : "Pending count"}
+          value={governance?.pending_count ?? 0}
+          tone={(governance?.pending_count ?? 0) > 0 ? "warning" : "ok"}
+        />
       </div>
 
-      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-        <StatCard label={isZh ? '模式' : 'Mode'} value={governance?.mode || '-'} tone={tone === 'ok' ? 'ok' : tone === 'warning' ? 'warning' : 'neutral'} />
-        <StatCard label={isZh ? '当前版本' : 'Current revision'} value={governance?.current_revision || '-'} />
-        <StatCard label={isZh ? '最新版本' : 'Latest revision'} value={governance?.latest_revision || '-'} />
-        <StatCard label={isZh ? '待执行数量' : 'Pending count'} value={governance?.pending_count ?? 0} tone={(governance?.pending_count ?? 0) > 0 ? 'warning' : 'ok'} />
-      </div>
-
-      <div className="grid gap-4 lg:grid-cols-2">
-        <div className="rounded-2xl border border-outline bg-surface p-4">
-          <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-on-surface">
-            <GitBranch className="h-4 w-4" />
-            {isZh ? '待执行 Revision' : 'Pending revisions'}
+      {/* Two-column detail */}
+      <div className="grid gap-4 lg:grid-cols-2 mb-5">
+        {/* Pending revisions */}
+        <section
+          style={{
+            background: "var(--color-codex-bg-elev)",
+            border: "1px solid var(--color-codex-line)",
+            borderRadius: "var(--codex-r-md, 6px)",
+            padding: "14px 16px",
+          }}
+        >
+          <div
+            className="mb-3 flex items-center gap-2"
+            style={{
+              fontSize: 12,
+              fontWeight: 600,
+              color: "var(--color-codex-ink)",
+              letterSpacing: "0.04em",
+              textTransform: "uppercase",
+            }}
+          >
+            <GitBranch className="h-3.5 w-3.5" aria-hidden="true" />
+            {isZh ? "待执行 Revision" : "Pending revisions"}
           </div>
           {governance?.pending_revisions?.length ? (
-            <div className="flex flex-wrap gap-2">
+            <div className="flex flex-wrap gap-1.5">
               {governance.pending_revisions.map((revision) => (
-                <span key={revision} className="rounded-full bg-amber-50 px-3 py-1 text-xs font-medium text-amber-800">
+                <span
+                  key={revision}
+                  className="font-mono"
+                  style={{
+                    padding: "3px 8px",
+                    fontSize: 11.5,
+                    background: "color-mix(in oklch, var(--color-codex-warn) 12%, transparent)",
+                    color: "var(--color-codex-warn)",
+                    borderRadius: "var(--codex-r-pill, 999px)",
+                    fontVariantNumeric: "tabular-nums",
+                  }}
+                >
                   {revision}
                 </span>
               ))}
             </div>
           ) : (
-            <div className="rounded-xl bg-surface-container-low p-4 text-sm text-on-surface-muted">
-              {isZh ? '没有待执行迁移。' : 'No pending migrations.'}
+            <div
+              className="flex items-center gap-2"
+              style={{
+                padding: "10px 12px",
+                background: "var(--color-codex-bg-tint)",
+                borderRadius: "var(--codex-r-sm, 3px)",
+                fontSize: 12.5,
+                color: "var(--color-codex-ink-mute)",
+              }}
+            >
+              <CxStatus tone="good">{isZh ? "无" : "none"}</CxStatus>
+              {isZh ? "没有待执行迁移。" : "No pending migrations."}
             </div>
           )}
-        </div>
+        </section>
 
-        <div className="rounded-2xl border border-outline bg-surface p-4">
-          <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-on-surface">
-            <Database className="h-4 w-4" />
-            {isZh ? '运维命令' : 'Operational commands'}
+        {/* Ops commands */}
+        <section
+          style={{
+            background: "var(--color-codex-bg-elev)",
+            border: "1px solid var(--color-codex-line)",
+            borderRadius: "var(--codex-r-md, 6px)",
+            padding: "14px 16px",
+          }}
+        >
+          <div
+            className="mb-3 flex items-center gap-2"
+            style={{
+              fontSize: 12,
+              fontWeight: 600,
+              color: "var(--color-codex-ink)",
+              letterSpacing: "0.04em",
+              textTransform: "uppercase",
+            }}
+          >
+            <Database className="h-3.5 w-3.5" aria-hidden="true" />
+            {isZh ? "运维命令" : "Operational commands"}
           </div>
-          <div className="space-y-2 text-sm text-on-surface-muted">
-            <code className="block rounded-xl bg-surface-container-low p-3">python scripts/migration_governance.py report</code>
-            <code className="block rounded-xl bg-surface-container-low p-3">python scripts/migration_governance.py check</code>
-            <code className="block rounded-xl bg-surface-container-low p-3">python scripts/migration_governance.py ensure</code>
-            <code className="block rounded-xl bg-surface-container-low p-3">python scripts/migration_governance.py upgrade</code>
+          <div className="flex flex-col gap-1.5">
+            {[
+              "python scripts/migration_governance.py report",
+              "python scripts/migration_governance.py check",
+              "python scripts/migration_governance.py ensure",
+              "python scripts/migration_governance.py upgrade",
+            ].map((cmd) => (
+              <code
+                key={cmd}
+                className="font-mono"
+                style={{
+                  display: "block",
+                  padding: "8px 10px",
+                  background: "var(--color-codex-bg-tint)",
+                  border: "1px solid var(--color-codex-line-soft)",
+                  borderRadius: "var(--codex-r-sm, 3px)",
+                  fontSize: 11.5,
+                  color: "var(--color-codex-ink-soft)",
+                  overflowX: "auto",
+                }}
+              >
+                {cmd}
+              </code>
+            ))}
           </div>
-        </div>
+        </section>
       </div>
 
-      <div className="rounded-2xl border border-outline bg-surface p-4">
-        <div className="mb-3 text-sm font-semibold text-on-surface">{isZh ? '已知 Revision' : 'Known revisions'}</div>
-        <div className="flex flex-wrap gap-2">
+      {/* Known revisions */}
+      <section
+        style={{
+          background: "var(--color-codex-bg-elev)",
+          border: "1px solid var(--color-codex-line)",
+          borderRadius: "var(--codex-r-md, 6px)",
+          padding: "14px 16px",
+        }}
+      >
+        <div
+          className="mb-3"
+          style={{
+            fontSize: 12,
+            fontWeight: 600,
+            color: "var(--color-codex-ink)",
+            letterSpacing: "0.04em",
+            textTransform: "uppercase",
+          }}
+        >
+          {isZh ? "已知 Revision" : "Known revisions"}
+        </div>
+        <div className="flex flex-wrap gap-1.5">
           {(governance?.known_revisions || []).map((revision) => (
-            <span key={revision} className="rounded-full bg-surface-container-low px-3 py-1 text-xs text-on-surface-muted">
+            <span
+              key={revision}
+              className="font-mono"
+              style={{
+                padding: "3px 8px",
+                fontSize: 11.5,
+                background: "var(--color-codex-bg-tint)",
+                color: "var(--color-codex-ink-mute)",
+                borderRadius: "var(--codex-r-pill, 999px)",
+                fontVariantNumeric: "tabular-nums",
+              }}
+            >
               {revision}
             </span>
           ))}
         </div>
-      </div>
+      </section>
     </div>
-  )
+  );
 }

--- a/web/src/pages/settings/ServerSettings.tsx
+++ b/web/src/pages/settings/ServerSettings.tsx
@@ -1,400 +1,673 @@
-import { useState, useEffect } from 'react'
-import { useTranslation } from 'react-i18next'
-import { 
-  Check, 
-  Globe, 
-  RefreshCw, 
-  AlertTriangle, 
-  Server, 
-  Shield,
-  Clock,
+/**
+ * Settings → 服务器配置 — V0.0.6 Codex redesign (PR 7/N).
+ *
+ * Refactors the API base URL config page to the Codex visual language.
+ * State machine + behaviors unchanged: ``getApiConfig``,
+ * ``saveApiBaseUrl``, the /health probe, the /settings/api_base_url
+ * PUT, and the post-save ``window.location.reload()`` all preserve
+ * their existing semantics.
+ *
+ * Sections (top-down):
+ *   1. Page header (title + subtitle).
+ *   2. Status banner — connection state pill + version/uptime.
+ *   3. URL config: source/value/backend snapshot + input + test button
+ *      + connection result chip.
+ *   4. Quick presets — 3 chip buttons.
+ *   5. Security info note.
+ *   6. Help link + save CTA footer.
+ */
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  AlertTriangle,
+  Check,
   ChevronRight,
+  Clock,
+  ExternalLink,
+  Globe,
   Loader2,
+  RefreshCw,
+  Server,
+  Shield,
   Wifi,
   WifiOff,
-  ExternalLink
-} from 'lucide-react'
-import { api } from '../../api/client'
-import { getApiConfig, saveApiBaseUrl, type ApiUrlSource } from '../../config/api'
+} from "lucide-react";
+
+import { api } from "../../api/client";
+import { CxStatus } from "../../components/codex";
+import {
+  getApiConfig,
+  saveApiBaseUrl,
+  type ApiUrlSource,
+} from "../../config/api";
 
 interface ServerInfo {
-  version: string
-  status: string
-  uptime?: string
+  version: string;
+  status: string;
+  uptime?: string;
 }
 
+type ConnectionStatus = "idle" | "online" | "offline";
+
+const INPUT_STYLE = {
+  flex: 1,
+  padding: "9px 12px",
+  fontSize: 13.5,
+  background: "var(--color-codex-bg)",
+  border: "1px solid var(--color-codex-line)",
+  borderRadius: "var(--codex-r-sm, 3px)",
+  color: "var(--color-codex-ink)",
+};
+
+const GHOST_BUTTON_STYLE = {
+  padding: "8px 14px",
+  fontSize: 12.5,
+  color: "var(--color-codex-ink-soft)",
+  border: "1px solid var(--color-codex-line)",
+  borderRadius: "var(--codex-r-sm, 3px)",
+  background: "var(--color-codex-bg-elev)",
+};
+
+const PRIMARY_BUTTON_STYLE = {
+  padding: "9px 18px",
+  background: "var(--color-codex-ink)",
+  color: "var(--color-codex-bg-elev)",
+  borderRadius: "var(--codex-r-sm, 3px)",
+  fontSize: 13,
+  fontWeight: 500,
+};
+
 export function ServerSettings() {
-  const { t } = useTranslation()
-  const [serverUrl, setServerUrl] = useState('')
-  const [initialServerUrl, setInitialServerUrl] = useState('')
-  const [backendServerUrl, setBackendServerUrl] = useState('')
-  const [effectiveUrl, setEffectiveUrl] = useState('')
-  const [effectiveSource, setEffectiveSource] = useState<ApiUrlSource>('default')
-  const [isChecking, setIsChecking] = useState(false)
-  const [status, setStatus] = useState<'idle' | 'online' | 'offline'>('idle')
-  const [saved, setSaved] = useState(false)
-  const [loading, setLoading] = useState(true)
-  const [serverInfo, setServerInfo] = useState<ServerInfo | null>(null)
-  const [error, setError] = useState('')
+  const { t } = useTranslation();
+  const [serverUrl, setServerUrl] = useState("");
+  const [initialServerUrl, setInitialServerUrl] = useState("");
+  const [backendServerUrl, setBackendServerUrl] = useState("");
+  const [effectiveUrl, setEffectiveUrl] = useState("");
+  const [effectiveSource, setEffectiveSource] = useState<ApiUrlSource>("default");
+  const [isChecking, setIsChecking] = useState(false);
+  const [status, setStatus] = useState<ConnectionStatus>("idle");
+  const [saved, setSaved] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [serverInfo, setServerInfo] = useState<ServerInfo | null>(null);
+  const [error, setError] = useState("");
 
   const sourceLabels: Record<ApiUrlSource, string> = {
-    localStorage: t('settings.server.sourceLocal') || '浏览器本地设置',
-    env: t('settings.server.sourceEnv') || '环境变量',
-    default: t('settings.server.sourceDefault') || '默认值',
-  }
+    localStorage: t("settings.server.sourceLocal") || "浏览器本地设置",
+    env: t("settings.server.sourceEnv") || "环境变量",
+    default: t("settings.server.sourceDefault") || "默认值",
+  };
 
-  const hasUnsavedChanges = serverUrl.trim() !== initialServerUrl.trim()
+  const hasUnsavedChanges = serverUrl.trim() !== initialServerUrl.trim();
 
-  // Load saved server URL on mount
   useEffect(() => {
-    loadServerSettings()
-  }, [])
+    void loadServerSettings();
+    // Load once on mount; no deps.
+  }, []);
 
   const loadServerSettings = async () => {
     try {
-      setLoading(true)
-      setError('')
-      const apiConfig = getApiConfig()
-      setEffectiveUrl(apiConfig.url)
-      setEffectiveSource(apiConfig.source)
+      setLoading(true);
+      setError("");
+      const apiConfig = getApiConfig();
+      setEffectiveUrl(apiConfig.url);
+      setEffectiveSource(apiConfig.source);
 
-      let resolvedUrl = apiConfig.url
-
+      let resolvedUrl = apiConfig.url;
       try {
-        const settings = await api.get<Record<string, string>>('/settings/')
+        const settings = await api.get<Record<string, string>>("/settings/");
         if (settings.api_base_url) {
-          setBackendServerUrl(settings.api_base_url)
-          resolvedUrl = settings.api_base_url
+          setBackendServerUrl(settings.api_base_url);
+          resolvedUrl = settings.api_base_url;
         }
       } catch {
-        setBackendServerUrl('')
+        setBackendServerUrl("");
       }
 
-      setServerUrl(resolvedUrl)
-      setInitialServerUrl(resolvedUrl)
-      await checkConnection(resolvedUrl)
+      setServerUrl(resolvedUrl);
+      setInitialServerUrl(resolvedUrl);
+      await checkConnection(resolvedUrl);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load settings')
+      setError(err instanceof Error ? err.message : "Failed to load settings");
     } finally {
-      setLoading(false)
+      setLoading(false);
     }
-  }
+  };
 
   const checkConnection = async (url?: string) => {
-    const checkUrl = url || serverUrl
-    if (!checkUrl) return
-    
-    setIsChecking(true)
-    setStatus('idle')
-    setError('')
-    
+    const checkUrl = url || serverUrl;
+    if (!checkUrl) return;
+
+    setIsChecking(true);
+    setStatus("idle");
+    setError("");
+
     try {
       const response = await fetch(`${checkUrl}/health`, {
-        method: 'GET',
-        headers: { 'Accept': 'application/json' },
-      })
-      
+        method: "GET",
+        headers: { Accept: "application/json" },
+      });
+
       if (response.ok) {
-        setStatus('online')
-        const data = await response.json().catch(() => null)
+        setStatus("online");
+        const data = await response.json().catch(() => null);
         if (data) {
           setServerInfo({
-            version: data.version || 'unknown',
-            status: data.status || 'healthy',
+            version: data.version || "unknown",
+            status: data.status || "healthy",
             uptime: data.uptime,
-          })
+          });
         }
       } else {
-        setStatus('offline')
-        setServerInfo(null)
+        setStatus("offline");
+        setServerInfo(null);
       }
     } catch {
-      setStatus('offline')
-      setServerInfo(null)
+      setStatus("offline");
+      setServerInfo(null);
     } finally {
-      setIsChecking(false)
+      setIsChecking(false);
     }
-  }
+  };
 
-  const handleCheckConnection = () => checkConnection()
+  const handleCheckConnection = () => void checkConnection();
 
   const handleSave = async () => {
     if (!serverUrl.trim()) {
-      setError(t('settings.server.emptyUrl') || '请输入服务器地址')
-      return
+      setError(t("settings.server.emptyUrl") || "请输入服务器地址");
+      return;
     }
-    
-    setLoading(true)
-    setError('')
-    
+
+    setLoading(true);
+    setError("");
+
     try {
-      // Save to backend settings
-      await api.put('/settings/api_base_url', { value: serverUrl.trim() })
-      
-      // Also save to localStorage for immediate effect using unified config
-      saveApiBaseUrl(serverUrl.trim())
-      
-      // Reload to apply new API URL
-      window.location.reload()
-      
-      setSaved(true)
-      setTimeout(() => setSaved(false), 2000)
-    } catch (err: any) {
-      setError(err.response?.data?.detail || err.message || '保存失败')
+      await api.put("/settings/api_base_url", { value: serverUrl.trim() });
+      saveApiBaseUrl(serverUrl.trim());
+      // The reload happens immediately, so setSaved/setTimeout below are
+      // mostly defensive — kept for visual feedback if reload is delayed.
+      window.location.reload();
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch (err) {
+      const detail =
+        (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
+      setError(detail || (err instanceof Error ? err.message : "保存失败"));
     } finally {
-      setLoading(false)
+      setLoading(false);
     }
-  }
+  };
 
   const handlePresetClick = (url: string) => {
-    setServerUrl(url)
-    checkConnection(url)
-  }
+    setServerUrl(url);
+    void checkConnection(url);
+  };
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center py-12">
-        <Loader2 className="w-6 h-6 text-primary animate-spin" />
+      <div
+        className="theme-codex flex items-center justify-center"
+        style={{ padding: "48px 0", color: "var(--color-codex-ink-mute)" }}
+      >
+        <Loader2 className="h-5 w-5 animate-spin" />
       </div>
-    )
+    );
   }
 
   return (
-    <div className="space-y-6">
+    <div
+      className="theme-codex"
+      data-testid="server-settings"
+      style={{
+        background: "var(--color-codex-bg)",
+        color: "var(--color-codex-ink)",
+        padding: "8px 4px 32px",
+      }}
+    >
       {/* Header */}
-      <div>
-        <h2 className="text-lg font-semibold text-on-surface mb-1">
-          {t('settings.server.title') || '服务器配置'}
-        </h2>
-        <p className="text-sm text-on-surface-muted">
-          {t('settings.server.subtitle') || '配置 AriaAI 后端服务器连接'}
+      <header style={{ marginBottom: 18 }}>
+        <h1
+          style={{
+            margin: 0,
+            fontSize: 22,
+            fontWeight: 500,
+            color: "var(--color-codex-ink)",
+            letterSpacing: "-0.015em",
+          }}
+        >
+          {t("settings.server.title") || "服务器配置"}
+        </h1>
+        <p
+          style={{
+            margin: "6px 0 0",
+            fontSize: 13,
+            color: "var(--color-codex-ink-mute)",
+            lineHeight: 1.6,
+          }}
+        >
+          {t("settings.server.subtitle") || "配置 AriaAI 后端服务器连接"}
         </p>
-      </div>
+      </header>
 
-      {/* Error Message */}
+      {/* Error */}
       {error && (
-        <div className="p-3 bg-error/10 border border-error/20 rounded-lg flex items-center gap-2 text-error text-sm">
-          <AlertTriangle className="w-4 h-4 flex-shrink-0" />
+        <div
+          role="alert"
+          className="mb-4 flex items-center gap-2"
+          style={{
+            padding: "9px 12px",
+            background: "color-mix(in oklch, var(--color-codex-bad) 8%, transparent)",
+            border: "1px solid color-mix(in oklch, var(--color-codex-bad) 30%, transparent)",
+            borderRadius: "var(--codex-r-sm, 3px)",
+            color: "var(--color-codex-bad)",
+            fontSize: 12,
+          }}
+        >
+          <AlertTriangle className="h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />
           {error}
         </div>
       )}
 
-      {/* Server Status Card */}
-      <div className="card">
-        <div className="flex items-center gap-4">
-          <div className={`w-12 h-12 rounded-xl flex items-center justify-center ${
-            status === 'online' 
-              ? 'bg-success/10 text-success' 
-              : status === 'offline'
-                ? 'bg-error/10 text-error'
-                : 'bg-surface-container-high text-on-surface-muted'
-          }`}>
-            {status === 'online' ? (
-              <Wifi className="w-6 h-6" />
-            ) : status === 'offline' ? (
-              <WifiOff className="w-6 h-6" />
+      {/* Status banner */}
+      <section
+        className="mb-4 flex items-center gap-4"
+        style={{
+          padding: "14px 16px",
+          background: "var(--color-codex-bg-elev)",
+          border: "1px solid var(--color-codex-line)",
+          borderRadius: "var(--codex-r-md, 6px)",
+        }}
+      >
+        <span
+          aria-hidden="true"
+          className="inline-flex items-center justify-center flex-shrink-0"
+          style={{
+            width: 40,
+            height: 40,
+            borderRadius: "var(--codex-r-sm, 3px)",
+            background:
+              status === "online"
+                ? "color-mix(in oklch, var(--color-codex-good) 14%, transparent)"
+                : status === "offline"
+                  ? "color-mix(in oklch, var(--color-codex-bad) 14%, transparent)"
+                  : "var(--color-codex-bg-tint)",
+            color:
+              status === "online"
+                ? "var(--color-codex-good)"
+                : status === "offline"
+                  ? "var(--color-codex-bad)"
+                  : "var(--color-codex-ink-mute)",
+          }}
+        >
+          {status === "online" ? (
+            <Wifi className="h-4 w-4" />
+          ) : status === "offline" ? (
+            <WifiOff className="h-4 w-4" />
+          ) : (
+            <Server className="h-4 w-4" />
+          )}
+        </span>
+        <div className="flex-1 min-w-0">
+          <div
+            style={{
+              fontSize: 14,
+              fontWeight: 500,
+              color: "var(--color-codex-ink)",
+            }}
+          >
+            {status === "online"
+              ? t("settings.server.connected") || "已连接"
+              : status === "offline"
+                ? t("settings.server.disconnected") || "未连接"
+                : t("settings.server.checking") || "检查中…"}
+          </div>
+          <div
+            className="mt-1 flex items-center gap-2"
+            style={{ fontSize: 12, color: "var(--color-codex-ink-mute)" }}
+          >
+            {serverInfo ? (
+              <>
+                <span className="font-mono">v{serverInfo.version}</span>
+                {serverInfo.uptime && (
+                  <>
+                    <span aria-hidden="true">·</span>
+                    <Clock className="h-3 w-3" aria-hidden="true" />
+                    <span className="font-mono">{serverInfo.uptime}</span>
+                  </>
+                )}
+              </>
             ) : (
-              <Server className="w-6 h-6" />
+              <span>
+                {status === "offline"
+                  ? t("settings.server.cannotConnect") || "无法连接到服务器"
+                  : t("settings.server.checkingStatus") || "正在检查服务器状态…"}
+              </span>
             )}
           </div>
-          <div className="flex-1">
-            <h3 className="font-medium text-on-surface">
-              {status === 'online' 
-                ? t('settings.server.connected') || '已连接'
-                : status === 'offline'
-                  ? t('settings.server.disconnected') || '未连接'
-                  : t('settings.server.checking') || '检查中...'}
-            </h3>
-            <p className="text-sm text-on-surface-muted">
-              {serverInfo ? (
-                <span className="flex items-center gap-2">
-                  <span>v{serverInfo.version}</span>
-                  {serverInfo.uptime && (
-                    <>
-                      <span>•</span>
-                      <Clock className="w-3 h-3" />
-                      <span>{serverInfo.uptime}</span>
-                    </>
-                  )}
-                </span>
-              ) : (
-                status === 'offline' 
-                  ? (t('settings.server.cannotConnect') || '无法连接到服务器')
-                  : (t('settings.server.checkingStatus') || '正在检查服务器状态...')
-              )}
-            </p>
-          </div>
+        </div>
+        <button
+          type="button"
+          onClick={handleCheckConnection}
+          disabled={isChecking}
+          className="inline-flex items-center gap-1.5 disabled:opacity-50"
+          style={GHOST_BUTTON_STYLE}
+        >
+          <RefreshCw
+            className={`h-3.5 w-3.5 ${isChecking ? "animate-spin" : ""}`}
+            aria-hidden="true"
+          />
+          {isChecking ? t("common.checking") || "检查中" : t("common.refresh") || "刷新"}
+        </button>
+      </section>
+
+      {/* URL config */}
+      <section
+        className="mb-4"
+        style={{
+          background: "var(--color-codex-bg-elev)",
+          border: "1px solid var(--color-codex-line)",
+          borderRadius: "var(--codex-r-md, 6px)",
+          padding: "16px 20px",
+        }}
+      >
+        <div
+          className="mb-3 flex items-center gap-2"
+          style={{ fontSize: 13.5, fontWeight: 600, color: "var(--color-codex-ink)" }}
+        >
+          <Globe className="h-4 w-4" aria-hidden="true" />
+          {t("settings.server.address") || "服务器地址"}
+        </div>
+
+        {/* Snapshot */}
+        <div
+          style={{
+            padding: "12px 14px",
+            background: "var(--color-codex-bg-tint)",
+            borderRadius: "var(--codex-r-sm, 3px)",
+            fontSize: 12.5,
+            marginBottom: 12,
+          }}
+        >
+          <SnapshotRow
+            label={t("settings.server.currentSource") || "当前生效来源"}
+            value={sourceLabels[effectiveSource]}
+          />
+          <SnapshotRow
+            label={t("settings.server.currentValue") || "当前生效地址"}
+            value={effectiveUrl}
+            mono
+          />
+          <SnapshotRow
+            label={t("settings.server.backendValue") || "后端存储值"}
+            value={backendServerUrl || t("settings.server.notSet") || "未设置"}
+            mono
+          />
+        </div>
+
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={serverUrl}
+            onChange={(e) => setServerUrl(e.target.value)}
+            placeholder="http://127.0.0.1:8000"
+            className="codex-input font-mono"
+            style={INPUT_STYLE}
+          />
           <button
+            type="button"
             onClick={handleCheckConnection}
-            disabled={isChecking}
-            className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-primary hover:bg-primary/10 rounded-xl transition-colors disabled:opacity-50"
+            disabled={isChecking || !serverUrl}
+            className="inline-flex items-center gap-1.5 disabled:opacity-50"
+            style={GHOST_BUTTON_STYLE}
           >
-            <RefreshCw className={`w-4 h-4 ${isChecking ? 'animate-spin' : ''}`} />
-            {isChecking ? (t('common.checking') || '检查中') : (t('common.refresh') || '刷新')}
+            <RefreshCw
+              className={`h-3.5 w-3.5 ${isChecking ? "animate-spin" : ""}`}
+              aria-hidden="true"
+            />
+            {t("settings.server.test") || "测试"}
           </button>
         </div>
-      </div>
 
-      {/* Server URL Configuration */}
-      <div className="card space-y-4">
-        <div className="flex items-center gap-3">
-          <Globe className="w-5 h-5 text-primary" />
-          <h3 className="font-medium text-on-surface">
-            {t('settings.server.address') || '服务器地址'}
-          </h3>
-        </div>
-
-        <div className="space-y-3">
-          <div className="rounded-xl bg-surface-container-low p-4 space-y-2 text-sm">
-            <div className="flex items-center justify-between gap-3">
-              <span className="text-on-surface-muted">{t('settings.server.currentSource') || '当前生效来源'}</span>
-              <span className="font-medium text-on-surface">{sourceLabels[effectiveSource]}</span>
-            </div>
-            <div className="flex items-center justify-between gap-3">
-              <span className="text-on-surface-muted">{t('settings.server.currentValue') || '当前生效地址'}</span>
-              <span className="font-mono text-on-surface text-right break-all">{effectiveUrl}</span>
-            </div>
-            <div className="flex items-center justify-between gap-3">
-              <span className="text-on-surface-muted">{t('settings.server.backendValue') || '后端存储值'}</span>
-              <span className="font-mono text-on-surface text-right break-all">
-                {backendServerUrl || (t('settings.server.notSet') || '未设置')}
-              </span>
-            </div>
+        {status !== "idle" && (
+          <div
+            className="mt-3 flex items-center gap-2"
+            style={{
+              padding: "8px 12px",
+              fontSize: 12,
+              background:
+                status === "online"
+                  ? "color-mix(in oklch, var(--color-codex-good) 8%, transparent)"
+                  : "color-mix(in oklch, var(--color-codex-bad) 8%, transparent)",
+              border: `1px solid color-mix(in oklch, var(${
+                status === "online" ? "--color-codex-good" : "--color-codex-bad"
+              }) 30%, transparent)`,
+              borderRadius: "var(--codex-r-sm, 3px)",
+              color:
+                status === "online"
+                  ? "var(--color-codex-good)"
+                  : "var(--color-codex-bad)",
+            }}
+          >
+            {status === "online" ? (
+              <>
+                <Check className="h-3.5 w-3.5" aria-hidden="true" />
+                {t("settings.server.connectionSuccess") || "连接成功"}
+              </>
+            ) : (
+              <>
+                <AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" />
+                {t("settings.server.connectionFailed") || "连接失败，请检查服务器地址"}
+              </>
+            )}
           </div>
+        )}
+      </section>
 
-          <div className="flex gap-2">
-            <input
-              type="text"
-              value={serverUrl}
-              onChange={(e) => setServerUrl(e.target.value)}
-              placeholder="http://127.0.0.1:8000"
-              className="flex-1 px-4 py-2.5 bg-surface-container-lowest border border-outline/20 rounded-xl text-on-surface placeholder:text-on-surface-muted focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40 transition-all"
-            />
-            <button
-              onClick={handleCheckConnection}
-              disabled={isChecking || !serverUrl}
-              className="flex items-center gap-2 px-4 py-2.5 border border-outline/20 rounded-xl hover:bg-surface-container-high transition-all disabled:opacity-50 text-on-surface-secondary"
-            >
-              <RefreshCw className={`w-4 h-4 ${isChecking ? 'animate-spin' : ''}`} />
-              {t('settings.server.test') || '测试'}
-            </button>
-          </div>
-
-          {/* Connection Status */}
-          {status !== 'idle' && (
-            <div className={`flex items-center gap-2 p-3 rounded-lg text-sm ${
-              status === 'online' 
-                ? 'bg-success/10 text-success border border-success/20' 
-                : 'bg-error/10 text-error border border-error/20'
-            }`}>
-              {status === 'online' ? (
-                <>
-                  <Check className="w-4 h-4" />
-                  <span>{t('settings.server.connectionSuccess') || '连接成功'}</span>
-                </>
-              ) : (
-                <>
-                  <AlertTriangle className="w-4 h-4" />
-                  <span>{t('settings.server.connectionFailed') || '连接失败，请检查服务器地址'}</span>
-                </>
-              )}
-            </div>
-          )}
+      {/* Presets */}
+      <section
+        className="mb-4"
+        style={{
+          background: "var(--color-codex-bg-elev)",
+          border: "1px solid var(--color-codex-line)",
+          borderRadius: "var(--codex-r-md, 6px)",
+          padding: "16px 20px",
+        }}
+      >
+        <div
+          className="mb-3 flex items-center gap-2"
+          style={{ fontSize: 13.5, fontWeight: 600, color: "var(--color-codex-ink)" }}
+        >
+          <ChevronRight className="h-4 w-4" aria-hidden="true" />
+          {t("settings.server.presets") || "快速选择"}
         </div>
-      </div>
-
-      {/* Quick Presets */}
-      <div className="card space-y-4">
-        <h3 className="font-medium text-on-surface flex items-center gap-2">
-          <ChevronRight className="w-4 h-4 text-primary" />
-          {t('settings.server.presets') || '快速选择'}
-        </h3>
         <div className="flex flex-wrap gap-2">
           {[
-            { label: t('settings.server.local') || '本地开发', url: 'http://127.0.0.1:8000', icon: '🖥️' },
-            { label: t('settings.server.lan') || '局域网', url: 'http://192.168.1.100:8000', icon: '🌐' },
-            { label: t('settings.server.production') || '生产环境', url: 'https://aria.d2cgo.co', icon: '☁️' },
-          ].map(preset => (
-            <button
-              key={preset.label}
-              onClick={() => handlePresetClick(preset.url)}
-              className={`flex items-center gap-2 px-4 py-2.5 text-sm rounded-xl transition-all ${
-                serverUrl === preset.url
-                  ? 'bg-primary/10 text-primary border border-primary/20'
-                  : 'border border-outline/20 hover:bg-surface-container-high text-on-surface-secondary'
-              }`}
-            >
-              <span>{preset.icon}</span>
-              {preset.label}
-            </button>
-          ))}
+            {
+              label: t("settings.server.local") || "本地开发",
+              url: "http://127.0.0.1:8000",
+            },
+            {
+              label: t("settings.server.lan") || "局域网",
+              url: "http://192.168.1.100:8000",
+            },
+            {
+              label: t("settings.server.production") || "生产环境",
+              url: "https://aria.d2cgo.co",
+            },
+          ].map((preset) => {
+            const active = serverUrl === preset.url;
+            return (
+              <button
+                key={preset.label}
+                type="button"
+                onClick={() => handlePresetClick(preset.url)}
+                className="inline-flex items-center gap-2 transition"
+                style={{
+                  padding: "7px 12px",
+                  fontSize: 12.5,
+                  color: active
+                    ? "var(--color-codex-accent-ink)"
+                    : "var(--color-codex-ink-soft)",
+                  background: active
+                    ? "var(--color-codex-accent-bg)"
+                    : "var(--color-codex-bg)",
+                  border: `1px solid ${
+                    active
+                      ? "var(--color-codex-accent)"
+                      : "var(--color-codex-line)"
+                  }`,
+                  borderRadius: "var(--codex-r-sm, 3px)",
+                  fontWeight: active ? 500 : 400,
+                }}
+              >
+                {preset.label}
+                <span
+                  className="font-mono"
+                  style={{
+                    fontSize: 11,
+                    color: "var(--color-codex-ink-faint)",
+                  }}
+                >
+                  {preset.url.replace(/^https?:\/\//, "")}
+                </span>
+              </button>
+            );
+          })}
         </div>
-      </div>
+      </section>
 
-      {/* Security Info */}
-      <div className="bg-tertiary-container/30 rounded-xl p-4 border border-tertiary/20">
-        <div className="flex items-start gap-3">
-          <Shield className="w-5 h-5 text-tertiary flex-shrink-0 mt-0.5" />
-          <div>
-            <p className="font-medium text-on-surface text-sm">
-              {t('settings.server.security') || '连接安全'}
-            </p>
-            <p className="text-sm text-on-surface-muted mt-1">
-              {t('settings.server.securityDesc') || 
-                '本地开发使用 HTTP，生产环境建议使用 HTTPS 加密连接。所有 API 请求都需要身份验证。'}
-            </p>
-          </div>
-        </div>
-      </div>
-
-      {/* Help Link */}
-      <a 
-        href="https://docs.ariaai.com/server-setup" 
-        target="_blank" 
-        rel="noopener noreferrer"
-        className="flex items-center gap-2 text-sm text-primary hover:text-primary/80 transition-colors"
+      {/* Security info */}
+      <section
+        className="mb-4 flex items-start gap-3"
+        style={{
+          padding: "12px 14px",
+          background: "color-mix(in oklch, var(--color-codex-info) 5%, transparent)",
+          border: "1px solid color-mix(in oklch, var(--color-codex-info) 25%, transparent)",
+          borderRadius: "var(--codex-r-sm, 3px)",
+        }}
       >
-        <ExternalLink className="w-4 h-4" />
-        {t('settings.server.help') || '如何设置服务器？'}
+        <Shield
+          className="h-4 w-4 flex-shrink-0"
+          aria-hidden="true"
+          style={{ color: "var(--color-codex-info)", marginTop: 1 }}
+        />
+        <div>
+          <div
+            style={{
+              fontSize: 13,
+              fontWeight: 500,
+              color: "var(--color-codex-ink)",
+            }}
+          >
+            {t("settings.server.security") || "连接安全"}
+          </div>
+          <p
+            style={{
+              margin: "3px 0 0",
+              fontSize: 12,
+              color: "var(--color-codex-ink-soft)",
+              lineHeight: 1.6,
+            }}
+          >
+            {t("settings.server.securityDesc") ||
+              "本地开发使用 HTTP，生产环境建议使用 HTTPS 加密连接。所有 API 请求都需要身份验证。"}
+          </p>
+        </div>
+      </section>
+
+      {/* Help link */}
+      <a
+        href="https://docs.ariaai.com/server-setup"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="mb-5 inline-flex items-center gap-1.5"
+        style={{
+          fontSize: 12.5,
+          color: "var(--color-codex-accent)",
+        }}
+      >
+        <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+        {t("settings.server.help") || "如何设置服务器？"}
       </a>
 
-      {/* Save Button */}
-      <div className="flex items-center justify-between pt-4 border-t border-outline/20">
-        <p className="text-sm text-on-surface-muted">
+      {/* Footer — save */}
+      <div
+        className="flex items-center justify-between"
+        style={{
+          paddingTop: 14,
+          borderTop: "1px solid var(--color-codex-line-soft)",
+        }}
+      >
+        <p style={{ fontSize: 12, color: "var(--color-codex-ink-mute)" }}>
           {saved ? (
-            <span className="text-success flex items-center gap-1">
-              <Check className="w-4 h-4" />
-              {t('settings.saved') || '已保存'}
+            <span
+              className="inline-flex items-center gap-1"
+              style={{ color: "var(--color-codex-good)" }}
+            >
+              <Check className="h-3.5 w-3.5" aria-hidden="true" />
+              {t("settings.saved") || "已保存"}
             </span>
           ) : hasUnsavedChanges ? (
-            t('settings.unsavedChanges') || '有未保存的更改'
+            <span className="inline-flex items-center gap-1.5">
+              <CxStatus tone="warn">{t("settings.unsavedChanges") || "有未保存的更改"}</CxStatus>
+            </span>
           ) : (
-            t('settings.allSaved') || '所有更改已保存'
+            <>{t("settings.allSaved") || "所有更改已保存"}</>
           )}
         </p>
         <button
-          onClick={handleSave}
+          type="button"
+          onClick={() => void handleSave()}
           disabled={loading || !serverUrl}
-          className="flex items-center gap-2 px-6 py-2.5 bg-primary hover:bg-primary/90 disabled:opacity-50 text-white rounded-xl font-medium transition-all"
+          className="inline-flex items-center gap-1.5 disabled:cursor-not-allowed disabled:opacity-50"
+          style={PRIMARY_BUTTON_STYLE}
         >
           {loading ? (
             <>
-              <Loader2 className="w-4 h-4 animate-spin" />
-              {t('settings.saving') || '保存中...'}
+              <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+              {t("settings.saving") || "保存中…"}
             </>
           ) : saved ? (
             <>
-              <Check className="w-4 h-4" />
-              {t('settings.saved') || '已保存'}
+              <Check className="h-3.5 w-3.5" aria-hidden="true" />
+              {t("settings.saved") || "已保存"}
             </>
           ) : (
             <>
-              <Server className="w-4 h-4" />
-              {t('settings.server.save') || '保存并应用'}
+              <Server className="h-3.5 w-3.5" aria-hidden="true" />
+              {t("settings.server.save") || "保存并应用"}
             </>
           )}
         </button>
       </div>
     </div>
-  )
+  );
+}
+
+// ----------------------------------------------------------------------------
+
+function SnapshotRow({
+  label,
+  value,
+  mono = false,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3" style={{ padding: "2px 0" }}>
+      <span style={{ color: "var(--color-codex-ink-mute)" }}>{label}</span>
+      <span
+        className={mono ? "font-mono" : undefined}
+        style={{
+          color: "var(--color-codex-ink-soft)",
+          textAlign: "right",
+          wordBreak: "break-all",
+          maxWidth: "70%",
+        }}
+      >
+        {value}
+      </span>
+    </div>
+  );
 }


### PR DESCRIPTION
## What
Refactors two admin-style status / config pages to the Codex visual language. Zero overlap with the V0.0.5 knowledge WIP. Every existing behavior (API calls, state machine, save + reload semantics) preserved.

## Migration
- Page header (title + subtitle) + ghost refresh button
- Status banner — switches between good-tinted and warn-tinted variants based on ``getModeTone(governance)``
- 4-stat tile row (mode / current revision / latest / pending count) — mono numerics, tabular-nums, semantic accent colors per tile
- 2-col detail row: pending revisions chip list + operational commands mono code block
- Known revisions chip list at the bottom

## Server
- Page header + accent error alert
- Status banner — Wifi/WifiOff/Server icon in semantic-toned tile + version/uptime in mono + inline ghost refresh button
- URL config panel: 3-row config snapshot + input + ghost test button + connection-result chip
- Preset chip row — each shows label + abbreviated URL; active = accent-bg
- Security info note on info-tinted background
- External help link in accent color
- Footer: status text + dark-ink primary save CTA

## What's unchanged
Data fetching (``/health/db/migrations``, ``getApiConfig`` + ``/settings/`` + ``/health``), save semantics (``saveApiBaseUrl`` + ``window.location.reload()``), error handling, preset URLs.

## Test plan
- [x] ``tsc --noEmit`` clean
- [x] ``vitest run`` (full) → 513/513
- [x] ``vite build`` clean
- [x] ``git diff --cached`` reviewed — exactly 2 staged files
- [ ] **Manual after deploy**:
  - ``/settings/migrations`` — verify status banner tone, stat tiles, refresh works
  - ``/settings/server`` — verify status banner, test connection, change URL + save

## Next
Per user request, pivoting to PR 8/N — Workspace 工作台 shell + main table. Remaining settings pages get batched later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)