### PR TITLE
Chat composer + skill panels — Codex (V0.0.6 · sub-D)

### DIFF
--- a/web/src/pages/chat/Chat.tsx
+++ b/web/src/pages/chat/Chat.tsx
@@ -2430,18 +2430,39 @@ export function Chat() {
 
           {/* Scroll-to-bottom fab */}
           {showScrollBtn && (
-            <button onClick={() => scrollToBottom()}
-              className="absolute bottom-6 right-6 w-8 h-8 rounded-full bg-white border border-gray-200 shadow-md flex items-center justify-center text-gray-400 hover:text-primary hover:border-primary/30 hover:shadow-lg transition-all"
+            <button
+              onClick={() => scrollToBottom()}
+              className="absolute bottom-6 right-6 flex h-8 w-8 items-center justify-center transition-all"
+              style={{
+                background: 'var(--color-codex-bg-elev)',
+                border: '1px solid var(--color-codex-line)',
+                color: 'var(--color-codex-ink-soft)',
+                borderRadius: 'var(--codex-r-pill, 999px)',
+                boxShadow: '0 4px 16px -4px rgba(0,0,0,0.08)',
+              }}
+              aria-label="Scroll to bottom"
             >
-              <ArrowDown className="w-3.5 h-3.5" />
+              <ArrowDown className="h-3.5 w-3.5" />
             </button>
           )}
         </div>
 
         {/* ── Input area ── */}
-        <div className="relative flex-shrink-0 border-t border-slate-200 bg-white px-3 pb-[calc(1rem+env(safe-area-inset-bottom))] pt-3 sm:px-6 sm:pb-5">
+        <div
+          className="relative flex-shrink-0 px-3 pb-[calc(1rem+env(safe-area-inset-bottom))] pt-3 sm:px-6 sm:pb-5"
+          style={{
+            background: 'var(--color-codex-bg)',
+            borderTop: '1px solid var(--color-codex-line)',
+          }}
+        >
           {/* Gradient fade — blends messages area into footer */}
-          <div className="absolute inset-x-0 top-0 h-10 bg-gradient-to-b from-transparent to-white -translate-y-full pointer-events-none" />
+          <div
+            className="pointer-events-none absolute inset-x-0 top-0 h-10 -translate-y-full"
+            style={{
+              background:
+                'linear-gradient(to bottom, transparent, var(--color-codex-bg))',
+            }}
+          />
           <div className={`mx-auto ${sidebarOpen ? 'max-w-4xl' : 'max-w-5xl'}`}>
             {/* Context pills */}
             <div className="flex items-center gap-1 mb-2 flex-nowrap overflow-x-auto pb-1 sm:flex-wrap sm:overflow-visible sm:pb-0">
@@ -2484,17 +2505,33 @@ export function Chat() {
                     {(() => {
                       const categories = ['all', ...Array.from(new Set(skills.map(s => s.category)))]
                       return (
-                        <div className="px-3 py-2 border-b border-gray-100">
+                        <div
+                          className="px-3 py-2"
+                          style={{ borderBottom: '1px solid var(--color-codex-line-soft)' }}
+                        >
                           <div className="flex flex-wrap gap-1">
-                            {categories.map(cat => (
-                              <button key={cat} onClick={e => { e.stopPropagation(); setSkillCategoryFilter(cat) }}
-                                className={`px-2 py-0.5 text-xs rounded-md transition-colors ${
-                                  skillCategoryFilter === cat ? 'bg-primary text-white' : 'bg-gray-100 text-gray-500 hover:bg-gray-200'
-                                }`}
-                              >
-                                {cat === 'all' ? (t('skills.allCategories') || '全部') : cat}
-                              </button>
-                            ))}
+                            {categories.map(cat => {
+                              const isActive = skillCategoryFilter === cat
+                              return (
+                                <button
+                                  key={cat}
+                                  onClick={e => { e.stopPropagation(); setSkillCategoryFilter(cat) }}
+                                  className="px-2 py-0.5 transition-colors"
+                                  style={{
+                                    fontSize: 11,
+                                    background: isActive
+                                      ? 'var(--color-codex-accent)'
+                                      : 'var(--color-codex-bg-tint)',
+                                    color: isActive
+                                      ? 'var(--color-codex-bg-elev)'
+                                      : 'var(--color-codex-ink-soft)',
+                                    borderRadius: 'var(--codex-r-sm, 3px)',
+                                  }}
+                                >
+                                  {cat === 'all' ? (t('skills.allCategories') || '全部') : cat}
+                                </button>
+                              )
+                            })}
                           </div>
                         </div>
                       )
@@ -2510,12 +2547,30 @@ export function Chat() {
                           }, {} as Record<string, Skill[]>)
                           return Object.entries(grouped).map(([category, categorySkills]) => (
                             <div key={category}>
-                              <div className="px-4 py-1.5 text-xs font-medium text-gray-400 bg-gray-50">{category}</div>
+                              <div
+                                className="px-4 py-1.5 font-mono"
+                                style={{
+                                  fontSize: 10.5,
+                                  background: 'var(--color-codex-bg-tint)',
+                                  color: 'var(--color-codex-ink-mute)',
+                                  letterSpacing: '0.06em',
+                                  textTransform: 'uppercase',
+                                }}
+                              >
+                                {category}
+                              </div>
                               {categorySkills.map(s => (
                                 <DropdownItem key={s.id} onClick={() => { setSelectedSkill(s.id); skillArmedRef.current = true; setShowSkillDropdown(false) }}>
                                   <div className="flex flex-col">
                                     <span>{s.name}</span>
-                                    {s.estimated_time && <span className="text-xs text-gray-400">{s.estimated_time}</span>}
+                                    {s.estimated_time && (
+                                      <span
+                                        className="font-mono"
+                                        style={{ fontSize: 10.5, color: 'var(--color-codex-ink-mute)' }}
+                                      >
+                                        {s.estimated_time}
+                                      </span>
+                                    )}
                                   </div>
                                 </DropdownItem>
                               ))}
@@ -2526,7 +2581,14 @@ export function Chat() {
                           <DropdownItem key={s.id} onClick={() => { setSelectedSkill(s.id); skillArmedRef.current = true; setShowSkillDropdown(false) }}>
                             <div className="flex flex-col">
                               <span>{s.name}</span>
-                              {s.estimated_time && <span className="text-xs text-gray-400">{s.estimated_time}</span>}
+                              {s.estimated_time && (
+                                <span
+                                  className="font-mono"
+                                  style={{ fontSize: 10.5, color: 'var(--color-codex-ink-mute)' }}
+                                >
+                                  {s.estimated_time}
+                                </span>
+                              )}
                             </div>
                           </DropdownItem>
                         ))
@@ -2540,9 +2602,25 @@ export function Chat() {
             {selectedSkillData && <SkillRequirementsPanel skill={selectedSkillData} />}
 
             {/* Textarea + actions */}
-            <div className="flex items-end gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2.5 shadow-sm focus-within:border-primary/40 focus-within:ring-4 focus-within:ring-primary/10 transition-all duration-200 sm:gap-3 sm:px-4 sm:py-3">
-              <button className="p-1.5 rounded-md hover:bg-slate-100 transition-colors text-slate-300 hover:text-slate-500 flex-shrink-0 mb-0.5 hidden sm:block">
-                <Paperclip className="w-4 h-4" />
+            <div
+              className="flex items-end gap-2 px-3 py-2.5 transition-all duration-200 sm:gap-3 sm:px-4 sm:py-3"
+              style={{
+                background: 'var(--color-codex-bg-elev)',
+                border: '1px solid var(--color-codex-line)',
+                borderRadius: 'var(--codex-r-md, 6px)',
+              }}
+            >
+              <button
+                className="hidden flex-shrink-0 p-1.5 transition-colors sm:block"
+                style={{
+                  marginBottom: 2,
+                  color: 'var(--color-codex-ink-faint)',
+                  borderRadius: 'var(--codex-r-sm, 3px)',
+                }}
+                title="Attach"
+                aria-label="Attach"
+              >
+                <Paperclip className="h-4 w-4" />
               </button>
               <textarea
                 ref={textareaRef}
@@ -2554,24 +2632,54 @@ export function Chat() {
                 placeholder={t('chat.placeholder')}
                 disabled={sending}
                 rows={1}
-                className="min-w-0 flex-1 bg-transparent text-[15px] text-slate-800 placeholder:text-slate-300 outline-none py-1.5 resize-none overflow-hidden disabled:opacity-50 leading-relaxed"
-                style={{ minHeight: '36px', maxHeight: '180px' }}
+                className="min-w-0 flex-1 resize-none overflow-hidden bg-transparent py-1.5 outline-none leading-relaxed disabled:opacity-50"
+                style={{
+                  minHeight: 36,
+                  maxHeight: 180,
+                  fontSize: 14.5,
+                  color: 'var(--color-codex-ink)',
+                }}
               />
               {sending ? (
-                <button onClick={handleStop} title={t('chat.stopGeneration')}
-                  className="p-2 rounded-lg bg-slate-100 hover:bg-slate-200 text-slate-500 transition-colors flex-shrink-0 mb-0.5"
+                <button
+                  onClick={handleStop}
+                  title={t('chat.stopGeneration')}
+                  className="flex-shrink-0 p-2 transition-colors"
+                  style={{
+                    marginBottom: 2,
+                    background: 'var(--color-codex-bg-tint)',
+                    color: 'var(--color-codex-ink-soft)',
+                    border: '1px solid var(--color-codex-line)',
+                    borderRadius: 'var(--codex-r-sm, 3px)',
+                  }}
                 >
-                  <Square className="w-3.5 h-3.5 fill-current" />
+                  <Square className="h-3.5 w-3.5 fill-current" />
                 </button>
               ) : (
-                <button onClick={handleSend} disabled={!input.trim()}
-                  className="p-2 rounded-lg bg-primary text-white hover:bg-primary/90 active:scale-95 transition-all disabled:opacity-25 flex-shrink-0 mb-0.5 shadow-sm shadow-primary/20"
+                <button
+                  onClick={handleSend}
+                  disabled={!input.trim()}
+                  className="flex-shrink-0 p-2 transition-all active:scale-95 disabled:opacity-25"
+                  style={{
+                    marginBottom: 2,
+                    background: 'var(--color-codex-accent)',
+                    color: 'var(--color-codex-bg-elev)',
+                    borderRadius: 'var(--codex-r-sm, 3px)',
+                  }}
+                  aria-label="Send"
                 >
-                  <Send className="w-3.5 h-3.5" />
+                  <Send className="h-3.5 w-3.5" />
                 </button>
               )}
             </div>
-            <p className="hidden text-xs text-gray-300 mt-2 text-center sm:block">
+            <p
+              className="mt-2 hidden text-center sm:block font-mono"
+              style={{
+                fontSize: 11,
+                color: 'var(--color-codex-ink-faint)',
+                letterSpacing: '0.04em',
+              }}
+            >
               {t('chat.shiftEnter')} · {t('chat.enterToSend')}
             </p>
           </div>
@@ -2580,22 +2688,63 @@ export function Chat() {
 
       {/* Delete Confirmation Dialog */}
       {showDeleteDialog && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-2xl p-6 w-full max-w-sm shadow-2xl border border-gray-200">
-            <h3 className="text-lg font-semibold text-gray-900 mb-2">{t('chat.deleteTitle')}</h3>
-            <p className="text-sm text-gray-500 mb-6">
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center p-4"
+          style={{ background: 'rgba(0, 0, 0, 0.4)' }}
+        >
+          <div
+            className="w-full max-w-sm p-6"
+            style={{
+              background: 'var(--color-codex-bg-elev)',
+              border: '1px solid var(--color-codex-line)',
+              borderRadius: 'var(--codex-r-md, 6px)',
+              boxShadow: '0 24px 60px -16px rgba(0,0,0,0.32)',
+            }}
+          >
+            <h3
+              style={{
+                fontSize: 16,
+                fontWeight: 600,
+                color: 'var(--color-codex-ink)',
+                margin: '0 0 8px',
+              }}
+            >
+              {t('chat.deleteTitle')}
+            </h3>
+            <p
+              style={{
+                fontSize: 13,
+                color: 'var(--color-codex-ink-soft)',
+                margin: '0 0 24px',
+                lineHeight: 1.6,
+              }}
+            >
               {t('chat.deleteConfirm')} {t('chat.deleteWarning')}
             </p>
             <div className="flex justify-end gap-3">
               <button
                 onClick={() => { setShowDeleteDialog(false); setDeleteTargetId(null) }}
-                className="px-4 py-2 text-gray-500 hover:bg-gray-100 rounded-lg transition-colors"
+                className="px-4 py-2 transition-colors"
+                style={{
+                  fontSize: 13,
+                  color: 'var(--color-codex-ink-soft)',
+                  background: 'var(--color-codex-bg)',
+                  border: '1px solid var(--color-codex-line)',
+                  borderRadius: 'var(--codex-r-sm, 3px)',
+                }}
               >
                 {t('common.cancel')}
               </button>
               <button
                 onClick={confirmDelete}
-                className="px-4 py-2 bg-red-500 hover:bg-red-600 text-white rounded-lg transition-colors"
+                className="px-4 py-2 transition-colors"
+                style={{
+                  fontSize: 13,
+                  fontWeight: 500,
+                  background: 'var(--color-codex-bad)',
+                  color: 'var(--color-codex-bg-elev)',
+                  borderRadius: 'var(--codex-r-sm, 3px)',
+                }}
               >
                 {t('common.delete')}
               </button>
@@ -2631,88 +2780,199 @@ function SkillRequirementsPanel({ skill }: { skill: Skill }) {
   
   const isQuick = extractMinutes(skill.estimated_time) <= 10
   
+  const typeLabel = isQuick
+    ? (t('skills.types.quick') || '快速')
+    : (t('skills.types.deep') || '深度')
+
   return (
-    <div className="mb-3 rounded-xl bg-primary/5 border border-gray-200 overflow-hidden">
-      {/* Header - always visible */}
+    <div
+      className="mb-3 overflow-hidden"
+      style={{
+        background: 'var(--color-codex-bg-elev)',
+        border: '1px solid var(--color-codex-line)',
+        borderRadius: 'var(--codex-r-md, 6px)',
+      }}
+    >
+      {/* Header */}
       <button
         onClick={() => setExpanded(!expanded)}
-        className="w-full flex items-center justify-between p-3 hover:bg-primary/10 transition-colors"
+        className="flex w-full items-center justify-between gap-3 p-3 transition-colors"
       >
-        <div className="flex items-center gap-2">
-          <Info className="w-4 h-4 text-primary" />
-          <span className="text-sm font-medium text-gray-700">
+        <div className="flex min-w-0 items-center gap-2">
+          <Info
+            className="h-4 w-4 flex-shrink-0"
+            style={{ color: 'var(--color-codex-accent)' }}
+          />
+          <span
+            style={{
+              fontSize: 12.5,
+              fontWeight: 600,
+              color: 'var(--color-codex-ink)',
+              letterSpacing: '0.02em',
+            }}
+          >
             {t('chat.skillRequirements') || '技能要求'}
           </span>
-          <span className="text-xs text-gray-400">
+          <span
+            className="truncate"
+            style={{ fontSize: 12, color: 'var(--color-codex-ink-mute)' }}
+          >
             {skill.name}
           </span>
-          <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${
-            isQuick ? 'bg-emerald-500/10 text-emerald-600' : 'bg-primary/10 text-primary'
-          }`}>
-            {isQuick ? (t('skills.types.quick') || '快速') : (t('skills.types.deep') || '深度')}
+          <span
+            className="font-mono"
+            style={{
+              padding: '1px 6px',
+              fontSize: 10.5,
+              background: 'var(--color-codex-bg-tint)',
+              color: 'var(--color-codex-ink-soft)',
+              borderRadius: 'var(--codex-r-pill, 999px)',
+              letterSpacing: '0.04em',
+              textTransform: 'uppercase',
+            }}
+          >
+            {typeLabel}
           </span>
           {skill.estimated_time && (
-            <span className="flex items-center gap-1 text-xs text-gray-400">
-              <Clock className="w-3 h-3" />
+            <span
+              className="flex items-center gap-1 font-mono"
+              style={{ fontSize: 10.5, color: 'var(--color-codex-ink-mute)' }}
+            >
+              <Clock className="h-3 w-3" />
               {skill.estimated_time}
             </span>
           )}
         </div>
-        <ChevronDown className={`w-4 h-4 text-gray-400 transition-transform ${expanded ? 'rotate-180' : ''}`} />
+        <ChevronDown
+          className={`h-4 w-4 transition-transform ${expanded ? 'rotate-180' : ''}`}
+          style={{ color: 'var(--color-codex-ink-faint)' }}
+        />
       </button>
-      
+
       {/* Expanded content */}
       {expanded && (
-        <div className="px-3 pb-3 border-t border-gray-200">
-          <div className="pt-3 space-y-3">
-            {/* Description */}
+        <div
+          className="px-3 pb-3"
+          style={{ borderTop: '1px solid var(--color-codex-line-soft)' }}
+        >
+          <div className="space-y-3 pt-3">
             {skill.description && (
               <div>
-                <p className="text-xs font-medium text-gray-500 mb-1">
+                <p
+                  className="mb-1 font-mono"
+                  style={{
+                    fontSize: 10.5,
+                    color: 'var(--color-codex-ink-mute)',
+                    letterSpacing: '0.06em',
+                    textTransform: 'uppercase',
+                  }}
+                >
                   {t('skills.description') || '描述'}
                 </p>
-                <p className="text-sm text-gray-700">{skill.description}</p>
+                <p style={{ fontSize: 13, color: 'var(--color-codex-ink)' }}>
+                  {skill.description}
+                </p>
               </div>
             )}
-            
-            {/* System Prompt */}
+
             {skill.system_prompt && (
               <div>
-                <p className="text-xs font-medium text-gray-500 mb-1">
+                <p
+                  className="mb-1 font-mono"
+                  style={{
+                    fontSize: 10.5,
+                    color: 'var(--color-codex-ink-mute)',
+                    letterSpacing: '0.06em',
+                    textTransform: 'uppercase',
+                  }}
+                >
                   {t('skills.systemPrompt') || '系统提示词'}
                 </p>
-                <div className="p-2.5 rounded-lg bg-gray-50 border border-gray-200">
-                  <p className="text-xs text-gray-700 leading-relaxed line-clamp-4 font-mono">
+                <div
+                  style={{
+                    padding: '8px 10px',
+                    background: 'var(--color-codex-bg-tint)',
+                    border: '1px solid var(--color-codex-line-soft)',
+                    borderRadius: 'var(--codex-r-sm, 3px)',
+                  }}
+                >
+                  <p
+                    className="font-mono line-clamp-4"
+                    style={{
+                      fontSize: 11.5,
+                      color: 'var(--color-codex-ink-soft)',
+                      lineHeight: 1.55,
+                      margin: 0,
+                    }}
+                  >
                     {skill.system_prompt}
                   </p>
                 </div>
               </div>
             )}
-            
-            {/* User Template */}
+
             {skill.user_template && (
               <div>
-                <p className="text-xs font-medium text-gray-500 mb-1">
+                <p
+                  className="mb-1 font-mono"
+                  style={{
+                    fontSize: 10.5,
+                    color: 'var(--color-codex-ink-mute)',
+                    letterSpacing: '0.06em',
+                    textTransform: 'uppercase',
+                  }}
+                >
                   {t('skills.userTemplate') || '用户模板'}
                 </p>
-                <div className="p-2.5 rounded-lg bg-gray-50 border border-gray-200">
-                  <p className="text-xs text-gray-700 leading-relaxed font-mono">
+                <div
+                  style={{
+                    padding: '8px 10px',
+                    background: 'var(--color-codex-bg-tint)',
+                    border: '1px solid var(--color-codex-line-soft)',
+                    borderRadius: 'var(--codex-r-sm, 3px)',
+                  }}
+                >
+                  <p
+                    className="font-mono"
+                    style={{
+                      fontSize: 11.5,
+                      color: 'var(--color-codex-ink-soft)',
+                      lineHeight: 1.55,
+                      margin: 0,
+                    }}
+                  >
                     {skill.user_template}
                   </p>
                 </div>
               </div>
             )}
-            
-            {/* Category & Tools */}
-            <div className="flex items-center gap-4 pt-1">
+
+            <div
+              className="flex items-center gap-4 pt-1"
+              style={{ fontSize: 11.5 }}
+            >
               <div>
-                <span className="text-xs text-gray-400">{t('skills.category') || '类别'}: </span>
-                <span className="text-xs font-medium text-gray-700">{skill.category}</span>
+                <span style={{ color: 'var(--color-codex-ink-mute)' }}>
+                  {t('skills.category') || '类别'}:{' '}
+                </span>
+                <span
+                  style={{ fontWeight: 500, color: 'var(--color-codex-ink)' }}
+                >
+                  {skill.category}
+                </span>
               </div>
               {skill.tools_definition_json && (
                 <div>
-                  <span className="text-xs text-gray-400">{t('skills.tools') || '工具'}: </span>
-                  <span className="text-xs font-medium text-gray-700">
+                  <span style={{ color: 'var(--color-codex-ink-mute)' }}>
+                    {t('skills.tools') || '工具'}:{' '}
+                  </span>
+                  <span
+                    className="font-mono"
+                    style={{
+                      fontWeight: 500,
+                      color: 'var(--color-codex-ink)',
+                    }}
+                  >
                     {(() => {
                       try {
                         const tools = JSON.parse(skill.tools_definition_json)
@@ -2787,40 +3047,98 @@ function SkillTemplateModal({ skill, variables, onApply, onCancel }: SkillTempla
   }
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-2xl w-full max-w-lg shadow-2xl border border-gray-200 overflow-hidden">
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      style={{ background: 'rgba(0, 0, 0, 0.4)' }}
+    >
+      <div
+        className="w-full max-w-lg overflow-hidden"
+        style={{
+          background: 'var(--color-codex-bg-elev)',
+          border: '1px solid var(--color-codex-line)',
+          borderRadius: 'var(--codex-r-md, 6px)',
+          boxShadow: '0 24px 60px -16px rgba(0,0,0,0.32)',
+        }}
+      >
         {/* Header */}
-        <div className="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <div className="w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center">
-              <Wrench className="w-5 h-5 text-primary" />
+        <div
+          className="flex items-center justify-between gap-3 px-6 py-4"
+          style={{ borderBottom: '1px solid var(--color-codex-line)' }}
+        >
+          <div className="flex min-w-0 items-center gap-3">
+            <div
+              className="flex h-10 w-10 flex-shrink-0 items-center justify-center"
+              style={{
+                background: 'var(--color-codex-accent-bg)',
+                color: 'var(--color-codex-accent)',
+                borderRadius: 'var(--codex-r-sm, 3px)',
+              }}
+            >
+              <Wrench className="h-5 w-5" />
             </div>
-            <div>
-              <h3 className="text-lg font-semibold text-gray-900">{skill.name}</h3>
-              <p className="text-xs text-gray-500">{t('chat.fillTemplate') || '填写模板变量'}</p>
+            <div className="min-w-0">
+              <h3
+                className="truncate"
+                style={{
+                  fontSize: 16,
+                  fontWeight: 600,
+                  color: 'var(--color-codex-ink)',
+                  margin: 0,
+                }}
+              >
+                {skill.name}
+              </h3>
+              <p
+                style={{
+                  fontSize: 11.5,
+                  color: 'var(--color-codex-ink-mute)',
+                  margin: '2px 0 0',
+                }}
+              >
+                {t('chat.fillTemplate') || '填写模板变量'}
+              </p>
             </div>
           </div>
-          <button 
+          <button
             onClick={onCancel}
-            className="p-2 rounded-xl hover:bg-gray-100 text-gray-500 transition-colors"
+            className="p-2 transition-colors"
+            style={{
+              color: 'var(--color-codex-ink-soft)',
+              borderRadius: 'var(--codex-r-sm, 3px)',
+            }}
+            aria-label="Close"
           >
-            <X className="w-5 h-5" />
+            <X className="h-5 w-5" />
           </button>
         </div>
 
         {/* Content */}
-        <div className="px-6 py-4 max-h-[60vh] overflow-auto">
-          {/* Description */}
+        <div className="max-h-[60vh] overflow-auto px-6 py-4">
           {skill.description && (
-            <p className="text-sm text-gray-500 mb-4">{skill.description}</p>
+            <p
+              style={{
+                fontSize: 13,
+                color: 'var(--color-codex-ink-soft)',
+                margin: '0 0 16px',
+              }}
+            >
+              {skill.description}
+            </p>
           )}
 
-          {/* Variable Inputs */}
           {variables.length > 0 ? (
-            <div className="space-y-3 mb-4">
+            <div className="mb-4 space-y-3">
               {variables.map((variable, idx) => (
                 <div key={variable.name}>
-                  <label className="block text-xs font-medium text-gray-500 mb-1.5">
+                  <label
+                    className="mb-1.5 block font-mono"
+                    style={{
+                      fontSize: 10.5,
+                      color: 'var(--color-codex-ink-mute)',
+                      letterSpacing: '0.06em',
+                      textTransform: 'uppercase',
+                    }}
+                  >
                     {variable.name}
                   </label>
                   <input
@@ -2828,42 +3146,102 @@ function SkillTemplateModal({ skill, variables, onApply, onCancel }: SkillTempla
                     value={values[variable.name] || ''}
                     onChange={(e) => setValues(prev => ({ ...prev, [variable.name]: e.target.value }))}
                     placeholder={`请输入${variable.name}...`}
-                    className="w-full px-3 py-2.5 rounded-xl bg-gray-50 border border-gray-200 text-sm text-gray-700 placeholder:text-gray-400 outline-none focus:border-primary/50 transition-colors"
+                    className="w-full px-3 py-2.5 outline-none transition-colors"
+                    style={{
+                      background: 'var(--color-codex-bg)',
+                      border: '1px solid var(--color-codex-line)',
+                      borderRadius: 'var(--codex-r-sm, 3px)',
+                      fontSize: 13,
+                      color: 'var(--color-codex-ink)',
+                    }}
                     autoFocus={idx === 0}
                   />
                 </div>
               ))}
             </div>
           ) : (
-            <div className="mb-4 p-3 rounded-xl bg-gray-50 border border-gray-200">
-              <p className="text-sm text-gray-500">{t('chat.noVariables') || '此模板没有需要填写的变量'}</p>
+            <div
+              className="mb-4 p-3"
+              style={{
+                background: 'var(--color-codex-bg-tint)',
+                border: '1px solid var(--color-codex-line-soft)',
+                borderRadius: 'var(--codex-r-sm, 3px)',
+              }}
+            >
+              <p style={{ fontSize: 13, color: 'var(--color-codex-ink-mute)', margin: 0 }}>
+                {t('chat.noVariables') || '此模板没有需要填写的变量'}
+              </p>
             </div>
           )}
 
           {/* Preview */}
           <div>
-            <p className="text-xs font-medium text-gray-500 mb-2">{t('chat.preview') || '预览'}</p>
-            <div className="p-3 rounded-xl bg-gray-50 border border-gray-200">
-              <p className="text-sm text-gray-700 whitespace-pre-wrap">{preview}</p>
+            <p
+              className="mb-2 font-mono"
+              style={{
+                fontSize: 10.5,
+                color: 'var(--color-codex-ink-mute)',
+                letterSpacing: '0.06em',
+                textTransform: 'uppercase',
+              }}
+            >
+              {t('chat.preview') || '预览'}
+            </p>
+            <div
+              style={{
+                padding: 12,
+                background: 'var(--color-codex-bg-tint)',
+                border: '1px solid var(--color-codex-line-soft)',
+                borderRadius: 'var(--codex-r-sm, 3px)',
+              }}
+            >
+              <p
+                className="whitespace-pre-wrap"
+                style={{
+                  fontSize: 13,
+                  color: 'var(--color-codex-ink-soft)',
+                  lineHeight: 1.6,
+                  margin: 0,
+                }}
+              >
+                {preview}
+              </p>
             </div>
           </div>
         </div>
 
         {/* Footer */}
-        <div className="px-6 py-4 border-t border-gray-200 flex justify-end gap-3">
+        <div
+          className="flex justify-end gap-3 px-6 py-4"
+          style={{ borderTop: '1px solid var(--color-codex-line)' }}
+        >
           <button
             type="button"
             onClick={onCancel}
-            className="px-4 py-2 text-gray-500 hover:bg-gray-100 rounded-xl transition-colors"
+            className="px-4 py-2 transition-colors"
+            style={{
+              fontSize: 13,
+              color: 'var(--color-codex-ink-soft)',
+              background: 'var(--color-codex-bg)',
+              border: '1px solid var(--color-codex-line)',
+              borderRadius: 'var(--codex-r-sm, 3px)',
+            }}
           >
             {t('common.cancel')}
           </button>
           <button
             type="button"
             onClick={handleApply}
-            className="px-4 py-2 bg-primary hover:bg-primary/90 text-white rounded-xl transition-colors flex items-center gap-2"
+            className="flex items-center gap-2 px-4 py-2 transition-colors"
+            style={{
+              fontSize: 13,
+              fontWeight: 500,
+              background: 'var(--color-codex-accent)',
+              color: 'var(--color-codex-bg-elev)',
+              borderRadius: 'var(--codex-r-sm, 3px)',
+            }}
           >
-            <Send className="w-4 h-4" />
+            <Send className="h-4 w-4" />
             {t('chat.applyAndSend') || '应用并发送'}
           </button>
         </div>
@@ -2911,32 +3289,51 @@ function ExportDropdown({ conversationId, conversationTitle }: {
       <button
         onClick={() => setIsOpen(!isOpen)}
         disabled={isExporting}
-        className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-colors disabled:opacity-50"
+        className="flex items-center gap-1.5 px-3 py-1.5 transition-colors disabled:opacity-50"
+        style={{
+          fontSize: 12.5,
+          color: 'var(--color-codex-ink-soft)',
+          borderRadius: 'var(--codex-r-sm, 3px)',
+        }}
         title={t('chat.export')}
       >
         {isExporting ? (
-          <Loader2 className="w-4 h-4 animate-spin" />
+          <Loader2 className="h-4 w-4 animate-spin" />
         ) : (
-          <Download className="w-4 h-4" />
+          <Download className="h-4 w-4" />
         )}
         <span className="hidden sm:inline">{t('chat.export')}</span>
-        <ChevronDown className="w-3 h-3" />
+        <ChevronDown className="h-3 w-3" />
       </button>
-      
+
       {isOpen && (
-        <div className="absolute right-0 top-full mt-1 w-44 bg-white rounded-lg shadow-lg border border-gray-200 py-1 z-50 animate-fade-in">
+        <div
+          className="animate-fade-in absolute right-0 top-full z-50 mt-1 w-44 py-1"
+          style={{
+            background: 'var(--color-codex-bg-elev)',
+            border: '1px solid var(--color-codex-line)',
+            borderRadius: 'var(--codex-r-md, 6px)',
+            boxShadow: '0 4px 16px -4px rgba(0,0,0,0.08)',
+          }}
+        >
           <button
             onClick={() => handleExport('markdown')}
-            className="w-full flex items-center gap-2 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+            className="flex w-full items-center gap-2 px-4 py-2 transition-colors"
+            style={{ fontSize: 13, color: 'var(--color-codex-ink)' }}
+            onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--color-codex-bg-tint)' }}
+            onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent' }}
           >
-            <FileText className="w-4 h-4 text-gray-400" />
+            <FileText className="h-4 w-4" style={{ color: 'var(--color-codex-ink-faint)' }} />
             {t('chat.exportMarkdown')}
           </button>
           <button
             onClick={() => handleExport('pdf')}
-            className="w-full flex items-center gap-2 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+            className="flex w-full items-center gap-2 px-4 py-2 transition-colors"
+            style={{ fontSize: 13, color: 'var(--color-codex-ink)' }}
+            onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--color-codex-bg-tint)' }}
+            onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent' }}
           >
-            <FileIcon className="w-4 h-4 text-red-400" />
+            <FileIcon className="h-4 w-4" style={{ color: 'var(--color-codex-bad)' }} />
             {t('chat.exportPDF')}
           </button>
         </div>
@@ -3134,31 +3531,55 @@ const ContextPill = forwardRef<HTMLDivElement, {
   open: boolean
   onToggle: () => void
   children?: React.ReactNode
-}>(({ icon, label, active, secondary, open, onToggle, children }, ref) => (
-  <div className="relative shrink-0" ref={ref}>
-    <button
-      onClick={onToggle}
-      aria-expanded={open}
-      className={`flex max-w-[70vw] items-center gap-1.5 truncate px-2.5 py-1 rounded-lg text-xs transition-colors sm:max-w-none ${
-        active
-          ? secondary
-            ? 'bg-gray-100/80 text-gray-600'
-            : 'bg-primary/8 text-primary'
-          : 'text-gray-400 hover:text-gray-600 hover:bg-gray-100/70'
-      }`}
-    >
-      {icon}
-      {label}
-    </button>
-    {children}
-  </div>
-))
+}>(({ icon, label, active, secondary, open, onToggle, children }, ref) => {
+  let background = 'transparent'
+  let color = 'var(--color-codex-ink-mute)'
+  if (active) {
+    if (secondary) {
+      background = 'var(--color-codex-bg-tint)'
+      color = 'var(--color-codex-ink-soft)'
+    } else {
+      background = 'var(--color-codex-accent-bg)'
+      color = 'var(--color-codex-accent-ink)'
+    }
+  }
+  return (
+    <div className="relative shrink-0" ref={ref}>
+      <button
+        onClick={onToggle}
+        aria-expanded={open}
+        className="flex max-w-[70vw] items-center gap-1.5 truncate px-2.5 py-1 transition-colors sm:max-w-none"
+        style={{
+          background,
+          color,
+          borderRadius: 'var(--codex-r-sm, 3px)',
+          fontSize: 11.5,
+          letterSpacing: '0.02em',
+        }}
+      >
+        {icon}
+        {label}
+      </button>
+      {children}
+    </div>
+  )
+})
 ContextPill.displayName = 'ContextPill'
 
 // ─── Dropdown primitives ─────────────────────────────────────────────────────
 function DropdownMenu({ children, wide }: { children: React.ReactNode; wide?: boolean }) {
   return (
-    <div className={`absolute bottom-full left-0 z-50 mb-2 max-w-[calc(100vw-1.5rem)] rounded-xl border border-gray-200 bg-white py-1.5 shadow-lg ${wide ? 'w-[calc(100vw-1.5rem)] sm:w-80' : 'w-60'}`}>
+    <div
+      className={`absolute bottom-full left-0 z-50 mb-2 max-w-[calc(100vw-1.5rem)] py-1.5 ${
+        wide ? 'w-[calc(100vw-1.5rem)] sm:w-80' : 'w-60'
+      }`}
+      style={{
+        background: 'var(--color-codex-bg-elev)',
+        border: '1px solid var(--color-codex-line)',
+        borderRadius: 'var(--codex-r-md, 6px)',
+        boxShadow: '0 4px 16px -4px rgba(0,0,0,0.08)',
+      }}
+    >
       {children}
     </div>
   )
@@ -3172,9 +3593,19 @@ function DropdownItem({ onClick, children, muted }: {
   return (
     <button
       onClick={onClick}
-      className={`w-full px-4 py-2 text-left text-sm hover:bg-gray-50 transition-colors ${
-        muted ? 'text-gray-400' : 'text-gray-700'
-      }`}
+      className="w-full px-4 py-2 text-left transition-colors hover:bg-codex-bg-tint"
+      style={{
+        fontSize: 13,
+        color: muted
+          ? 'var(--color-codex-ink-mute)'
+          : 'var(--color-codex-ink)',
+      }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.background = 'var(--color-codex-bg-tint)'
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.background = 'transparent'
+      }}
     >
       {children}
     </button>


### PR DESCRIPTION
## Summary

Final slice of the chat refactor. Brings the remaining composer chrome to Codex tokens so the page no longer mixes slate / primary / emerald with the parchment palette.

- **Composer footer** — codex bg, hairline top divider, bg-elev input shell, accent send button, codex stop button, mono shortcut hint
- **ContextPill** — accent-bg for primary active, bg-tint for secondary active, hairline sm radius
- **Skill dropdown** — accent-fill active category chip, bg-tint inactive, mono uppercase category headers, mono estimated-time hints
- **SkillRequirementsPanel** — bg-elev card, mono uppercase field labels, bg-tint code blocks for prompt / template
- **SkillTemplateModal** — codex shell, accent-bg icon tile, mono variable labels, bg-tint preview, codex ghost cancel + accent apply
- **ExportDropdown** — codex menu shell, bg-tint hover
- **Delete dialog** — codex shell, codex ghost cancel + `--color-codex-bad` destructive
- **Scroll-to-bottom fab** — codex bg-elev pill with hairline border
- **DropdownMenu / DropdownItem** primitives — codex shell + bg-tint hover

No behavior changes — same props, same handlers, same dropdown logic.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 513 passed
- [x] `npx vite build` clean
- [ ] Visual smoke: open workspace chat, exercise composer (textarea, send, stop), open project/skill ContextPill dropdowns, fire skill template modal, open export dropdown, fire delete dialog — confirm everything stays in Codex palette.

🤖 Generated with [Claude Code](https://claude.com/claude-code)