### PR TITLE
test: mock /user-memory in App.test.tsx to unblock AdminGuard test

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,10 +1,38 @@
-import { describe, it, expect, beforeEach, beforeAll } from 'vitest'
+import { describe, it, expect, beforeEach, beforeAll, vi } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import i18n from 'i18next'
 import { initReactI18next, I18nextProvider } from 'react-i18next'
 import en from './i18n/locales/en.json'
 import zh from './i18n/locales/zh.json'
+
+// Mock the API client so authenticated routes don't hang on /auth/me,
+// /user-memory, /settings/, and /messages/unread-count network calls.
+// The crucial mock is /user-memory returning ``onboarding_seen: true`` —
+// without it Layout's first-run gate redirects every authenticated
+// route to /onboarding, which would shadow the AdminGuard test.
+vi.mock('./api/client', () => ({
+  api: {
+    get: vi.fn(async (url: string) => {
+      if (url === '/auth/me')
+        return { id: 1, display_name: 'Test', email: 't@example.com', is_admin: false }
+      if (url === '/user-memory')
+        return {
+          preferences: { personal_info: { onboarding_seen: true } },
+          version: 1,
+          updated_at: '',
+        }
+      if (url === '/settings/') return { timezone: 'UTC' }
+      if (url === '/messages/unread-count') return { unread_count: 0 }
+      return {}
+    }),
+    post: vi.fn(async () => ({})),
+    put: vi.fn(async () => ({})),
+    patch: vi.fn(async () => ({})),
+    delete: vi.fn(async () => ({})),
+  },
+}))
+
 import App from './App'
 
 beforeAll(() => {


### PR DESCRIPTION
## Why
The ``AdminGuard > redirects non-admin to /403`` case was failing on ``main`` (pre-existing — confirmed by stashing my Workspace work across PR #32 / #33 and re-running). Test count was 512/513 instead of 513/513.

## Root cause (not a routing/guard regression)
The test renders ``MemoryRouter`` at ``/settings/memory-ops`` with a non-admin user in localStorage but **doesn't mock api/client**. So:

1. AuthGuard passes (``authToken`` present).
2. Layout fires ``api.get('/user-memory')``.
3. Unmocked → ``Network Error``.
4. Layout's fail-open (PR #16) sets ``userMemoryPrefs = {}``.
5. ``hasSeenOnboarding({})`` returns ``false``.
6. Layout returns ``<Navigate to="/onboarding">`` **before** the child route (and AdminGuard) can render.
7. Test ends up on Onboarding (matches the ``button aria-checked="false"`` chip-radio in the failure dump), never on Forbidden.

The redirect chain is correct in production — first-run users should always be bounced to /onboarding. The test just needed to model an already-onboarded user.

## Fix
Add ``vi.mock('./api/client', ...)`` returning sensible shapes for the 4 endpoints Layout fires on mount:
- ``/auth/me`` → Test user object
- ``/user-memory`` → ``preferences.personal_info.onboarding_seen: true`` so Layout's gate passes
- ``/settings/`` → ``{ timezone: 'UTC' }``
- ``/messages/unread-count`` → ``{ unread_count: 0 }``

Existing tests stay unchanged. All 7 App cases pass.

## Test plan
- [x] ``vitest run src/App.test.tsx`` → 7/7
- [x] ``vitest run`` (full) → 513/513 (was 512/513)
- [x] ``tsc --noEmit`` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)