### PR TITLE
Settings admin pages — Codex (V0.0.6 · 12/N)

### DIFF
--- a/web/src/pages/settings/AboutSettings.tsx
+++ b/web/src/pages/settings/AboutSettings.tsx
@@ -34,6 +34,21 @@ interface ChangelogEntry {
   changes: string[]
 }
 
+const labelStyle: React.CSSProperties = {
+  fontSize: 10.5,
+  fontFamily: 'var(--font-mono, ui-monospace, monospace)',
+  color: 'var(--color-codex-ink-mute)',
+  letterSpacing: '0.06em',
+  textTransform: 'uppercase',
+}
+
+const cardStyle: React.CSSProperties = {
+  padding: 18,
+  background: 'var(--color-codex-bg-elev)',
+  border: '1px solid var(--color-codex-line)',
+  borderRadius: 'var(--codex-r-md, 6px)',
+}
+
 export function AboutSettings() {
   const { i18n, t } = useTranslation()
   const isZh = i18n.language.startsWith('zh')
@@ -107,15 +122,15 @@ export function AboutSettings() {
   ]
 
   const techStack = [
-    { name: 'React', color: 'bg-sky-100 text-sky-700 border-sky-200' },
-    { name: 'TypeScript', color: 'bg-blue-100 text-blue-700 border-blue-200' },
-    { name: 'Vite', color: 'bg-violet-100 text-violet-700 border-violet-200' },
-    { name: 'Tailwind CSS', color: 'bg-cyan-100 text-cyan-700 border-cyan-200' },
-    { name: 'FastAPI', color: 'bg-emerald-100 text-emerald-700 border-emerald-200' },
-    { name: 'PostgreSQL', color: 'bg-indigo-100 text-indigo-700 border-indigo-200' },
-    { name: 'SQLModel', color: 'bg-amber-100 text-amber-700 border-amber-200' },
-    { name: 'Claude API', color: 'bg-orange-100 text-orange-700 border-orange-200' },
-    { name: 'Moonshot AI', color: 'bg-fuchsia-100 text-fuchsia-700 border-fuchsia-200' },
+    'React',
+    'TypeScript',
+    'Vite',
+    'Tailwind CSS',
+    'FastAPI',
+    'PostgreSQL',
+    'SQLModel',
+    'Claude API',
+    'Moonshot AI',
   ]
 
   const links = [
@@ -193,35 +208,83 @@ export function AboutSettings() {
     t('about.subtitle') || (isZh ? '版本信息与技术说明' : 'Version info and technical details')
 
   const renderOverview = () => (
-    <div className="space-y-6">
-      <div className="overflow-hidden rounded-[28px] border border-sky-100 bg-[linear-gradient(135deg,_rgba(255,255,255,0.98),_rgba(239,246,255,0.96)_38%,_rgba(236,253,245,0.92)_100%)] p-6 shadow-[0_24px_70px_-42px_rgba(59,130,246,0.28)]">
-        <div className="flex flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
+    <div className="space-y-5">
+      {/* Identity card */}
+      <div style={cardStyle}>
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
           <div className="flex items-start gap-4">
-            <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-sky-500 shadow-lg shadow-sky-500/20">
-              <Sparkles className="h-8 w-8 text-white" />
+            <div
+              className="flex h-14 w-14 flex-shrink-0 items-center justify-center"
+              style={{
+                background: 'var(--color-codex-accent-bg)',
+                color: 'var(--color-codex-accent)',
+                borderRadius: 'var(--codex-r-md, 6px)',
+              }}
+            >
+              <Sparkles className="h-7 w-7" />
             </div>
-            <div className="space-y-2">
+            <div className="min-w-0 space-y-2">
               <div className="flex flex-wrap items-center gap-2">
-                <h3 className="text-2xl font-semibold text-slate-950">AriaAI</h3>
-                <span className="rounded-full bg-white/80 px-3 py-1 text-xs font-semibold text-sky-700 ring-1 ring-sky-100">
+                <h2
+                  style={{
+                    margin: 0,
+                    fontSize: 22,
+                    fontWeight: 500,
+                    color: 'var(--color-codex-ink)',
+                    letterSpacing: '-0.015em',
+                  }}
+                >
+                  AriaAI
+                </h2>
+                <span
+                  className="font-mono"
+                  style={{
+                    padding: '2px 8px',
+                    fontSize: 11,
+                    background: 'var(--color-codex-bg-tint)',
+                    color: 'var(--color-codex-ink-soft)',
+                    border: '1px solid var(--color-codex-line)',
+                    borderRadius: 'var(--codex-r-sm, 3px)',
+                    letterSpacing: '0.04em',
+                  }}
+                >
                   V{systemInfo.version}
                 </span>
                 <span
-                  className={`rounded-full px-3 py-1 text-xs font-medium ${
-                    systemInfo.apiStatus === 'online'
-                      ? 'bg-emerald-100 text-emerald-700 ring-1 ring-emerald-200'
-                      : 'bg-rose-100 text-rose-700 ring-1 ring-rose-200'
-                  }`}
+                  className="font-mono"
+                  style={{
+                    padding: '2px 8px',
+                    fontSize: 10.5,
+                    background:
+                      systemInfo.apiStatus === 'online'
+                        ? 'var(--color-codex-accent-bg)'
+                        : 'color-mix(in oklch, var(--color-codex-bad) 12%, transparent)',
+                    color:
+                      systemInfo.apiStatus === 'online'
+                        ? 'var(--color-codex-accent-ink)'
+                        : 'var(--color-codex-bad)',
+                    borderRadius: 'var(--codex-r-pill, 999px)',
+                    letterSpacing: '0.06em',
+                    textTransform: 'uppercase',
+                  }}
                 >
                   {systemInfo.apiStatus === 'online'
-                    ? t('about.systemOnline') || (isZh ? '系统在线' : 'Online')
-                    : t('about.systemOffline') || (isZh ? '系统离线' : 'Offline')}
+                    ? t('about.systemOnline') || (isZh ? '在线' : 'Online')
+                    : t('about.systemOffline') || (isZh ? '离线' : 'Offline')}
                 </span>
               </div>
-              <p className="text-sm text-slate-600">
+              <p style={{ margin: 0, fontSize: 13, color: 'var(--color-codex-ink-soft)' }}>
                 {t('about.tagline') || (isZh ? '智能咨询助手' : 'Intelligent Consulting Assistant')}
               </p>
-              <p className="max-w-2xl text-sm leading-6 text-slate-600">
+              <p
+                style={{
+                  margin: 0,
+                  maxWidth: 560,
+                  fontSize: 12.5,
+                  lineHeight: 1.6,
+                  color: 'var(--color-codex-ink-mute)',
+                }}
+              >
                 {isZh
                   ? '当前版本页汇总产品版本、打包时间、API 状态与基础技术栈，方便发布留档与环境核对。'
                   : 'This release page summarizes the product version, build time, API status, and baseline stack for quick release verification.'}
@@ -230,36 +293,51 @@ export function AboutSettings() {
           </div>
           <button
             onClick={copyVersionInfo}
-            className="inline-flex items-center gap-2 self-start rounded-2xl border border-white/80 bg-white/85 px-4 py-2.5 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-white"
+            className="inline-flex flex-shrink-0 items-center gap-2 self-start px-3 py-2 transition-colors"
+            style={{
+              fontSize: 12.5,
+              background: 'var(--color-codex-bg)',
+              color: 'var(--color-codex-ink-soft)',
+              border: '1px solid var(--color-codex-line)',
+              borderRadius: 'var(--codex-r-sm, 3px)',
+            }}
             title={t('about.copyInfo') || (isZh ? '复制版本信息' : 'Copy version info')}
           >
-            {copied ? <Check className="h-4 w-4 text-emerald-600" /> : <Copy className="h-4 w-4" />}
-            {copied ? (isZh ? '已复制' : 'Copied') : t('about.copyInfo') || (isZh ? '复制版本信息' : 'Copy version info')}
+            {copied ? (
+              <Check className="h-3.5 w-3.5" style={{ color: 'var(--color-codex-accent)' }} />
+            ) : (
+              <Copy className="h-3.5 w-3.5" />
+            )}
+            {copied ? (isZh ? '已复制' : 'Copied') : t('about.copyInfo') || (isZh ? '复制版本信息' : 'Copy info')}
           </button>
         </div>
       </div>
 
-      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      {/* Stat grid */}
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
         {[
           {
             icon: Package,
             label: t('about.version') || (isZh ? '版本' : 'Version'),
             value: `V${systemInfo.version}`,
-            sub: t('about.webVersion') || (isZh ? '前端发布版本' : 'Web release version'),
+            sub: t('about.webVersion') || (isZh ? '前端发布版本' : 'Web release'),
           },
           {
             icon: Server,
             label: t('about.apiVersion') || (isZh ? 'API 版本' : 'API Version'),
             value: systemInfo.apiVersion || '-',
-            sub: systemInfo.apiStatus === 'online'
-              ? t('about.connected') || (isZh ? '接口已连接' : 'Connected')
-              : (isZh ? '接口未连接' : 'Unavailable'),
+            sub:
+              systemInfo.apiStatus === 'online'
+                ? t('about.connected') || (isZh ? '接口已连接' : 'Connected')
+                : isZh
+                  ? '接口未连接'
+                  : 'Unavailable',
           },
           {
             icon: Calendar,
             label: t('about.buildDate') || (isZh ? '构建日期' : 'Build Date'),
             value: systemInfo.buildDate,
-            sub: `${t('about.packagedAt') || (isZh ? '打包时间' : 'Packaged at')}: ${packagedAtLabel}`,
+            sub: `${t('about.packagedAt') || (isZh ? '打包时间' : 'Packaged')}: ${packagedAtLabel}`,
           },
           {
             icon: Shield,
@@ -273,36 +351,89 @@ export function AboutSettings() {
         ].map((item) => (
           <div
             key={item.label}
-            className="rounded-3xl border border-slate-200/80 bg-white/92 p-5 shadow-[0_16px_40px_-32px_rgba(59,130,246,0.2)]"
+            style={{
+              padding: 16,
+              background: 'var(--color-codex-bg-elev)',
+              border: '1px solid var(--color-codex-line)',
+              borderRadius: 'var(--codex-r-md, 6px)',
+            }}
           >
             <div className="mb-3 flex items-center justify-between">
-              <div className="text-sm text-slate-500">{item.label}</div>
-              <div className="rounded-xl bg-sky-50 p-2 text-sky-600">
-                <item.icon className="h-4 w-4" />
+              <div style={labelStyle}>{item.label}</div>
+              <div
+                className="flex h-7 w-7 items-center justify-center"
+                style={{
+                  background: 'var(--color-codex-bg-tint)',
+                  color: 'var(--color-codex-ink-soft)',
+                  borderRadius: 'var(--codex-r-sm, 3px)',
+                }}
+              >
+                <item.icon className="h-3.5 w-3.5" />
               </div>
             </div>
-            <div className="text-xl font-semibold text-slate-950">{item.value}</div>
-            <div className="mt-2 text-sm leading-6 text-slate-600">{item.sub}</div>
+            <div
+              className="font-mono"
+              style={{
+                fontSize: 18,
+                fontWeight: 500,
+                color: 'var(--color-codex-ink)',
+                letterSpacing: '-0.01em',
+              }}
+            >
+              {item.value}
+            </div>
+            <div
+              style={{
+                marginTop: 6,
+                fontSize: 11.5,
+                lineHeight: 1.55,
+                color: 'var(--color-codex-ink-mute)',
+              }}
+            >
+              {item.sub}
+            </div>
           </div>
         ))}
       </div>
 
-      <div className="grid gap-5 lg:grid-cols-[1.05fr_0.95fr]">
-        <div className="rounded-[28px] border border-outline/10 bg-surface p-6 shadow-sm">
-          <div className="mb-4">
-            <h3 className="text-base font-semibold text-on-surface">
+      {/* Release notes + tech stack */}
+      <div className="grid gap-3 lg:grid-cols-[1.05fr_0.95fr]">
+        <div style={cardStyle}>
+          <div className="mb-3">
+            <h3 style={{ margin: 0, fontSize: 15, fontWeight: 600, color: 'var(--color-codex-ink)' }}>
               {isZh ? '版本说明' : 'Release Notes'}
             </h3>
-            <p className="mt-1 text-sm text-on-surface-muted">
+            <p style={{ margin: '4px 0 0', fontSize: 12, color: 'var(--color-codex-ink-mute)' }}>
               {isZh ? '当前记录版本的定位与说明。' : 'Purpose and scope of the current recorded release.'}
             </p>
           </div>
-          <div className="rounded-2xl border border-sky-100 bg-sky-50/70 p-4">
-            <div className="flex items-center gap-2 text-sm font-semibold text-sky-700">
-              <Sparkles className="h-4 w-4" />
+          <div
+            style={{
+              padding: 14,
+              background: 'var(--color-codex-bg-tint)',
+              border: '1px solid var(--color-codex-line-soft)',
+              borderRadius: 'var(--codex-r-sm, 3px)',
+            }}
+          >
+            <div
+              className="flex items-center gap-2"
+              style={{
+                fontSize: 12.5,
+                fontWeight: 600,
+                color: 'var(--color-codex-accent-ink)',
+              }}
+            >
+              <Sparkles className="h-3.5 w-3.5" />
               {isZh ? 'V0.0.3 发布版本' : 'V0.0.3 Release'}
             </div>
-            <p className="mt-3 text-sm leading-7 text-slate-700">
+            <p
+              style={{
+                margin: '10px 0 0',
+                fontSize: 12.5,
+                lineHeight: 1.7,
+                color: 'var(--color-codex-ink-soft)',
+              }}
+            >
               {isZh
                 ? '本版本聚焦 Skill 体系治理、Harness 架构设计和记忆系统升级，为 AriaAI 从项目助手向可控、可沉淀、可审计的项目 AI 工作台演进奠定架构基础。'
                 : 'This release focuses on Skill governance, Harness architecture design, and memory system upgrades, laying the architectural foundation for evolving AriaAI from a project assistant to a controllable, traceable, and auditable project AI workbench.'}
@@ -310,100 +441,229 @@ export function AboutSettings() {
           </div>
         </div>
 
-        <div className="rounded-[28px] border border-outline/10 bg-surface p-6 shadow-sm">
-          <div className="mb-4">
-            <h3 className="text-base font-semibold text-on-surface">
+        <div style={cardStyle}>
+          <div className="mb-3">
+            <h3 style={{ margin: 0, fontSize: 15, fontWeight: 600, color: 'var(--color-codex-ink)' }}>
               {t('about.techStack') || (isZh ? '技术栈' : 'Tech Stack')}
             </h3>
-            <p className="mt-1 text-sm text-on-surface-muted">
+            <p style={{ margin: '4px 0 0', fontSize: 12, color: 'var(--color-codex-ink-mute)' }}>
               {isZh ? '当前版本主要依赖的核心技术。' : 'Core technologies behind the current release.'}
             </p>
           </div>
           <div className="flex flex-wrap gap-2">
-            {techStack.map((tech) => (
-              <span key={tech.name} className={`rounded-xl border px-3 py-1.5 text-sm font-medium ${tech.color}`}>
-                {tech.name}
+            {techStack.map((name) => (
+              <span
+                key={name}
+                className="font-mono"
+                style={{
+                  padding: '4px 10px',
+                  fontSize: 11.5,
+                  background: 'var(--color-codex-bg-tint)',
+                  color: 'var(--color-codex-ink-soft)',
+                  border: '1px solid var(--color-codex-line-soft)',
+                  borderRadius: 'var(--codex-r-sm, 3px)',
+                  letterSpacing: '0.02em',
+                }}
+              >
+                {name}
               </span>
             ))}
           </div>
         </div>
       </div>
 
-      <div className="rounded-[28px] border border-outline/10 bg-surface p-6 shadow-sm">
-        <div className="mb-4">
-          <h3 className="text-base font-semibold text-on-surface">
+      {/* Quick links */}
+      <div style={cardStyle}>
+        <div className="mb-3">
+          <h3 style={{ margin: 0, fontSize: 15, fontWeight: 600, color: 'var(--color-codex-ink)' }}>
             {isZh ? '常用链接' : 'Quick Links'}
           </h3>
-          <p className="mt-1 text-sm text-on-surface-muted">
+          <p style={{ margin: '4px 0 0', fontSize: 12, color: 'var(--color-codex-ink-mute)' }}>
             {isZh ? '跳转到仓库、支持与反馈入口。' : 'Jump to repository, support, and feedback destinations.'}
           </p>
         </div>
-        <div className="grid gap-3 sm:grid-cols-2">
+        <div className="grid gap-2 sm:grid-cols-2">
           {links.map((link) => (
             <a
               key={link.title}
               href={link.href}
               target={link.href.startsWith('http') ? '_blank' : undefined}
               rel={link.href.startsWith('http') ? 'noopener noreferrer' : undefined}
-              className="group flex items-center gap-3 rounded-2xl border border-outline/10 bg-surface-container-low px-4 py-4 transition hover:border-outline/30 hover:bg-surface-container-lowest"
+              className="group flex items-center gap-3 transition-colors"
+              style={{
+                padding: '12px 14px',
+                background: 'var(--color-codex-bg)',
+                border: '1px solid var(--color-codex-line-soft)',
+                borderRadius: 'var(--codex-r-sm, 3px)',
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.background = 'var(--color-codex-bg-tint)'
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.background = 'var(--color-codex-bg)'
+              }}
             >
-              <div className="rounded-xl bg-surface-container-high p-2.5 text-on-surface-muted transition group-hover:bg-sky-50 group-hover:text-sky-600">
+              <div
+                className="flex h-8 w-8 items-center justify-center flex-shrink-0"
+                style={{
+                  background: 'var(--color-codex-bg-tint)',
+                  color: 'var(--color-codex-ink-soft)',
+                  borderRadius: 'var(--codex-r-sm, 3px)',
+                }}
+              >
                 <link.icon className="h-4 w-4" />
               </div>
               <div className="min-w-0 flex-1">
-                <div className="text-sm font-medium text-on-surface">{link.title}</div>
-                <div className="truncate text-xs text-on-surface-muted">{link.subtitle}</div>
+                <div
+                  style={{
+                    fontSize: 13,
+                    fontWeight: 500,
+                    color: 'var(--color-codex-ink)',
+                  }}
+                >
+                  {link.title}
+                </div>
+                <div
+                  className="truncate font-mono"
+                  style={{
+                    fontSize: 11,
+                    color: 'var(--color-codex-ink-mute)',
+                  }}
+                >
+                  {link.subtitle}
+                </div>
               </div>
-              <ExternalLink className="h-4 w-4 text-on-surface-muted" />
+              <ExternalLink
+                className="h-3.5 w-3.5"
+                style={{ color: 'var(--color-codex-ink-faint)' }}
+              />
             </a>
           ))}
         </div>
       </div>
 
-      <div className="flex flex-col gap-3 border-t border-outline/10 pt-6 text-xs text-on-surface-muted sm:flex-row sm:items-center sm:justify-between">
-        <p className="flex items-center gap-1">
-          Made with <Heart className="h-3 w-3 text-error" /> by AriaAI Team
+      {/* Footer */}
+      <div
+        className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
+        style={{
+          paddingTop: 18,
+          borderTop: '1px solid var(--color-codex-line-soft)',
+          fontSize: 11.5,
+          color: 'var(--color-codex-ink-mute)',
+        }}
+      >
+        <p className="flex items-center gap-1" style={{ margin: 0 }}>
+          Made with <Heart className="h-3 w-3" style={{ color: 'var(--color-codex-bad)' }} /> by AriaAI Team
         </p>
-        <p>© 2026 AriaAI. {t('about.allRightsReserved') || (isZh ? '保留所有权利' : 'All rights reserved')}</p>
+        <p style={{ margin: 0 }} className="font-mono">
+          © 2026 AriaAI. {t('about.allRightsReserved') || (isZh ? '保留所有权利' : 'All rights reserved')}
+        </p>
       </div>
     </div>
   )
 
   const renderChangelog = () => (
-    <div className="space-y-6">
+    <div className="space-y-5">
       <div>
-        <h3 className="text-lg font-semibold text-on-surface">
+        <h2 style={{ margin: 0, fontSize: 16, fontWeight: 600, color: 'var(--color-codex-ink)' }}>
           {t('about.changelog') || (isZh ? '更新日志' : 'Changelog')}
-        </h3>
-        <p className="mt-1 text-sm text-on-surface-muted">
+        </h2>
+        <p style={{ margin: '4px 0 0', fontSize: 12.5, color: 'var(--color-codex-ink-mute)' }}>
           {isZh ? '记录每个正式版本的重要变更。' : 'Track the important changes for each recorded release.'}
         </p>
       </div>
 
-      <div className="space-y-6">
+      <div className="space-y-4">
         {changelog.map((entry, index) => (
           <div
             key={entry.version}
-            className={`relative pl-6 ${index !== changelog.length - 1 ? 'border-l-2 border-outline/20 pb-6' : ''}`}
+            className="relative pl-6"
+            style={
+              index !== changelog.length - 1
+                ? {
+                    paddingBottom: 20,
+                    borderLeft: '1px solid var(--color-codex-line)',
+                    marginLeft: 4,
+                  }
+                : { marginLeft: 4 }
+            }
           >
-            <div className="absolute left-0 top-1 h-3 w-3 -translate-x-[7px] rounded-full bg-primary" />
-            <div className="rounded-2xl border border-outline/10 bg-surface p-5 shadow-sm">
-              <div className="mb-3 flex flex-wrap items-center gap-3">
-                <span className="rounded-lg bg-primary/10 px-2.5 py-1 text-sm font-semibold text-primary">
+            <div
+              className="absolute"
+              style={{
+                left: -5,
+                top: 6,
+                width: 9,
+                height: 9,
+                borderRadius: 'var(--codex-r-pill, 999px)',
+                background: index === 0 ? 'var(--color-codex-accent)' : 'var(--color-codex-ink-faint)',
+              }}
+            />
+            <div style={cardStyle}>
+              <div className="mb-3 flex flex-wrap items-center gap-2">
+                <span
+                  className="font-mono"
+                  style={{
+                    padding: '2px 8px',
+                    fontSize: 11.5,
+                    fontWeight: 600,
+                    background: 'var(--color-codex-bg-tint)',
+                    color: 'var(--color-codex-ink)',
+                    border: '1px solid var(--color-codex-line)',
+                    borderRadius: 'var(--codex-r-sm, 3px)',
+                    letterSpacing: '0.04em',
+                  }}
+                >
                   V{entry.version}
                 </span>
-                <span className="text-sm text-on-surface-muted">{entry.date}</span>
+                <span
+                  className="font-mono"
+                  style={{ fontSize: 11.5, color: 'var(--color-codex-ink-mute)' }}
+                >
+                  {entry.date}
+                </span>
                 {index === 0 ? (
-                  <span className="rounded-full bg-emerald-100 px-2.5 py-0.5 text-xs font-medium text-emerald-700">
+                  <span
+                    className="font-mono"
+                    style={{
+                      padding: '2px 8px',
+                      fontSize: 10.5,
+                      background: 'var(--color-codex-accent-bg)',
+                      color: 'var(--color-codex-accent-ink)',
+                      borderRadius: 'var(--codex-r-pill, 999px)',
+                      letterSpacing: '0.06em',
+                      textTransform: 'uppercase',
+                    }}
+                  >
                     {t('about.latest') || (isZh ? '最新' : 'Latest')}
                   </span>
                 ) : null}
               </div>
-              <p className="mb-4 text-sm leading-6 text-slate-700">{entry.summary}</p>
+              <p
+                style={{
+                  margin: '0 0 14px',
+                  fontSize: 13,
+                  lineHeight: 1.6,
+                  color: 'var(--color-codex-ink-soft)',
+                }}
+              >
+                {entry.summary}
+              </p>
               <ul className="space-y-2">
                 {entry.changes.map((change) => (
-                  <li key={change} className="flex items-start gap-2 text-sm text-on-surface">
-                    <ChevronRight className="mt-0.5 h-4 w-4 flex-shrink-0 text-primary" />
+                  <li
+                    key={change}
+                    className="flex items-start gap-2"
+                    style={{
+                      fontSize: 12.5,
+                      lineHeight: 1.6,
+                      color: 'var(--color-codex-ink)',
+                    }}
+                  >
+                    <ChevronRight
+                      className="mt-0.5 h-3.5 w-3.5 flex-shrink-0"
+                      style={{ color: 'var(--color-codex-accent)' }}
+                    />
                     {change}
                   </li>
                 ))}
@@ -416,39 +676,46 @@ export function AboutSettings() {
   )
 
   const renderLicense = () => (
-    <div className="space-y-6">
+    <div className="space-y-5">
       <div>
-        <h3 className="text-lg font-semibold text-on-surface">
+        <h2 style={{ margin: 0, fontSize: 16, fontWeight: 600, color: 'var(--color-codex-ink)' }}>
           {t('about.license') || (isZh ? '许可说明' : 'License')}
-        </h3>
-        <p className="mt-1 text-sm text-on-surface-muted">
+        </h2>
+        <p style={{ margin: '4px 0 0', fontSize: 12.5, color: 'var(--color-codex-ink-mute)' }}>
           {isZh ? '当前产品许可与第三方依赖许可概览。' : 'Overview of product licensing and third-party dependencies.'}
         </p>
       </div>
 
-      <div className="rounded-2xl border border-outline/10 bg-surface p-6 shadow-sm">
-        <h4 className="mb-4 font-medium text-on-surface">
+      <div style={cardStyle}>
+        <h3 style={{ margin: '0 0 14px', fontSize: 14, fontWeight: 600, color: 'var(--color-codex-ink)' }}>
           {isZh ? 'AriaAI 使用许可' : 'AriaAI License Agreement'}
-        </h4>
-        <div className="space-y-4 text-sm leading-7 text-on-surface-muted">
-          <p>Copyright © 2026 AriaAI. {t('about.allRightsReserved') || (isZh ? '保留所有权利' : 'All rights reserved')}.</p>
-          <p>
+        </h3>
+        <div
+          className="space-y-3"
+          style={{ fontSize: 12.5, lineHeight: 1.75, color: 'var(--color-codex-ink-mute)' }}
+        >
+          <p style={{ margin: 0 }}>
+            Copyright © 2026 AriaAI. {t('about.allRightsReserved') || (isZh ? '保留所有权利' : 'All rights reserved')}.
+          </p>
+          <p style={{ margin: 0 }}>
             {isZh
               ? '本软件为专有软件与保密资产。未经授权，不得以任何形式复制、转让或分发。'
               : 'This software is proprietary and confidential. Unauthorized copying, transfer, or distribution is prohibited.'}
           </p>
-          <p>
+          <p style={{ margin: 0 }}>
             {isZh
-              ? '软件按“现状”提供，不附带任何明示或暗示担保，包括适销性、特定用途适用性及非侵权担保。'
+              ? '软件按"现状"提供，不附带任何明示或暗示担保，包括适销性、特定用途适用性及非侵权担保。'
               : 'The software is provided "as is", without warranty of any kind, express or implied, including merchantability, fitness for a particular purpose, and noninfringement.'}
           </p>
         </div>
       </div>
 
       <div>
-        <h4 className="mb-3 font-medium text-on-surface">
+        <h3
+          style={{ margin: '0 0 12px', fontSize: 14, fontWeight: 600, color: 'var(--color-codex-ink)' }}
+        >
           {t('about.thirdPartyLicenses') || (isZh ? '第三方许可证' : 'Third-party Licenses')}
-        </h4>
+        </h3>
         <div className="space-y-2">
           {[
             { name: 'React', license: 'MIT License' },
@@ -458,10 +725,23 @@ export function AboutSettings() {
           ].map((item) => (
             <div
               key={item.name}
-              className="flex items-center justify-between rounded-xl border border-outline/10 bg-surface-container-low px-4 py-3"
+              className="flex items-center justify-between"
+              style={{
+                padding: '10px 14px',
+                background: 'var(--color-codex-bg-elev)',
+                border: '1px solid var(--color-codex-line)',
+                borderRadius: 'var(--codex-r-sm, 3px)',
+              }}
             >
-              <span className="text-sm font-medium text-on-surface">{item.name}</span>
-              <span className="text-xs text-on-surface-muted">{item.license}</span>
+              <span style={{ fontSize: 13, fontWeight: 500, color: 'var(--color-codex-ink)' }}>
+                {item.name}
+              </span>
+              <span
+                className="font-mono"
+                style={{ fontSize: 11, color: 'var(--color-codex-ink-mute)' }}
+              >
+                {item.license}
+              </span>
             </div>
           ))}
         </div>
@@ -471,37 +751,82 @@ export function AboutSettings() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center py-12">
-        <Loader2 className="h-6 w-6 animate-spin text-primary" />
+      <div
+        className="theme-codex flex items-center justify-center py-12"
+        style={{ background: 'var(--color-codex-bg)' }}
+      >
+        <Loader2 className="h-6 w-6 animate-spin" style={{ color: 'var(--color-codex-accent)' }} />
       </div>
     )
   }
 
   return (
-    <div className="space-y-6">
-      <div>
-        <h2 className="mb-1 text-lg font-semibold text-on-surface">{headerTitle}</h2>
-        <p className="text-sm text-on-surface-muted">{headerSubtitle}</p>
-      </div>
+    <div
+      className="theme-codex"
+      style={{
+        background: 'var(--color-codex-bg)',
+        color: 'var(--color-codex-ink)',
+        padding: '8px 4px 32px',
+      }}
+    >
+      <header style={{ marginBottom: 18 }}>
+        <h1
+          style={{
+            margin: 0,
+            fontSize: 22,
+            fontWeight: 500,
+            color: 'var(--color-codex-ink)',
+            letterSpacing: '-0.015em',
+          }}
+        >
+          {headerTitle}
+        </h1>
+        <p
+          style={{
+            margin: '6px 0 0',
+            fontSize: 13,
+            color: 'var(--color-codex-ink-mute)',
+            lineHeight: 1.6,
+          }}
+        >
+          {headerSubtitle}
+        </p>
+      </header>
 
-      <div className="flex gap-1 rounded-xl bg-surface-container-low p-1">
+      <div
+        className="mb-5 flex gap-1 p-1"
+        style={{
+          background: 'var(--color-codex-bg-elev)',
+          border: '1px solid var(--color-codex-line)',
+          borderRadius: 'var(--codex-r-sm, 3px)',
+        }}
+      >
         {[
           { id: 'overview', label: t('about.overview') || (isZh ? '概览' : 'Overview') },
           { id: 'changelog', label: t('about.changelog') || (isZh ? '更新日志' : 'Changelog') },
           { id: 'license', label: t('about.license') || (isZh ? '许可说明' : 'License') },
-        ].map((tab) => (
-          <button
-            key={tab.id}
-            onClick={() => setActiveTab(tab.id as 'overview' | 'changelog' | 'license')}
-            className={`flex-1 rounded-lg px-4 py-2 text-sm font-medium transition-all ${
-              activeTab === tab.id
-                ? 'bg-surface text-on-surface shadow-sm'
-                : 'text-on-surface-muted hover:text-on-surface'
-            }`}
-          >
-            {tab.label}
-          </button>
-        ))}
+        ].map((tab) => {
+          const isActive = activeTab === tab.id
+          return (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id as 'overview' | 'changelog' | 'license')}
+              className="flex-1 px-3 py-2 transition-all"
+              style={{
+                fontSize: 12.5,
+                fontWeight: isActive ? 600 : 500,
+                background: isActive ? 'var(--color-codex-bg)' : 'transparent',
+                color: isActive ? 'var(--color-codex-ink)' : 'var(--color-codex-ink-mute)',
+                borderRadius: 'var(--codex-r-sm, 3px)',
+                border: isActive
+                  ? '1px solid var(--color-codex-line)'
+                  : '1px solid transparent',
+              }}
+            >
+              {tab.label}
+            </button>
+          )
+        })}
       </div>
 
       {activeTab === 'overview' && renderOverview()}

--- a/web/src/pages/settings/ApiLimitsSettings.tsx
+++ b/web/src/pages/settings/ApiLimitsSettings.tsx
@@ -111,6 +111,22 @@ function isBudgetTight(budget: BudgetInfo | null) {
   return budget.remaining <= Math.max(5, Math.floor(budget.limit * 0.15))
 }
 
+type Tone = 'default' | 'warning' | 'danger' | 'success'
+
+const TONE_ICON_BG: Record<Tone, string> = {
+  default: 'var(--color-codex-bg-tint)',
+  warning: 'color-mix(in oklch, var(--color-codex-warn) 14%, transparent)',
+  danger: 'color-mix(in oklch, var(--color-codex-bad) 12%, transparent)',
+  success: 'var(--color-codex-accent-bg)',
+}
+
+const TONE_ICON_COLOR: Record<Tone, string> = {
+  default: 'var(--color-codex-ink-soft)',
+  warning: 'var(--color-codex-warn)',
+  danger: 'var(--color-codex-bad)',
+  success: 'var(--color-codex-accent)',
+}
+
 function StatusCard({
   icon: Icon,
   title,
@@ -122,32 +138,53 @@ function StatusCard({
   title: string
   value: string | number
   description: string
-  tone?: 'default' | 'warning' | 'danger' | 'success'
+  tone?: Tone
 }) {
-  const toneClass = {
-    default: 'bg-surface-container-low text-on-surface',
-    warning: 'bg-amber-50 text-amber-950',
-    danger: 'bg-red-50 text-red-950',
-    success: 'bg-emerald-50 text-emerald-950',
-  }[tone]
-
-  const iconClass = {
-    default: 'bg-primary/10 text-primary',
-    warning: 'bg-amber-100 text-amber-700',
-    danger: 'bg-red-100 text-red-700',
-    success: 'bg-emerald-100 text-emerald-700',
-  }[tone]
-
   return (
-    <div className={`rounded-2xl p-4 ${toneClass}`}>
+    <div
+      style={{
+        padding: 16,
+        background: 'var(--color-codex-bg-elev)',
+        border: '1px solid var(--color-codex-line)',
+        borderRadius: 'var(--codex-r-md, 6px)',
+      }}
+    >
       <div className="flex items-center justify-between gap-3">
-        <div className={`rounded-xl p-2 ${iconClass}`}>
-          <Icon className="h-5 w-5" />
+        <div
+          className="flex h-9 w-9 items-center justify-center"
+          style={{
+            background: TONE_ICON_BG[tone],
+            color: TONE_ICON_COLOR[tone],
+            borderRadius: 'var(--codex-r-sm, 3px)',
+          }}
+        >
+          <Icon className="h-4 w-4" />
         </div>
-        <div className="text-right text-2xl font-semibold">{value}</div>
+        <div
+          className="text-right font-mono"
+          style={{
+            fontSize: 22,
+            fontWeight: 500,
+            color: 'var(--color-codex-ink)',
+          }}
+        >
+          {value}
+        </div>
       </div>
-      <div className="mt-4 text-sm font-medium">{title}</div>
-      <div className="mt-1 text-xs opacity-75">{description}</div>
+      <div
+        className="mt-3 font-mono"
+        style={{
+          fontSize: 10.5,
+          color: 'var(--color-codex-ink-mute)',
+          letterSpacing: '0.06em',
+          textTransform: 'uppercase',
+        }}
+      >
+        {title}
+      </div>
+      <div style={{ marginTop: 4, fontSize: 11.5, color: 'var(--color-codex-ink-mute)', lineHeight: 1.5 }}>
+        {description}
+      </div>
     </div>
   )
 }
@@ -155,13 +192,24 @@ function StatusCard({
 function BudgetStrip({ title, budget, isZh }: { title: string; budget: BudgetInfo | null; isZh: boolean }) {
   const percent = getBudgetPercent(budget)
   const tight = isBudgetTight(budget)
+  const barColor = tight ? 'var(--color-codex-warn)' : 'var(--color-codex-accent)'
 
   return (
-    <div className="rounded-2xl border border-outline-variant/50 bg-surface-container-low p-4">
+    <div
+      style={{
+        padding: 14,
+        background: 'var(--color-codex-bg-elev)',
+        border: '1px solid var(--color-codex-line)',
+        borderRadius: 'var(--codex-r-sm, 3px)',
+      }}
+    >
       <div className="flex items-center justify-between gap-4">
-        <div>
-          <div className="text-sm font-medium text-on-surface">{title}</div>
-          <div className="mt-1 text-xs text-on-surface-muted">
+        <div className="min-w-0">
+          <div style={{ fontSize: 13, fontWeight: 500, color: 'var(--color-codex-ink)' }}>{title}</div>
+          <div
+            className="mt-0.5 font-mono"
+            style={{ fontSize: 11, color: 'var(--color-codex-ink-mute)' }}
+          >
             {budget
               ? isZh
                 ? `已用 ${budget.used} / ${budget.limit}，剩余 ${budget.remaining}`
@@ -171,10 +219,39 @@ function BudgetStrip({ title, budget, isZh }: { title: string; budget: BudgetInf
                 : 'No budget data yet'}
           </div>
         </div>
-        {tight && <span className="rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-800">{isZh ? '接近上限' : 'Tight'}</span>}
+        {tight && (
+          <span
+            className="font-mono"
+            style={{
+              padding: '2px 8px',
+              fontSize: 10.5,
+              background: 'color-mix(in oklch, var(--color-codex-warn) 14%, transparent)',
+              color: 'var(--color-codex-warn)',
+              borderRadius: 'var(--codex-r-pill, 999px)',
+              letterSpacing: '0.06em',
+              textTransform: 'uppercase',
+            }}
+          >
+            {isZh ? '接近上限' : 'Tight'}
+          </span>
+        )}
       </div>
-      <div className="mt-3 h-2 overflow-hidden rounded-full bg-surface-container-high">
-        <div className={`h-full rounded-full ${tight ? 'bg-amber-500' : 'bg-emerald-500'}`} style={{ width: `${percent}%` }} />
+      <div
+        className="mt-3 h-1.5 overflow-hidden"
+        style={{
+          background: 'var(--color-codex-bg-tint)',
+          borderRadius: 'var(--codex-r-pill, 999px)',
+        }}
+      >
+        <div
+          className="h-full"
+          style={{
+            width: `${percent}%`,
+            background: barColor,
+            borderRadius: 'var(--codex-r-pill, 999px)',
+            transition: 'width 0.4s',
+          }}
+        />
       </div>
     </div>
   )
@@ -242,47 +319,106 @@ export function ApiLimitsSettings() {
 
   if (loading) {
     return (
-      <div className="flex min-h-[420px] items-center justify-center p-8">
-        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      <div
+        className="theme-codex flex min-h-[420px] items-center justify-center p-8"
+        style={{ background: 'var(--color-codex-bg)' }}
+      >
+        <Loader2 className="h-8 w-8 animate-spin" style={{ color: 'var(--color-codex-accent)' }} />
       </div>
     )
   }
 
   return (
-    <div className="space-y-6 p-6">
-      <div className="overflow-hidden rounded-3xl bg-gradient-to-br from-emerald-950 via-teal-900 to-slate-950 p-6 text-white shadow-sm">
-        <div className="flex flex-col justify-between gap-5 md:flex-row md:items-start">
-          <div>
-            <div className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-xs font-medium text-emerald-50">
-              <ShieldAlert className="h-4 w-4" />
-              {isZh ? 'API 健康观察' : 'API health monitor'}
-            </div>
-            <h2 className="mt-4 text-2xl font-semibold">{isZh ? 'API 限流提醒' : 'API Rate Limits'}</h2>
-            <p className="mt-2 max-w-2xl text-sm leading-6 text-emerald-50/80">
-              {isZh
-                ? '集中展示模型 API 的 429、rate limit、超时和预热预算压力，方便你快速判断是该等待恢复、降低并发，还是检查 API Key 与模型配置。'
-                : 'A focused view for 429s, rate limits, timeouts, and warm-up budget pressure so you can decide whether to wait, reduce concurrency, or inspect model settings.'}
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={() => void loadLimits(true)}
-            disabled={refreshing}
-            className="inline-flex items-center justify-center gap-2 rounded-xl bg-white px-4 py-2 text-sm font-medium text-emerald-950 transition hover:bg-emerald-50 disabled:opacity-60"
+    <div
+      className="theme-codex"
+      style={{
+        background: 'var(--color-codex-bg)',
+        color: 'var(--color-codex-ink)',
+        padding: '8px 4px 32px',
+      }}
+    >
+      <header
+        className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between"
+        style={{ marginBottom: 20 }}
+      >
+        <div>
+          <div
+            className="inline-flex items-center gap-1.5"
+            style={{
+              marginBottom: 6,
+              padding: '2px 8px',
+              fontSize: 10.5,
+              background: 'var(--color-codex-bg-tint)',
+              color: 'var(--color-codex-ink-soft)',
+              borderRadius: 'var(--codex-r-pill, 999px)',
+              fontFamily: 'var(--font-mono, ui-monospace, monospace)',
+              letterSpacing: '0.06em',
+              textTransform: 'uppercase',
+            }}
           >
-            <RefreshCw className={`h-4 w-4 ${refreshing ? 'animate-spin' : ''}`} />
-            {isZh ? '刷新' : 'Refresh'}
-          </button>
+            <ShieldAlert className="h-3 w-3" />
+            {isZh ? 'API 健康观察' : 'API health monitor'}
+          </div>
+          <h1
+            style={{
+              margin: 0,
+              fontSize: 22,
+              fontWeight: 500,
+              color: 'var(--color-codex-ink)',
+              letterSpacing: '-0.015em',
+            }}
+          >
+            {isZh ? 'API 限流提醒' : 'API Rate Limits'}
+          </h1>
+          <p
+            style={{
+              margin: '6px 0 0',
+              fontSize: 13,
+              color: 'var(--color-codex-ink-mute)',
+              lineHeight: 1.6,
+              maxWidth: 640,
+            }}
+          >
+            {isZh
+              ? '集中展示模型 API 的 429、rate limit、超时和预热预算压力，方便你快速判断是该等待恢复、降低并发，还是检查 API Key 与模型配置。'
+              : 'A focused view for 429s, rate limits, timeouts, and warm-up budget pressure so you can decide whether to wait, reduce concurrency, or inspect model settings.'}
+          </p>
         </div>
-      </div>
+        <button
+          type="button"
+          onClick={() => void loadLimits(true)}
+          disabled={refreshing}
+          className="inline-flex flex-shrink-0 items-center gap-2 px-3 py-2 transition-colors disabled:opacity-60"
+          style={{
+            fontSize: 12.5,
+            background: 'var(--color-codex-bg-elev)',
+            color: 'var(--color-codex-ink-soft)',
+            border: '1px solid var(--color-codex-line)',
+            borderRadius: 'var(--codex-r-sm, 3px)',
+          }}
+        >
+          <RefreshCw className={`h-3.5 w-3.5 ${refreshing ? 'animate-spin' : ''}`} />
+          {isZh ? '刷新' : 'Refresh'}
+        </button>
+      </header>
 
       {error && (
-        <div className="rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+        <div
+          style={{
+            marginBottom: 16,
+            padding: '10px 14px',
+            background: 'color-mix(in oklch, var(--color-codex-bad) 8%, transparent)',
+            border: '1px solid color-mix(in oklch, var(--color-codex-bad) 30%, transparent)',
+            borderRadius: 'var(--codex-r-sm, 3px)',
+            color: 'var(--color-codex-bad)',
+            fontSize: 13,
+          }}
+        >
           {error}
         </div>
       )}
 
-      <div className="grid gap-4 md:grid-cols-4">
+      <div className="grid gap-3 md:grid-cols-4">
         <StatusCard
           icon={Gauge}
           title={isZh ? '限流告警' : 'Rate-limit alerts'}
@@ -313,13 +449,36 @@ export function ApiLimitsSettings() {
         />
       </div>
 
-      <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_360px]">
-        <div className="space-y-4">
-          <div className="rounded-2xl border border-outline-variant/50 bg-surface-container-low p-5">
+      <div className="mt-5 grid gap-5 xl:grid-cols-[minmax(0,1fr)_320px]">
+        <div className="space-y-3">
+          <div
+            style={{
+              padding: 18,
+              background: 'var(--color-codex-bg-elev)',
+              border: '1px solid var(--color-codex-line)',
+              borderRadius: 'var(--codex-r-md, 6px)',
+            }}
+          >
             <div className="flex items-start justify-between gap-4">
               <div>
-                <h3 className="text-lg font-semibold text-on-surface">{isZh ? '最近限流提醒' : 'Recent API limit alerts'}</h3>
-                <p className="mt-1 text-sm text-on-surface-muted">
+                <h2
+                  style={{
+                    margin: 0,
+                    fontSize: 15,
+                    fontWeight: 600,
+                    color: 'var(--color-codex-ink)',
+                  }}
+                >
+                  {isZh ? '最近限流提醒' : 'Recent API limit alerts'}
+                </h2>
+                <p
+                  style={{
+                    margin: '4px 0 0',
+                    fontSize: 12.5,
+                    color: 'var(--color-codex-ink-mute)',
+                    lineHeight: 1.55,
+                  }}
+                >
                   {rateLimitFailures.length > 0
                     ? isZh
                       ? '这些任务已经被归类为 API 限流，建议稍后重试或降低批量预热节奏。'
@@ -329,54 +488,173 @@ export function ApiLimitsSettings() {
                       : 'No explicit rate limit found; recent model-pressure events are shown below for diagnosis.'}
                 </p>
               </div>
-              {hasPressure ? (
-                <span className="rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-800">
-                  {isZh ? '需要关注' : 'Needs attention'}
-                </span>
-              ) : (
-                <span className="rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-800">
-                  {isZh ? '运行平稳' : 'Healthy'}
-                </span>
-              )}
+              <span
+                className="font-mono flex-shrink-0"
+                style={{
+                  padding: '2px 8px',
+                  fontSize: 10.5,
+                  background: hasPressure
+                    ? 'color-mix(in oklch, var(--color-codex-warn) 14%, transparent)'
+                    : 'var(--color-codex-accent-bg)',
+                  color: hasPressure
+                    ? 'var(--color-codex-warn)'
+                    : 'var(--color-codex-accent-ink)',
+                  borderRadius: 'var(--codex-r-pill, 999px)',
+                  letterSpacing: '0.06em',
+                  textTransform: 'uppercase',
+                }}
+              >
+                {hasPressure
+                  ? isZh
+                    ? '需要关注'
+                    : 'Attention'
+                  : isZh
+                    ? '运行平稳'
+                    : 'Healthy'}
+              </span>
             </div>
           </div>
 
           {latestFailures.length === 0 ? (
-            <div className="rounded-3xl border border-emerald-200 bg-emerald-50 p-8 text-center text-emerald-950">
-              <CheckCircle2 className="mx-auto h-10 w-10 text-emerald-600" />
-              <h3 className="mt-4 text-lg font-semibold">{isZh ? '目前没有 API 限流提醒' : 'No API limit alerts right now'}</h3>
-              <p className="mx-auto mt-2 max-w-lg text-sm text-emerald-800">
+            <div
+              className="text-center"
+              style={{
+                padding: '32px 24px',
+                background: 'var(--color-codex-bg-elev)',
+                border: '1px solid var(--color-codex-line)',
+                borderRadius: 'var(--codex-r-md, 6px)',
+              }}
+            >
+              <CheckCircle2
+                className="mx-auto h-9 w-9"
+                style={{ color: 'var(--color-codex-accent)' }}
+              />
+              <h3
+                style={{
+                  margin: '12px 0 0',
+                  fontSize: 15,
+                  fontWeight: 600,
+                  color: 'var(--color-codex-ink)',
+                }}
+              >
+                {isZh ? '目前没有 API 限流提醒' : 'No API limit alerts right now'}
+              </h3>
+              <p
+                style={{
+                  margin: '6px auto 0',
+                  maxWidth: 420,
+                  fontSize: 12.5,
+                  color: 'var(--color-codex-ink-mute)',
+                  lineHeight: 1.6,
+                }}
+              >
                 {isZh
                   ? '系统没有检测到 429、rate limit 或模型压力失败。页面会每 15 秒自动刷新一次。'
                   : 'No 429, rate limit, or model-pressure failures were detected. This page refreshes every 15 seconds.'}
               </p>
             </div>
           ) : (
-            <div className="space-y-3">
+            <div className="space-y-2">
               {latestFailures.map((failure) => (
                 <button
                   key={`${failure.scope}-${getFailureName(failure)}-${failure.stage}-${failure.failed_at}`}
                   type="button"
                   onClick={() => navigate(getFailureLink(failure))}
-                  className="w-full rounded-2xl border border-outline-variant/60 bg-surface p-4 text-left transition hover:-translate-y-0.5 hover:border-primary/30 hover:shadow-sm"
+                  className="w-full text-left transition-colors"
+                  style={{
+                    padding: 14,
+                    background: 'var(--color-codex-bg-elev)',
+                    border: '1px solid var(--color-codex-line)',
+                    borderRadius: 'var(--codex-r-sm, 3px)',
+                  }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.background = 'var(--color-codex-bg-tint)'
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.background = 'var(--color-codex-bg-elev)'
+                  }}
                 >
                   <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
                     <div className="min-w-0">
                       <div className="flex flex-wrap items-center gap-2">
-                        <span className="rounded-full bg-red-100 px-2.5 py-1 text-xs font-medium text-red-800">
-                          {isRateLimitFailure(failure) ? (isZh ? 'API 限流' : 'Rate limit') : failure.category || (isZh ? '模型压力' : 'Model pressure')}
+                        <span
+                          className="font-mono"
+                          style={{
+                            padding: '2px 8px',
+                            fontSize: 10.5,
+                            background: 'color-mix(in oklch, var(--color-codex-bad) 12%, transparent)',
+                            color: 'var(--color-codex-bad)',
+                            borderRadius: 'var(--codex-r-pill, 999px)',
+                            letterSpacing: '0.04em',
+                            textTransform: 'uppercase',
+                          }}
+                        >
+                          {isRateLimitFailure(failure)
+                            ? isZh
+                              ? 'API 限流'
+                              : 'Rate limit'
+                            : failure.category || (isZh ? '模型压力' : 'Pressure')}
                         </span>
-                        <span className="rounded-full bg-surface-container-high px-2.5 py-1 text-xs text-on-surface-muted">
+                        <span
+                          className="font-mono"
+                          style={{
+                            padding: '2px 8px',
+                            fontSize: 10.5,
+                            background: 'var(--color-codex-bg-tint)',
+                            color: 'var(--color-codex-ink-mute)',
+                            borderRadius: 'var(--codex-r-pill, 999px)',
+                            letterSpacing: '0.04em',
+                            textTransform: 'uppercase',
+                          }}
+                        >
                           {failure.scope === 'project' ? (isZh ? '项目' : 'Project') : isZh ? '客户' : 'Client'}
                         </span>
-                        <span className="text-xs text-on-surface-muted">{formatDate(failure.failed_at, isZh)}</span>
+                        <span
+                          className="font-mono"
+                          style={{ fontSize: 11, color: 'var(--color-codex-ink-mute)' }}
+                        >
+                          {formatDate(failure.failed_at, isZh)}
+                        </span>
                       </div>
-                      <div className="mt-3 text-base font-semibold text-on-surface">{getFailureName(failure)}</div>
-                      <div className="mt-1 text-xs text-on-surface-muted">{failure.stage}</div>
-                      <p className="mt-2 line-clamp-2 text-sm leading-6 text-on-surface-muted">{failure.message}</p>
+                      <div
+                        className="mt-2"
+                        style={{
+                          fontSize: 14,
+                          fontWeight: 600,
+                          color: 'var(--color-codex-ink)',
+                        }}
+                      >
+                        {getFailureName(failure)}
+                      </div>
+                      <div
+                        className="mt-1 font-mono"
+                        style={{ fontSize: 11.5, color: 'var(--color-codex-ink-mute)' }}
+                      >
+                        {failure.stage}
+                      </div>
+                      <p
+                        className="line-clamp-2"
+                        style={{
+                          margin: '6px 0 0',
+                          fontSize: 12.5,
+                          lineHeight: 1.55,
+                          color: 'var(--color-codex-ink-soft)',
+                        }}
+                      >
+                        {failure.message}
+                      </p>
                     </div>
-                    <div className="shrink-0 rounded-xl bg-surface-container-low px-3 py-2 text-xs text-on-surface-muted">
-                      {isZh ? '重试次数' : 'Retries'}: {failure.retry_count ?? 0}
+                    <div
+                      className="font-mono flex-shrink-0"
+                      style={{
+                        padding: '6px 10px',
+                        fontSize: 11,
+                        background: 'var(--color-codex-bg-tint)',
+                        color: 'var(--color-codex-ink-mute)',
+                        borderRadius: 'var(--codex-r-sm, 3px)',
+                      }}
+                    >
+                      {isZh ? '重试' : 'Retries'}: {failure.retry_count ?? 0}
                     </div>
                   </div>
                 </button>
@@ -385,40 +663,124 @@ export function ApiLimitsSettings() {
           )}
         </div>
 
-        <aside className="space-y-4">
-          <div className="rounded-2xl border border-outline-variant/50 bg-surface-container-low p-5">
-            <h3 className="text-base font-semibold text-on-surface">{isZh ? '处理建议' : 'Recommended actions'}</h3>
-            <div className="mt-4 space-y-3">
+        <aside className="space-y-3">
+          <div
+            style={{
+              padding: 18,
+              background: 'var(--color-codex-bg-elev)',
+              border: '1px solid var(--color-codex-line)',
+              borderRadius: 'var(--codex-r-md, 6px)',
+            }}
+          >
+            <h2
+              style={{
+                margin: 0,
+                fontSize: 14,
+                fontWeight: 600,
+                color: 'var(--color-codex-ink)',
+              }}
+            >
+              {isZh ? '处理建议' : 'Recommended actions'}
+            </h2>
+            <div className="mt-3 space-y-2">
               <button
                 type="button"
                 onClick={() => navigate('/settings/memory-ops')}
-                className="flex w-full items-start gap-3 rounded-xl bg-surface px-4 py-3 text-left transition hover:bg-surface-container-high"
+                className="flex w-full items-start gap-3 text-left transition-colors"
+                style={{
+                  padding: '12px 14px',
+                  background: 'var(--color-codex-bg)',
+                  border: '1px solid var(--color-codex-line-soft)',
+                  borderRadius: 'var(--codex-r-sm, 3px)',
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.background = 'var(--color-codex-bg-tint)'
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.background = 'var(--color-codex-bg)'
+                }}
               >
-                <AlertTriangle className="mt-0.5 h-5 w-5 text-amber-600" />
+                <AlertTriangle
+                  className="mt-0.5 h-4 w-4 flex-shrink-0"
+                  style={{ color: 'var(--color-codex-warn)' }}
+                />
                 <span>
-                  <span className="block text-sm font-medium text-on-surface">{isZh ? '先暂停批量预热' : 'Pause batch warm-ups first'}</span>
-                  <span className="mt-1 block text-xs leading-5 text-on-surface-muted">
-                    {isZh ? '限流出现时优先减少并发和重试风暴，再手动处理高优先级任务。' : 'When rate limits appear, reduce concurrency and avoid retry storms before handling priority jobs.'}
+                  <span
+                    style={{
+                      display: 'block',
+                      fontSize: 13,
+                      fontWeight: 500,
+                      color: 'var(--color-codex-ink)',
+                    }}
+                  >
+                    {isZh ? '先暂停批量预热' : 'Pause batch warm-ups first'}
+                  </span>
+                  <span
+                    style={{
+                      display: 'block',
+                      marginTop: 2,
+                      fontSize: 11.5,
+                      lineHeight: 1.55,
+                      color: 'var(--color-codex-ink-mute)',
+                    }}
+                  >
+                    {isZh
+                      ? '限流出现时优先减少并发和重试风暴，再手动处理高优先级任务。'
+                      : 'When rate limits appear, reduce concurrency and avoid retry storms before handling priority jobs.'}
                   </span>
                 </span>
               </button>
               <button
                 type="button"
                 onClick={() => navigate('/settings/ai')}
-                className="flex w-full items-start gap-3 rounded-xl bg-surface px-4 py-3 text-left transition hover:bg-surface-container-high"
+                className="flex w-full items-start gap-3 text-left transition-colors"
+                style={{
+                  padding: '12px 14px',
+                  background: 'var(--color-codex-bg)',
+                  border: '1px solid var(--color-codex-line-soft)',
+                  borderRadius: 'var(--codex-r-sm, 3px)',
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.background = 'var(--color-codex-bg-tint)'
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.background = 'var(--color-codex-bg)'
+                }}
               >
-                <Brain className="mt-0.5 h-5 w-5 text-primary" />
+                <Brain
+                  className="mt-0.5 h-4 w-4 flex-shrink-0"
+                  style={{ color: 'var(--color-codex-accent)' }}
+                />
                 <span>
-                  <span className="block text-sm font-medium text-on-surface">{isZh ? '检查模型与 API Key' : 'Check model and API key'}</span>
-                  <span className="mt-1 block text-xs leading-5 text-on-surface-muted">
-                    {isZh ? '如果限流持续，检查供应商额度、模型可用性和当前 API Key 状态。' : 'If pressure continues, inspect provider quota, model availability, and API key status.'}
+                  <span
+                    style={{
+                      display: 'block',
+                      fontSize: 13,
+                      fontWeight: 500,
+                      color: 'var(--color-codex-ink)',
+                    }}
+                  >
+                    {isZh ? '检查模型与 API Key' : 'Check model and API key'}
+                  </span>
+                  <span
+                    style={{
+                      display: 'block',
+                      marginTop: 2,
+                      fontSize: 11.5,
+                      lineHeight: 1.55,
+                      color: 'var(--color-codex-ink-mute)',
+                    }}
+                  >
+                    {isZh
+                      ? '如果限流持续，检查供应商额度、模型可用性和当前 API Key 状态。'
+                      : 'If pressure continues, inspect provider quota, model availability, and API key status.'}
                   </span>
                 </span>
               </button>
             </div>
           </div>
 
-          <div className="space-y-3">
+          <div className="space-y-2">
             <BudgetStrip title={isZh ? '项目记忆预热预算' : 'Project memory warm budget'} budget={projectBudget} isZh={isZh} />
             <BudgetStrip title={isZh ? '客户记忆预热预算' : 'Client memory warm budget'} budget={clientBudget} isZh={isZh} />
           </div>

--- a/web/src/pages/settings/MessageSettings.tsx
+++ b/web/src/pages/settings/MessageSettings.tsx
@@ -75,18 +75,89 @@ export function MessageSettings() {
     [messages],
   )
 
+  const inputStyle: React.CSSProperties = {
+    width: '100%',
+    padding: '8px 12px',
+    fontSize: 13.5,
+    background: 'var(--color-codex-bg)',
+    border: '1px solid var(--color-codex-line)',
+    borderRadius: 'var(--codex-r-sm, 3px)',
+    color: 'var(--color-codex-ink)',
+    outline: 'none',
+  }
+
+  const labelStyle: React.CSSProperties = {
+    display: 'block',
+    marginBottom: 6,
+    fontSize: 10.5,
+    fontFamily: 'var(--font-mono, ui-monospace, monospace)',
+    color: 'var(--color-codex-ink-mute)',
+    letterSpacing: '0.06em',
+    textTransform: 'uppercase',
+  }
+
+  const statusBadgeStyle = (published: boolean): React.CSSProperties => ({
+    padding: '2px 8px',
+    fontSize: 10.5,
+    background: published ? 'var(--color-codex-accent-bg)' : 'var(--color-codex-bg-tint)',
+    color: published ? 'var(--color-codex-accent-ink)' : 'var(--color-codex-ink-mute)',
+    borderRadius: 'var(--codex-r-pill, 999px)',
+    fontFamily: 'var(--font-mono, ui-monospace, monospace)',
+    letterSpacing: '0.04em',
+    textTransform: 'uppercase',
+  })
+
   return (
-    <div className="space-y-6">
-      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+    <div
+      className="theme-codex"
+      style={{
+        background: 'var(--color-codex-bg)',
+        color: 'var(--color-codex-ink)',
+        padding: '8px 4px 32px',
+      }}
+    >
+      <header
+        className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between"
+        style={{ marginBottom: 20 }}
+      >
         <div>
-          <div className="mb-2 inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-1 text-xs font-medium text-primary">
-            <Bell className="h-3.5 w-3.5" />
+          <div
+            className="inline-flex items-center gap-1.5"
+            style={{
+              marginBottom: 6,
+              padding: '2px 8px',
+              fontSize: 10.5,
+              background: 'var(--color-codex-bg-tint)',
+              color: 'var(--color-codex-ink-soft)',
+              borderRadius: 'var(--codex-r-pill, 999px)',
+              fontFamily: 'var(--font-mono, ui-monospace, monospace)',
+              letterSpacing: '0.06em',
+              textTransform: 'uppercase',
+            }}
+          >
+            <Bell className="h-3 w-3" />
             {isZh ? '消息管理' : 'Message Manager'}
           </div>
-          <h2 className="text-lg font-semibold text-on-surface">
-            {isZh ? '发布系统消息并查看阅读情况' : 'Publish notices and review message engagement'}
-          </h2>
-          <p className="mt-1 text-sm text-on-surface-muted">
+          <h1
+            style={{
+              margin: 0,
+              fontSize: 22,
+              fontWeight: 500,
+              color: 'var(--color-codex-ink)',
+              letterSpacing: '-0.015em',
+            }}
+          >
+            {isZh ? '发布系统消息并查看阅读情况' : 'Publish notices and review engagement'}
+          </h1>
+          <p
+            style={{
+              margin: '6px 0 0',
+              fontSize: 13,
+              color: 'var(--color-codex-ink-mute)',
+              lineHeight: 1.6,
+              maxWidth: 640,
+            }}
+          >
             {isZh
               ? '管理员可以在这里发布系统通知，用户会在右上角看到未读提醒并进入消息中心查看。'
               : 'Admins can publish system notices here. Users see the unread badge in the top bar and can open the message center.'}
@@ -94,67 +165,120 @@ export function MessageSettings() {
         </div>
         <button
           onClick={() => void loadMessages()}
-          className="inline-flex items-center gap-2 rounded-xl border border-outline/20 px-4 py-2 text-sm text-on-surface-secondary transition hover:bg-surface-container-high"
+          className="inline-flex flex-shrink-0 items-center gap-2 px-3 py-2 transition-colors"
+          style={{
+            fontSize: 12.5,
+            background: 'var(--color-codex-bg-elev)',
+            color: 'var(--color-codex-ink-soft)',
+            border: '1px solid var(--color-codex-line)',
+            borderRadius: 'var(--codex-r-sm, 3px)',
+          }}
         >
-          <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+          <RefreshCw className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`} />
           {isZh ? '刷新列表' : 'Refresh'}
         </button>
-      </div>
+      </header>
 
       {error ? (
-        <div className="rounded-2xl border border-error/20 bg-error/5 px-4 py-3 text-sm text-error">{error}</div>
+        <div
+          style={{
+            marginBottom: 16,
+            padding: '10px 14px',
+            background: 'color-mix(in oklch, var(--color-codex-bad) 8%, transparent)',
+            border: '1px solid color-mix(in oklch, var(--color-codex-bad) 30%, transparent)',
+            borderRadius: 'var(--codex-r-sm, 3px)',
+            color: 'var(--color-codex-bad)',
+            fontSize: 13,
+          }}
+        >
+          {error}
+        </div>
       ) : null}
       {success ? (
-        <div className="rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
+        <div
+          style={{
+            marginBottom: 16,
+            padding: '10px 14px',
+            background: 'var(--color-codex-accent-bg)',
+            border: '1px solid color-mix(in oklch, var(--color-codex-accent) 30%, transparent)',
+            borderRadius: 'var(--codex-r-sm, 3px)',
+            color: 'var(--color-codex-accent-ink)',
+            fontSize: 13,
+          }}
+        >
           {success}
         </div>
       ) : null}
 
-      <div className="grid gap-6 xl:grid-cols-[0.95fr_1.05fr]">
-        <div className="rounded-3xl border border-outline/10 bg-surface-container-low p-6">
+      <div className="grid gap-5 xl:grid-cols-[0.95fr_1.05fr]">
+        {/* Publish form */}
+        <section
+          style={{
+            padding: 20,
+            background: 'var(--color-codex-bg-elev)',
+            border: '1px solid var(--color-codex-line)',
+            borderRadius: 'var(--codex-r-md, 6px)',
+          }}
+        >
           <div className="mb-5 flex items-center gap-3">
-            <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+            <div
+              className="flex h-10 w-10 flex-shrink-0 items-center justify-center"
+              style={{
+                background: 'var(--color-codex-accent-bg)',
+                color: 'var(--color-codex-accent)',
+                borderRadius: 'var(--codex-r-sm, 3px)',
+              }}
+            >
               <Megaphone className="h-5 w-5" />
             </div>
             <div>
-              <h3 className="font-semibold text-on-surface">{isZh ? '发布新消息' : 'Publish a message'}</h3>
-              <p className="text-sm text-on-surface-muted">
-                {isZh ? '建议标题简洁，正文说明动作或背景。' : 'Keep the title concise and make the body actionable.'}
+              <h2
+                style={{
+                  margin: 0,
+                  fontSize: 15,
+                  fontWeight: 600,
+                  color: 'var(--color-codex-ink)',
+                }}
+              >
+                {isZh ? '发布新消息' : 'Publish a message'}
+              </h2>
+              <p
+                style={{
+                  margin: '2px 0 0',
+                  fontSize: 12,
+                  color: 'var(--color-codex-ink-mute)',
+                }}
+              >
+                {isZh ? '建议标题简洁，正文说明动作或背景。' : 'Keep the title concise and the body actionable.'}
               </p>
             </div>
           </div>
 
           <div className="space-y-4">
             <div>
-              <label className="mb-1.5 block text-sm font-medium text-on-surface-secondary">
-                {isZh ? '标题' : 'Title'}
-              </label>
+              <label style={labelStyle}>{isZh ? '标题' : 'Title'}</label>
               <input
                 value={formData.title}
                 onChange={(e) => setFormData((current) => ({ ...current, title: e.target.value }))}
                 placeholder={isZh ? '例如：本周系统维护安排' : 'For example: Weekly maintenance notice'}
-                className="w-full rounded-xl border border-outline/20 bg-surface-container-lowest px-4 py-2.5 text-on-surface outline-none transition focus:border-primary/40 focus:ring-2 focus:ring-primary/20"
+                style={inputStyle}
               />
             </div>
 
             <div>
-              <label className="mb-1.5 block text-sm font-medium text-on-surface-secondary">
-                {isZh ? '正文' : 'Content'}
-              </label>
+              <label style={labelStyle}>{isZh ? '正文' : 'Content'}</label>
               <textarea
                 value={formData.content}
                 onChange={(e) => setFormData((current) => ({ ...current, content: e.target.value }))}
                 rows={7}
                 placeholder={isZh ? '输入消息正文...' : 'Write the announcement...'}
-                className="w-full rounded-xl border border-outline/20 bg-surface-container-lowest px-4 py-3 text-on-surface outline-none transition focus:border-primary/40 focus:ring-2 focus:ring-primary/20"
+                style={{ ...inputStyle, padding: '10px 12px', resize: 'vertical' }}
               />
             </div>
 
             <div className="grid gap-4 sm:grid-cols-2">
               <div>
-                <label className="mb-1.5 block text-sm font-medium text-on-surface-secondary">
-                  {isZh ? '消息级别' : 'Level'}
-                </label>
+                <label style={labelStyle}>{isZh ? '消息级别' : 'Level'}</label>
                 <select
                   value={formData.level}
                   onChange={(e) =>
@@ -163,7 +287,7 @@ export function MessageSettings() {
                       level: e.target.value as MessageFormData['level'],
                     }))
                   }
-                  className="w-full rounded-xl border border-outline/20 bg-surface-container-lowest px-4 py-2.5 text-on-surface outline-none transition focus:border-primary/40 focus:ring-2 focus:ring-primary/20"
+                  style={inputStyle}
                 >
                   <option value="info">{isZh ? '普通通知' : 'Info'}</option>
                   <option value="success">{isZh ? '成功提醒' : 'Success'}</option>
@@ -172,28 +296,35 @@ export function MessageSettings() {
                 </select>
               </div>
               <div>
-                <label className="mb-1.5 block text-sm font-medium text-on-surface-secondary">
-                  {isZh ? '跳转链接' : 'Open link'}
-                </label>
+                <label style={labelStyle}>{isZh ? '跳转链接' : 'Open link'}</label>
                 <input
                   value={formData.link}
                   onChange={(e) => setFormData((current) => ({ ...current, link: e.target.value }))}
                   placeholder={isZh ? '/projects 或 /settings/memory' : '/projects or /settings/memory'}
-                  className="w-full rounded-xl border border-outline/20 bg-surface-container-lowest px-4 py-2.5 text-on-surface outline-none transition focus:border-primary/40 focus:ring-2 focus:ring-primary/20"
+                  style={inputStyle}
                 />
               </div>
             </div>
 
-            <label className="flex items-center gap-3 rounded-xl bg-surface-container-high px-4 py-3">
+            <label
+              className="flex items-center gap-3"
+              style={{
+                padding: '10px 14px',
+                background: 'var(--color-codex-bg-tint)',
+                border: '1px solid var(--color-codex-line-soft)',
+                borderRadius: 'var(--codex-r-sm, 3px)',
+              }}
+            >
               <input
                 type="checkbox"
                 checked={formData.is_published}
                 onChange={(e) =>
                   setFormData((current) => ({ ...current, is_published: e.target.checked }))
                 }
-                className="h-4 w-4 accent-primary"
+                className="h-4 w-4"
+                style={{ accentColor: 'var(--color-codex-accent)' }}
               />
-              <span className="text-sm text-on-surface">
+              <span style={{ fontSize: 13, color: 'var(--color-codex-ink)' }}>
                 {isZh ? '立即发布给所有用户' : 'Publish immediately to all users'}
               </span>
             </label>
@@ -201,57 +332,129 @@ export function MessageSettings() {
             <button
               onClick={() => void handleCreate()}
               disabled={submitting}
-              className="inline-flex items-center gap-2 rounded-xl bg-primary px-4 py-2.5 text-sm font-medium text-white transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+              className="inline-flex items-center gap-2 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+              style={{
+                padding: '8px 16px',
+                fontSize: 13,
+                fontWeight: 500,
+                background: 'var(--color-codex-accent)',
+                color: 'var(--color-codex-bg-elev)',
+                borderRadius: 'var(--codex-r-sm, 3px)',
+              }}
             >
               {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
               {isZh ? '发布消息' : 'Publish'}
             </button>
           </div>
-        </div>
+        </section>
 
         <div className="space-y-4">
-          <div className="grid gap-4 sm:grid-cols-3">
-            <div className="rounded-3xl border border-outline/10 bg-surface-container-low p-5">
-              <div className="text-sm text-on-surface-muted">{isZh ? '消息总数' : 'Messages'}</div>
-              <div className="mt-2 text-2xl font-semibold text-on-surface">{messages.length}</div>
-            </div>
-            <div className="rounded-3xl border border-outline/10 bg-surface-container-low p-5">
-              <div className="text-sm text-on-surface-muted">{isZh ? '已发布' : 'Published'}</div>
-              <div className="mt-2 text-2xl font-semibold text-on-surface">
-                {messages.filter((message) => message.is_published).length}
+          {/* Stat cards */}
+          <div className="grid gap-3 sm:grid-cols-3">
+            {[
+              { label: isZh ? '消息总数' : 'Messages', value: messages.length },
+              {
+                label: isZh ? '已发布' : 'Published',
+                value: messages.filter((message) => message.is_published).length,
+              },
+              { label: isZh ? '累计已读' : 'Total reads', value: totalRead },
+            ].map((stat) => (
+              <div
+                key={stat.label}
+                style={{
+                  padding: 16,
+                  background: 'var(--color-codex-bg-elev)',
+                  border: '1px solid var(--color-codex-line)',
+                  borderRadius: 'var(--codex-r-md, 6px)',
+                }}
+              >
+                <div
+                  className="font-mono"
+                  style={{
+                    fontSize: 10.5,
+                    color: 'var(--color-codex-ink-mute)',
+                    letterSpacing: '0.06em',
+                    textTransform: 'uppercase',
+                  }}
+                >
+                  {stat.label}
+                </div>
+                <div
+                  className="font-mono"
+                  style={{
+                    marginTop: 6,
+                    fontSize: 24,
+                    fontWeight: 500,
+                    color: 'var(--color-codex-ink)',
+                  }}
+                >
+                  {stat.value}
+                </div>
               </div>
-            </div>
-            <div className="rounded-3xl border border-outline/10 bg-surface-container-low p-5">
-              <div className="text-sm text-on-surface-muted">{isZh ? '累计已读' : 'Total reads'}</div>
-              <div className="mt-2 text-2xl font-semibold text-on-surface">{totalRead}</div>
-            </div>
+            ))}
           </div>
 
-          <div className="rounded-3xl border border-outline/10 bg-surface-container-low p-6">
+          {/* Message list */}
+          <section
+            style={{
+              padding: 20,
+              background: 'var(--color-codex-bg-elev)',
+              border: '1px solid var(--color-codex-line)',
+              borderRadius: 'var(--codex-r-md, 6px)',
+            }}
+          >
             <div className="mb-4 flex items-center gap-2">
-              <CheckCircle2 className="h-4 w-4 text-primary" />
-              <h3 className="font-semibold text-on-surface">{isZh ? '消息列表' : 'Published messages'}</h3>
+              <CheckCircle2
+                className="h-4 w-4"
+                style={{ color: 'var(--color-codex-accent)' }}
+              />
+              <h2
+                style={{
+                  margin: 0,
+                  fontSize: 15,
+                  fontWeight: 600,
+                  color: 'var(--color-codex-ink)',
+                }}
+              >
+                {isZh ? '消息列表' : 'Published messages'}
+              </h2>
             </div>
 
             {loading ? (
               <div className="flex items-center justify-center py-12">
-                <Loader2 className="h-5 w-5 animate-spin text-primary" />
+                <Loader2
+                  className="h-5 w-5 animate-spin"
+                  style={{ color: 'var(--color-codex-accent)' }}
+                />
               </div>
             ) : (
               <div className="space-y-3">
                 {messages.map((message) => (
-                  <div key={message.id} className="rounded-2xl border border-outline/10 bg-surface px-4 py-4">
+                  <div
+                    key={message.id}
+                    style={{
+                      padding: '14px 16px',
+                      background: 'var(--color-codex-bg)',
+                      border: '1px solid var(--color-codex-line-soft)',
+                      borderRadius: 'var(--codex-r-sm, 3px)',
+                    }}
+                  >
                     <div className="mb-2 flex flex-wrap items-center gap-2">
-                      <span className="rounded-full bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary">
+                      <span
+                        className="font-mono"
+                        style={{
+                          padding: '2px 8px',
+                          fontSize: 10.5,
+                          background: 'var(--color-codex-bg-tint)',
+                          color: 'var(--color-codex-ink-soft)',
+                          borderRadius: 'var(--codex-r-pill, 999px)',
+                          letterSpacing: '0.04em',
+                          textTransform: 'uppercase',
+                        }}
+                      >
                         {message.level}
                       </span>
-                      <span
-                        className={`rounded-full px-2.5 py-1 text-xs font-medium ${
-                          message.is_published
-                            ? 'bg-emerald-100 text-emerald-700'
-                            : 'bg-slate-100 text-slate-600'
-                        }`}
-                      >
+                      <span style={statusBadgeStyle(message.is_published)}>
                         {message.is_published
                           ? isZh
                             ? '已发布'
@@ -260,18 +463,47 @@ export function MessageSettings() {
                             ? '未发布'
                             : 'Draft'}
                       </span>
-                      <span className="text-xs text-on-surface-muted">
-                        {formatDateTime(message.created_at, isZh ? 'zh-CN' : 'en-US', undefined, getResolvedAppTimeZone())}
+                      <span
+                        className="font-mono"
+                        style={{ fontSize: 11, color: 'var(--color-codex-ink-mute)' }}
+                      >
+                        {formatDateTime(
+                          message.created_at,
+                          isZh ? 'zh-CN' : 'en-US',
+                          undefined,
+                          getResolvedAppTimeZone(),
+                        )}
                       </span>
                     </div>
-                    <h4 className="text-sm font-semibold text-on-surface">{message.title}</h4>
-                    <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-on-surface-secondary">
+                    <h3
+                      style={{
+                        margin: 0,
+                        fontSize: 14,
+                        fontWeight: 600,
+                        color: 'var(--color-codex-ink)',
+                      }}
+                    >
+                      {message.title}
+                    </h3>
+                    <p
+                      className="whitespace-pre-wrap"
+                      style={{
+                        marginTop: 8,
+                        marginBottom: 0,
+                        fontSize: 13,
+                        lineHeight: 1.6,
+                        color: 'var(--color-codex-ink-soft)',
+                      }}
+                    >
                       {message.content}
                     </p>
-                    <div className="mt-3 flex flex-wrap items-center gap-4 text-xs text-on-surface-muted">
+                    <div
+                      className="mt-3 flex flex-wrap items-center gap-4"
+                      style={{ fontSize: 11.5, color: 'var(--color-codex-ink-mute)' }}
+                    >
                       <span>
                         {isZh ? '已读人数：' : 'Read count: '}
-                        {message.read_count}
+                        <span className="font-mono">{message.read_count}</span>
                       </span>
                       {message.created_by_display_name ? (
                         <span>
@@ -282,20 +514,30 @@ export function MessageSettings() {
                       {message.link ? (
                         <span>
                           {isZh ? '链接：' : 'Link: '}
-                          {message.link}
+                          <span className="font-mono">{message.link}</span>
                         </span>
                       ) : null}
                     </div>
                   </div>
                 ))}
                 {messages.length === 0 ? (
-                  <div className="rounded-2xl bg-surface px-4 py-8 text-center text-sm text-on-surface-muted">
+                  <div
+                    className="text-center"
+                    style={{
+                      padding: '32px 16px',
+                      background: 'var(--color-codex-bg-tint)',
+                      border: '1px dashed var(--color-codex-line)',
+                      borderRadius: 'var(--codex-r-sm, 3px)',
+                      fontSize: 13,
+                      color: 'var(--color-codex-ink-mute)',
+                    }}
+                  >
                     {isZh ? '还没有发布过系统消息。' : 'No messages have been published yet.'}
                   </div>
                 ) : null}
               </div>
             )}
-          </div>
+          </section>
         </div>
       </div>
     </div>

--- a/web/src/pages/settings/UsersSettings.tsx
+++ b/web/src/pages/settings/UsersSettings.tsx
@@ -1,13 +1,13 @@
 import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { 
-  Users, 
-  UserPlus, 
-  Trash2, 
-  Shield, 
-  User, 
-  Loader2, 
-  AlertCircle, 
+import {
+  Users,
+  UserPlus,
+  Trash2,
+  Shield,
+  User,
+  Loader2,
+  AlertCircle,
   Check,
   Lock,
   Edit3,
@@ -15,7 +15,7 @@ import {
   Mail,
   UserCog,
   Search,
-  RefreshCw
+  RefreshCw,
 } from 'lucide-react'
 import { api } from '../../api/client'
 
@@ -34,6 +34,105 @@ interface UserFormData {
   password?: string
 }
 
+const INPUT_STYLE: React.CSSProperties = {
+  width: '100%',
+  padding: '8px 12px',
+  fontSize: 13.5,
+  background: 'var(--color-codex-bg)',
+  border: '1px solid var(--color-codex-line)',
+  borderRadius: 'var(--codex-r-sm, 3px)',
+  color: 'var(--color-codex-ink)',
+  outline: 'none',
+}
+
+const LABEL_STYLE: React.CSSProperties = {
+  display: 'block',
+  marginBottom: 6,
+  fontSize: 10.5,
+  fontFamily: 'var(--font-mono, ui-monospace, monospace)',
+  color: 'var(--color-codex-ink-mute)',
+  letterSpacing: '0.06em',
+  textTransform: 'uppercase',
+}
+
+const GHOST_BUTTON_STYLE: React.CSSProperties = {
+  padding: '8px 14px',
+  fontSize: 13,
+  background: 'var(--color-codex-bg)',
+  color: 'var(--color-codex-ink-soft)',
+  border: '1px solid var(--color-codex-line)',
+  borderRadius: 'var(--codex-r-sm, 3px)',
+}
+
+const ACCENT_BUTTON_STYLE: React.CSSProperties = {
+  padding: '8px 14px',
+  fontSize: 13,
+  fontWeight: 500,
+  background: 'var(--color-codex-accent)',
+  color: 'var(--color-codex-bg-elev)',
+  borderRadius: 'var(--codex-r-sm, 3px)',
+}
+
+const DANGER_BUTTON_STYLE: React.CSSProperties = {
+  padding: '8px 14px',
+  fontSize: 13,
+  fontWeight: 500,
+  background: 'var(--color-codex-bad)',
+  color: 'var(--color-codex-bg-elev)',
+  borderRadius: 'var(--codex-r-sm, 3px)',
+}
+
+function DialogShell({ icon: Icon, iconTone, title, children }: {
+  icon: typeof UserPlus
+  iconTone: 'accent' | 'danger' | 'neutral'
+  title: string
+  children: React.ReactNode
+}) {
+  const toneBg = iconTone === 'danger'
+    ? 'color-mix(in oklch, var(--color-codex-bad) 12%, transparent)'
+    : iconTone === 'neutral'
+      ? 'var(--color-codex-bg-tint)'
+      : 'var(--color-codex-accent-bg)'
+  const toneColor = iconTone === 'danger'
+    ? 'var(--color-codex-bad)'
+    : iconTone === 'neutral'
+      ? 'var(--color-codex-ink-soft)'
+      : 'var(--color-codex-accent)'
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      style={{ background: 'rgba(0,0,0,0.4)' }}
+    >
+      <div
+        className="w-full max-w-md p-6"
+        style={{
+          background: 'var(--color-codex-bg-elev)',
+          border: '1px solid var(--color-codex-line)',
+          borderRadius: 'var(--codex-r-md, 6px)',
+          boxShadow: '0 24px 60px -16px rgba(0,0,0,0.32)',
+        }}
+      >
+        <div className="mb-4 flex items-center gap-3">
+          <div
+            className="flex h-10 w-10 items-center justify-center"
+            style={{
+              background: toneBg,
+              color: toneColor,
+              borderRadius: 'var(--codex-r-sm, 3px)',
+            }}
+          >
+            <Icon className="h-5 w-5" />
+          </div>
+          <h3 style={{ margin: 0, fontSize: 16, fontWeight: 600, color: 'var(--color-codex-ink)' }}>
+            {title}
+          </h3>
+        </div>
+        {children}
+      </div>
+    </div>
+  )
+}
+
 export function UsersSettings() {
   const { t } = useTranslation()
   const [users, setUsers] = useState<UserItem[]>([])
@@ -41,15 +140,13 @@ export function UsersSettings() {
   const [error, setError] = useState('')
   const [successMessage, setSuccessMessage] = useState('')
   const [searchQuery, setSearchQuery] = useState('')
-  
-  // Dialog states
+
   const [showAddDialog, setShowAddDialog] = useState(false)
   const [showEditDialog, setShowEditDialog] = useState(false)
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
   const [showResetPasswordDialog, setShowResetPasswordDialog] = useState(false)
   const [selectedUser, setSelectedUser] = useState<UserItem | null>(null)
-  
-  // Form states
+
   const [formData, setFormData] = useState<UserFormData>({
     email: '',
     display_name: '',
@@ -59,7 +156,6 @@ export function UsersSettings() {
   const [newPassword, setNewPassword] = useState('')
   const [formLoading, setFormLoading] = useState(false)
 
-  // Load users on mount
   useEffect(() => {
     loadUsers()
   }, [])
@@ -82,10 +178,10 @@ export function UsersSettings() {
       setError(t('users.emailAndPasswordRequired') || 'Email and password are required')
       return
     }
-    
+
     setFormLoading(true)
     setError('')
-    
+
     try {
       await api.post('/auth/users', {
         email: formData.email,
@@ -93,12 +189,12 @@ export function UsersSettings() {
         display_name: formData.display_name || formData.email.split('@')[0],
         is_admin: formData.is_admin,
       })
-      
+
       setSuccessMessage(t('users.userAdded') || 'User added successfully')
       setShowAddDialog(false)
       resetForm()
       await loadUsers()
-      
+
       setTimeout(() => setSuccessMessage(''), 3000)
     } catch (err: any) {
       setError(err.response?.data?.detail || err.message || 'Failed to add user')
@@ -109,22 +205,22 @@ export function UsersSettings() {
 
   const handleEditUser = async () => {
     if (!selectedUser) return
-    
+
     setFormLoading(true)
     setError('')
-    
+
     try {
       await api.patch(`/auth/users/${selectedUser.id}`, {
         display_name: formData.display_name,
         is_admin: formData.is_admin,
         is_active: true,
       })
-      
+
       setSuccessMessage(t('users.userUpdated') || 'User updated successfully')
       setShowEditDialog(false)
       setSelectedUser(null)
       await loadUsers()
-      
+
       setTimeout(() => setSuccessMessage(''), 3000)
     } catch (err: any) {
       setError(err.response?.data?.detail || err.message || 'Failed to update user')
@@ -135,18 +231,18 @@ export function UsersSettings() {
 
   const handleDeleteUser = async () => {
     if (!selectedUser) return
-    
+
     setFormLoading(true)
     setError('')
-    
+
     try {
       await api.delete(`/auth/users/${selectedUser.id}`)
-      
+
       setSuccessMessage(t('users.userDeleted') || 'User deleted successfully')
       setShowDeleteDialog(false)
       setSelectedUser(null)
       await loadUsers()
-      
+
       setTimeout(() => setSuccessMessage(''), 3000)
     } catch (err: any) {
       setError(err.response?.data?.detail || err.message || 'Failed to delete user')
@@ -160,20 +256,20 @@ export function UsersSettings() {
       setError(t('users.passwordRequired') || 'Password is required')
       return
     }
-    
+
     setFormLoading(true)
     setError('')
-    
+
     try {
       await api.post(`/auth/users/${selectedUser.id}/reset-password`, {
         new_password: newPassword,
       })
-      
+
       setSuccessMessage(t('users.passwordReset') || 'Password reset successfully')
       setShowResetPasswordDialog(false)
       setSelectedUser(null)
       setNewPassword('')
-      
+
       setTimeout(() => setSuccessMessage(''), 3000)
     } catch (err: any) {
       setError(err.response?.data?.detail || err.message || 'Failed to reset password')
@@ -213,29 +309,57 @@ export function UsersSettings() {
     })
   }
 
-  // Filter users by search query
-  const filteredUsers = users.filter(user => 
-    user.email.toLowerCase().includes(searchQuery.toLowerCase()) ||
-    user.display_name.toLowerCase().includes(searchQuery.toLowerCase())
+  const filteredUsers = users.filter(
+    (user) =>
+      user.email.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      user.display_name.toLowerCase().includes(searchQuery.toLowerCase()),
   )
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center py-12">
-        <Loader2 className="w-6 h-6 text-primary animate-spin" />
+      <div
+        className="theme-codex flex items-center justify-center py-12"
+        style={{ background: 'var(--color-codex-bg)' }}
+      >
+        <Loader2 className="h-6 w-6 animate-spin" style={{ color: 'var(--color-codex-accent)' }} />
       </div>
     )
   }
 
   return (
-    <div className="space-y-6">
+    <div
+      className="theme-codex"
+      style={{
+        background: 'var(--color-codex-bg)',
+        color: 'var(--color-codex-ink)',
+        padding: '8px 4px 32px',
+      }}
+    >
       {/* Header */}
-      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+      <header
+        className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between"
+        style={{ marginBottom: 20 }}
+      >
         <div>
-          <h2 className="text-lg font-semibold text-on-surface mb-1">
+          <h1
+            style={{
+              margin: 0,
+              fontSize: 22,
+              fontWeight: 500,
+              color: 'var(--color-codex-ink)',
+              letterSpacing: '-0.015em',
+            }}
+          >
             {t('users.title') || '用户管理'}
-          </h2>
-          <p className="text-sm text-on-surface-muted">
+          </h1>
+          <p
+            style={{
+              margin: '6px 0 0',
+              fontSize: 13,
+              color: 'var(--color-codex-ink-mute)',
+              lineHeight: 1.6,
+            }}
+          >
             {t('users.subtitle') || '管理团队成员和权限'}
           </p>
         </div>
@@ -244,385 +368,519 @@ export function UsersSettings() {
             resetForm()
             setShowAddDialog(true)
           }}
-          className="flex items-center justify-center gap-2 px-4 py-2.5 bg-primary hover:bg-primary/90 text-white rounded-xl font-medium transition-all"
+          className="inline-flex items-center justify-center gap-2 px-3 py-2 transition-colors"
+          style={{
+            fontSize: 13,
+            fontWeight: 500,
+            background: 'var(--color-codex-accent)',
+            color: 'var(--color-codex-bg-elev)',
+            borderRadius: 'var(--codex-r-sm, 3px)',
+          }}
         >
-          <UserPlus className="w-4 h-4" />
+          <UserPlus className="h-3.5 w-3.5" />
           {t('users.addUser') || '添加用户'}
         </button>
-      </div>
+      </header>
 
       {/* Alerts */}
       {error && (
-        <div className="p-3 bg-error/10 border border-error/20 rounded-lg flex items-center gap-2 text-error text-sm">
-          <AlertCircle className="w-4 h-4 flex-shrink-0" />
+        <div
+          className="mb-4 flex items-center gap-2"
+          style={{
+            padding: '10px 14px',
+            fontSize: 13,
+            background: 'color-mix(in oklch, var(--color-codex-bad) 8%, transparent)',
+            border: '1px solid color-mix(in oklch, var(--color-codex-bad) 30%, transparent)',
+            borderRadius: 'var(--codex-r-sm, 3px)',
+            color: 'var(--color-codex-bad)',
+          }}
+        >
+          <AlertCircle className="h-4 w-4 flex-shrink-0" />
           {error}
-          <button 
+          <button
             onClick={() => setError('')}
-            className="ml-auto hover:opacity-70"
+            className="ml-auto opacity-70 hover:opacity-100"
+            aria-label="Dismiss"
           >
-            <X className="w-4 h-4" />
+            <X className="h-4 w-4" />
           </button>
         </div>
       )}
-      
+
       {successMessage && (
-        <div className="p-3 bg-success/10 border border-success/20 rounded-lg flex items-center gap-2 text-success text-sm">
-          <Check className="w-4 h-4 flex-shrink-0" />
+        <div
+          className="mb-4 flex items-center gap-2"
+          style={{
+            padding: '10px 14px',
+            fontSize: 13,
+            background: 'var(--color-codex-accent-bg)',
+            border: '1px solid color-mix(in oklch, var(--color-codex-accent) 30%, transparent)',
+            borderRadius: 'var(--codex-r-sm, 3px)',
+            color: 'var(--color-codex-accent-ink)',
+          }}
+        >
+          <Check className="h-4 w-4 flex-shrink-0" />
           {successMessage}
         </div>
       )}
 
-      {/* Search and Refresh */}
-      <div className="flex items-center gap-3">
-        <div className="relative flex-1 max-w-sm">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-on-surface-muted" />
+      {/* Search + refresh */}
+      <div className="mb-4 flex items-center gap-2">
+        <div className="relative max-w-sm flex-1">
+          <Search
+            className="absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2"
+            style={{ color: 'var(--color-codex-ink-faint)' }}
+          />
           <input
             type="text"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             placeholder={t('users.search') || '搜索用户...'}
-            className="w-full pl-10 pr-4 py-2.5 bg-surface-container-low border border-outline/20 rounded-xl text-on-surface placeholder:text-on-surface-muted focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40 transition-all"
+            style={{ ...INPUT_STYLE, paddingLeft: 32 }}
           />
         </div>
         <button
           onClick={loadUsers}
           disabled={loading}
-          className="flex items-center gap-2 px-3 py-2.5 border border-outline/20 rounded-xl hover:bg-surface-container-high transition-all disabled:opacity-50 text-on-surface-secondary"
+          className="flex items-center justify-center px-3 py-2 transition-colors disabled:opacity-50"
+          style={GHOST_BUTTON_STYLE}
+          title={t('common.refresh') || 'Refresh'}
         >
-          <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
+          <RefreshCw className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`} />
         </button>
       </div>
 
-      {/* Users List */}
+      {/* User list */}
       <div className="space-y-2">
-        {filteredUsers.map(user => (
+        {filteredUsers.map((user) => (
           <div
             key={user.id}
-            className="flex items-center justify-between p-4 bg-surface-container-low rounded-xl border border-outline/10 hover:border-outline/20 transition-all"
+            className="flex items-center justify-between"
+            style={{
+              padding: '14px 16px',
+              background: 'var(--color-codex-bg-elev)',
+              border: '1px solid var(--color-codex-line)',
+              borderRadius: 'var(--codex-r-sm, 3px)',
+            }}
           >
             <div className="flex items-center gap-3">
-              <div className="w-10 h-10 bg-primary/10 rounded-xl flex items-center justify-center">
-                <User className="w-5 h-5 text-primary" />
+              <div
+                className="flex h-10 w-10 flex-shrink-0 items-center justify-center"
+                style={{
+                  background: 'var(--color-codex-bg-tint)',
+                  color: 'var(--color-codex-ink-soft)',
+                  borderRadius: 'var(--codex-r-sm, 3px)',
+                }}
+              >
+                <User className="h-5 w-5" />
               </div>
-              <div>
-                <div className="flex items-center gap-2 flex-wrap">
-                  <span className="font-medium text-on-surface">
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span
+                    style={{
+                      fontSize: 14,
+                      fontWeight: 500,
+                      color: 'var(--color-codex-ink)',
+                    }}
+                  >
                     {user.display_name}
                   </span>
                   {user.is_admin && (
-                    <span className="flex items-center gap-1 px-2 py-0.5 text-xs bg-tertiary-container text-on-tertiary-container rounded-full">
-                      <Shield className="w-3 h-3" />
-                      {t('users.admin') || '管理员'}
+                    <span
+                      className="flex items-center gap-1 font-mono"
+                      style={{
+                        padding: '2px 8px',
+                        fontSize: 10.5,
+                        background: 'var(--color-codex-accent-bg)',
+                        color: 'var(--color-codex-accent-ink)',
+                        borderRadius: 'var(--codex-r-pill, 999px)',
+                        letterSpacing: '0.04em',
+                        textTransform: 'uppercase',
+                      }}
+                    >
+                      <Shield className="h-3 w-3" />
+                      {t('users.admin') || 'Admin'}
                     </span>
                   )}
                   {!user.is_active && (
-                    <span className="px-2 py-0.5 text-xs bg-error/10 text-error rounded-full">
-                      {t('users.inactive') || '已停用'}
+                    <span
+                      className="font-mono"
+                      style={{
+                        padding: '2px 8px',
+                        fontSize: 10.5,
+                        background: 'color-mix(in oklch, var(--color-codex-bad) 12%, transparent)',
+                        color: 'var(--color-codex-bad)',
+                        borderRadius: 'var(--codex-r-pill, 999px)',
+                        letterSpacing: '0.04em',
+                        textTransform: 'uppercase',
+                      }}
+                    >
+                      {t('users.inactive') || 'Inactive'}
                     </span>
                   )}
                 </div>
-                <p className="text-sm text-on-surface-muted flex items-center gap-1">
-                  <Mail className="w-3 h-3" />
+                <p
+                  className="flex items-center gap-1 font-mono"
+                  style={{
+                    margin: '4px 0 0',
+                    fontSize: 11.5,
+                    color: 'var(--color-codex-ink-mute)',
+                  }}
+                >
+                  <Mail className="h-3 w-3" />
                   {user.email}
                 </p>
               </div>
             </div>
-            
-            {/* Actions */}
+
             <div className="flex items-center gap-1">
               <button
                 onClick={() => openEditDialog(user)}
-                className="p-2 hover:bg-surface-container-high rounded-lg transition-colors"
+                className="p-2 transition-colors"
+                style={{ color: 'var(--color-codex-ink-soft)', borderRadius: 'var(--codex-r-sm, 3px)' }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.background = 'var(--color-codex-bg-tint)'
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.background = 'transparent'
+                }}
                 title={t('users.edit') || '编辑'}
               >
-                <Edit3 className="w-4 h-4 text-on-surface-muted" />
+                <Edit3 className="h-4 w-4" />
               </button>
               <button
                 onClick={() => openResetPasswordDialog(user)}
-                className="p-2 hover:bg-surface-container-high rounded-lg transition-colors"
+                className="p-2 transition-colors"
+                style={{ color: 'var(--color-codex-ink-soft)', borderRadius: 'var(--codex-r-sm, 3px)' }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.background = 'var(--color-codex-bg-tint)'
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.background = 'transparent'
+                }}
                 title={t('users.resetPassword') || '重置密码'}
               >
-                <Lock className="w-4 h-4 text-on-surface-muted" />
+                <Lock className="h-4 w-4" />
               </button>
               <button
                 onClick={() => openDeleteDialog(user)}
-                className="p-2 hover:bg-error/10 rounded-lg transition-colors group"
+                className="group p-2 transition-colors"
+                style={{ color: 'var(--color-codex-ink-soft)', borderRadius: 'var(--codex-r-sm, 3px)' }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.background =
+                    'color-mix(in oklch, var(--color-codex-bad) 10%, transparent)'
+                  e.currentTarget.style.color = 'var(--color-codex-bad)'
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.background = 'transparent'
+                  e.currentTarget.style.color = 'var(--color-codex-ink-soft)'
+                }}
                 title={t('users.delete') || '删除'}
               >
-                <Trash2 className="w-4 h-4 text-on-surface-muted group-hover:text-error" />
+                <Trash2 className="h-4 w-4" />
               </button>
             </div>
           </div>
         ))}
       </div>
 
-      {/* Empty State */}
+      {/* Empty state */}
       {filteredUsers.length === 0 && !loading && (
-        <div className="text-center py-12 bg-surface-container-low rounded-xl border border-outline/10">
-          <Users className="w-12 h-12 text-on-surface-muted mx-auto mb-4" />
-          <p className="text-on-surface-muted">
-            {searchQuery 
-              ? (t('users.noSearchResults') || '未找到匹配的用户')
-              : (t('users.noUsers') || '暂无其他用户')
-            }
+        <div
+          className="text-center"
+          style={{
+            padding: '40px 24px',
+            background: 'var(--color-codex-bg-tint)',
+            border: '1px dashed var(--color-codex-line)',
+            borderRadius: 'var(--codex-r-sm, 3px)',
+          }}
+        >
+          <Users
+            className="mx-auto mb-4 h-10 w-10"
+            style={{ color: 'var(--color-codex-ink-faint)' }}
+          />
+          <p style={{ margin: 0, fontSize: 13, color: 'var(--color-codex-ink-mute)' }}>
+            {searchQuery
+              ? t('users.noSearchResults') || '未找到匹配的用户'
+              : t('users.noUsers') || '暂无其他用户'}
           </p>
         </div>
       )}
 
-      {/* Add User Dialog */}
+      {/* Add user dialog */}
       {showAddDialog && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="bg-surface rounded-2xl p-6 w-full max-w-md shadow-2xl border border-outline/20">
-            <div className="flex items-center gap-3 mb-4">
-              <div className="w-10 h-10 bg-primary/10 rounded-xl flex items-center justify-center">
-                <UserPlus className="w-5 h-5 text-primary" />
-              </div>
-              <h3 className="text-lg font-semibold text-on-surface">
-                {t('users.addUser') || '添加用户'}
-              </h3>
-            </div>
-            
-            <div className="space-y-4">
-              <div>
-                <label className="block text-sm font-medium text-on-surface-secondary mb-1.5">
-                  {t('users.email') || '邮箱地址'} *
-                </label>
-                <input
-                  type="email"
-                  value={formData.email}
-                  onChange={(e) => setFormData({ ...formData, email: e.target.value })}
-                  placeholder="user@example.com"
-                  className="w-full px-4 py-2.5 bg-surface-container-lowest border border-outline/20 rounded-xl text-on-surface placeholder:text-on-surface-muted focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40 transition-all"
-                />
-              </div>
-              
-              <div>
-                <label className="block text-sm font-medium text-on-surface-secondary mb-1.5">
-                  {t('users.displayName') || '显示名称'}
-                </label>
-                <input
-                  type="text"
-                  value={formData.display_name}
-                  onChange={(e) => setFormData({ ...formData, display_name: e.target.value })}
-                  placeholder={t('users.displayNamePlaceholder') || '输入显示名称'}
-                  className="w-full px-4 py-2.5 bg-surface-container-lowest border border-outline/20 rounded-xl text-on-surface placeholder:text-on-surface-muted focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40 transition-all"
-                />
-              </div>
-              
-              <div>
-                <label className="block text-sm font-medium text-on-surface-secondary mb-1.5">
-                  {t('users.password') || '密码'} *
-                </label>
-                <input
-                  type="password"
-                  value={formData.password}
-                  onChange={(e) => setFormData({ ...formData, password: e.target.value })}
-                  placeholder={t('users.passwordPlaceholder') || '至少6位字符'}
-                  className="w-full px-4 py-2.5 bg-surface-container-lowest border border-outline/20 rounded-xl text-on-surface placeholder:text-on-surface-muted focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40 transition-all"
-                />
-              </div>
-              
-              <div className="flex items-center gap-3 p-3 bg-surface-container-high rounded-xl">
-                <input
-                  type="checkbox"
-                  id="isAdmin"
-                  checked={formData.is_admin}
-                  onChange={(e) => setFormData({ ...formData, is_admin: e.target.checked })}
-                  className="w-4 h-4 accent-primary rounded"
-                />
-                <label htmlFor="isAdmin" className="flex-1 text-sm text-on-surface cursor-pointer">
-                  <span className="font-medium">{t('users.setAsAdmin') || '设为管理员'}</span>
-                  <p className="text-xs text-on-surface-muted mt-0.5">
-                    {t('users.adminDesc') || '管理员可以管理用户和系统设置'}
-                  </p>
-                </label>
-              </div>
-            </div>
-            
-            <div className="flex justify-end gap-2 mt-6">
-              <button
-                onClick={() => setShowAddDialog(false)}
-                className="px-4 py-2.5 text-on-surface-secondary hover:bg-surface-container-high rounded-xl transition-all"
-              >
-                {t('common.cancel') || '取消'}
-              </button>
-              <button
-                onClick={handleAddUser}
-                disabled={formLoading || !formData.email || !formData.password}
-                className="flex items-center gap-2 px-4 py-2.5 bg-primary hover:bg-primary/90 disabled:opacity-50 text-white rounded-xl transition-all"
-              >
-                {formLoading && <Loader2 className="w-4 h-4 animate-spin" />}
-                {t('users.add') || '添加'}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Edit User Dialog */}
-      {showEditDialog && selectedUser && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="bg-surface rounded-2xl p-6 w-full max-w-md shadow-2xl border border-outline/20">
-            <div className="flex items-center gap-3 mb-4">
-              <div className="w-10 h-10 bg-secondary/10 rounded-xl flex items-center justify-center">
-                <UserCog className="w-5 h-5 text-secondary" />
-              </div>
-              <h3 className="text-lg font-semibold text-on-surface">
-                {t('users.editUser') || '编辑用户'}
-              </h3>
-            </div>
-            
-            <div className="space-y-4">
-              <div>
-                <label className="block text-sm font-medium text-on-surface-secondary mb-1.5">
-                  {t('users.email') || '邮箱地址'}
-                </label>
-                <input
-                  type="email"
-                  value={formData.email}
-                  disabled
-                  className="w-full px-4 py-2.5 bg-surface-container-low border border-outline/20 rounded-xl text-on-surface-muted cursor-not-allowed"
-                />
-                <p className="text-xs text-on-surface-muted mt-1">
-                  {t('users.emailCannotChange') || '邮箱地址无法更改'}
-                </p>
-              </div>
-              
-              <div>
-                <label className="block text-sm font-medium text-on-surface-secondary mb-1.5">
-                  {t('users.displayName') || '显示名称'}
-                </label>
-                <input
-                  type="text"
-                  value={formData.display_name}
-                  onChange={(e) => setFormData({ ...formData, display_name: e.target.value })}
-                  className="w-full px-4 py-2.5 bg-surface-container-lowest border border-outline/20 rounded-xl text-on-surface placeholder:text-on-surface-muted focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40 transition-all"
-                />
-              </div>
-              
-              <div className="flex items-center gap-3 p-3 bg-surface-container-high rounded-xl">
-                <input
-                  type="checkbox"
-                  id="editIsAdmin"
-                  checked={formData.is_admin}
-                  onChange={(e) => setFormData({ ...formData, is_admin: e.target.checked })}
-                  className="w-4 h-4 accent-primary rounded"
-                />
-                <label htmlFor="editIsAdmin" className="flex-1 text-sm text-on-surface cursor-pointer">
-                  <span className="font-medium">{t('users.setAsAdmin') || '设为管理员'}</span>
-                </label>
-              </div>
-            </div>
-            
-            <div className="flex justify-end gap-2 mt-6">
-              <button
-                onClick={() => setShowEditDialog(false)}
-                className="px-4 py-2.5 text-on-surface-secondary hover:bg-surface-container-high rounded-xl transition-all"
-              >
-                {t('common.cancel') || '取消'}
-              </button>
-              <button
-                onClick={handleEditUser}
-                disabled={formLoading}
-                className="flex items-center gap-2 px-4 py-2.5 bg-primary hover:bg-primary/90 disabled:opacity-50 text-white rounded-xl transition-all"
-              >
-                {formLoading && <Loader2 className="w-4 h-4 animate-spin" />}
-                {t('common.save') || '保存'}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Delete User Dialog */}
-      {showDeleteDialog && selectedUser && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="bg-surface rounded-2xl p-6 w-full max-w-md shadow-2xl border border-outline/20">
-            <div className="flex items-center gap-3 mb-4">
-              <div className="w-10 h-10 bg-error/10 rounded-xl flex items-center justify-center">
-                <Trash2 className="w-5 h-5 text-error" />
-              </div>
-              <h3 className="text-lg font-semibold text-on-surface">
-                {t('users.deleteUser') || '删除用户'}
-              </h3>
-            </div>
-            
-            <p className="text-on-surface-muted mb-4">
-              {t('users.deleteConfirm') || '确定要删除用户'} 
-              <span className="font-medium text-on-surface"> {selectedUser.display_name}</span>?
-              {t('users.deleteWarning') || '此操作无法撤销。'}
-            </p>
-            
-            <div className="flex justify-end gap-2">
-              <button
-                onClick={() => setShowDeleteDialog(false)}
-                className="px-4 py-2.5 text-on-surface-secondary hover:bg-surface-container-high rounded-xl transition-all"
-              >
-                {t('common.cancel') || '取消'}
-              </button>
-              <button
-                onClick={handleDeleteUser}
-                disabled={formLoading}
-                className="flex items-center gap-2 px-4 py-2.5 bg-error hover:bg-error/90 disabled:opacity-50 text-white rounded-xl transition-all"
-              >
-                {formLoading && <Loader2 className="w-4 h-4 animate-spin" />}
-                {t('common.delete') || '删除'}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Reset Password Dialog */}
-      {showResetPasswordDialog && selectedUser && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="bg-surface rounded-2xl p-6 w-full max-w-md shadow-2xl border border-outline/20">
-            <div className="flex items-center gap-3 mb-4">
-              <div className="w-10 h-10 bg-primary/10 rounded-xl flex items-center justify-center">
-                <Lock className="w-5 h-5 text-primary" />
-              </div>
-              <h3 className="text-lg font-semibold text-on-surface">
-                {t('users.resetPassword') || '重置密码'}
-              </h3>
-            </div>
-            
-            <p className="text-sm text-on-surface-muted mb-4">
-              {t('users.resetPasswordFor') || '为'} 
-              <span className="font-medium text-on-surface"> {selectedUser.display_name} </span>
-              {t('users.setNewPassword') || '设置新密码'}
-            </p>
-            
+        <DialogShell
+          icon={UserPlus}
+          iconTone="accent"
+          title={t('users.addUser') || '添加用户'}
+        >
+          <div className="space-y-4">
             <div>
-              <label className="block text-sm font-medium text-on-surface-secondary mb-1.5">
-                {t('users.newPassword') || '新密码'}
-              </label>
+              <label style={LABEL_STYLE}>{t('users.email') || '邮箱地址'} *</label>
               <input
-                type="password"
-                value={newPassword}
-                onChange={(e) => setNewPassword(e.target.value)}
-                placeholder={t('users.passwordPlaceholder') || '至少6位字符'}
-                className="w-full px-4 py-2.5 bg-surface-container-lowest border border-outline/20 rounded-xl text-on-surface placeholder:text-on-surface-muted focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40 transition-all"
+                type="email"
+                value={formData.email}
+                onChange={(e) => setFormData({ ...formData, email: e.target.value })}
+                placeholder="user@example.com"
+                style={INPUT_STYLE}
               />
             </div>
-            
-            <div className="flex justify-end gap-2 mt-6">
-              <button
-                onClick={() => setShowResetPasswordDialog(false)}
-                className="px-4 py-2.5 text-on-surface-secondary hover:bg-surface-container-high rounded-xl transition-all"
-              >
-                {t('common.cancel') || '取消'}
-              </button>
-              <button
-                onClick={handleResetPassword}
-                disabled={formLoading || !newPassword}
-                className="flex items-center gap-2 px-4 py-2.5 bg-primary hover:bg-primary/90 disabled:opacity-50 text-white rounded-xl transition-all"
-              >
-                {formLoading && <Loader2 className="w-4 h-4 animate-spin" />}
-                {t('users.reset') || '重置'}
-              </button>
+
+            <div>
+              <label style={LABEL_STYLE}>{t('users.displayName') || '显示名称'}</label>
+              <input
+                type="text"
+                value={formData.display_name}
+                onChange={(e) => setFormData({ ...formData, display_name: e.target.value })}
+                placeholder={t('users.displayNamePlaceholder') || '输入显示名称'}
+                style={INPUT_STYLE}
+              />
             </div>
+
+            <div>
+              <label style={LABEL_STYLE}>{t('users.password') || '密码'} *</label>
+              <input
+                type="password"
+                value={formData.password}
+                onChange={(e) => setFormData({ ...formData, password: e.target.value })}
+                placeholder={t('users.passwordPlaceholder') || '至少6位字符'}
+                style={INPUT_STYLE}
+              />
+            </div>
+
+            <label
+              className="flex items-center gap-3"
+              style={{
+                padding: '10px 14px',
+                background: 'var(--color-codex-bg-tint)',
+                border: '1px solid var(--color-codex-line-soft)',
+                borderRadius: 'var(--codex-r-sm, 3px)',
+              }}
+            >
+              <input
+                type="checkbox"
+                id="isAdmin"
+                checked={formData.is_admin}
+                onChange={(e) => setFormData({ ...formData, is_admin: e.target.checked })}
+                className="h-4 w-4"
+                style={{ accentColor: 'var(--color-codex-accent)' }}
+              />
+              <div className="flex-1">
+                <span
+                  style={{
+                    display: 'block',
+                    fontSize: 13,
+                    fontWeight: 500,
+                    color: 'var(--color-codex-ink)',
+                  }}
+                >
+                  {t('users.setAsAdmin') || '设为管理员'}
+                </span>
+                <p
+                  style={{
+                    margin: '2px 0 0',
+                    fontSize: 11.5,
+                    color: 'var(--color-codex-ink-mute)',
+                  }}
+                >
+                  {t('users.adminDesc') || '管理员可以管理用户和系统设置'}
+                </p>
+              </div>
+            </label>
           </div>
-        </div>
+
+          <div className="mt-6 flex justify-end gap-2">
+            <button onClick={() => setShowAddDialog(false)} style={GHOST_BUTTON_STYLE}>
+              {t('common.cancel') || '取消'}
+            </button>
+            <button
+              onClick={handleAddUser}
+              disabled={formLoading || !formData.email || !formData.password}
+              className="inline-flex items-center gap-2 disabled:opacity-50"
+              style={ACCENT_BUTTON_STYLE}
+            >
+              {formLoading && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+              {t('users.add') || '添加'}
+            </button>
+          </div>
+        </DialogShell>
+      )}
+
+      {/* Edit user dialog */}
+      {showEditDialog && selectedUser && (
+        <DialogShell
+          icon={UserCog}
+          iconTone="neutral"
+          title={t('users.editUser') || '编辑用户'}
+        >
+          <div className="space-y-4">
+            <div>
+              <label style={LABEL_STYLE}>{t('users.email') || '邮箱地址'}</label>
+              <input
+                type="email"
+                value={formData.email}
+                disabled
+                style={{
+                  ...INPUT_STYLE,
+                  background: 'var(--color-codex-bg-tint)',
+                  color: 'var(--color-codex-ink-mute)',
+                  cursor: 'not-allowed',
+                }}
+              />
+              <p
+                style={{
+                  margin: '4px 0 0',
+                  fontSize: 11,
+                  color: 'var(--color-codex-ink-mute)',
+                }}
+              >
+                {t('users.emailCannotChange') || '邮箱地址无法更改'}
+              </p>
+            </div>
+
+            <div>
+              <label style={LABEL_STYLE}>{t('users.displayName') || '显示名称'}</label>
+              <input
+                type="text"
+                value={formData.display_name}
+                onChange={(e) => setFormData({ ...formData, display_name: e.target.value })}
+                style={INPUT_STYLE}
+              />
+            </div>
+
+            <label
+              className="flex items-center gap-3"
+              style={{
+                padding: '10px 14px',
+                background: 'var(--color-codex-bg-tint)',
+                border: '1px solid var(--color-codex-line-soft)',
+                borderRadius: 'var(--codex-r-sm, 3px)',
+              }}
+            >
+              <input
+                type="checkbox"
+                id="editIsAdmin"
+                checked={formData.is_admin}
+                onChange={(e) => setFormData({ ...formData, is_admin: e.target.checked })}
+                className="h-4 w-4"
+                style={{ accentColor: 'var(--color-codex-accent)' }}
+              />
+              <span
+                style={{
+                  fontSize: 13,
+                  fontWeight: 500,
+                  color: 'var(--color-codex-ink)',
+                }}
+              >
+                {t('users.setAsAdmin') || '设为管理员'}
+              </span>
+            </label>
+          </div>
+
+          <div className="mt-6 flex justify-end gap-2">
+            <button onClick={() => setShowEditDialog(false)} style={GHOST_BUTTON_STYLE}>
+              {t('common.cancel') || '取消'}
+            </button>
+            <button
+              onClick={handleEditUser}
+              disabled={formLoading}
+              className="inline-flex items-center gap-2 disabled:opacity-50"
+              style={ACCENT_BUTTON_STYLE}
+            >
+              {formLoading && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+              {t('common.save') || '保存'}
+            </button>
+          </div>
+        </DialogShell>
+      )}
+
+      {/* Delete user dialog */}
+      {showDeleteDialog && selectedUser && (
+        <DialogShell
+          icon={Trash2}
+          iconTone="danger"
+          title={t('users.deleteUser') || '删除用户'}
+        >
+          <p
+            style={{
+              margin: '0 0 20px',
+              fontSize: 13,
+              lineHeight: 1.6,
+              color: 'var(--color-codex-ink-soft)',
+            }}
+          >
+            {t('users.deleteConfirm') || '确定要删除用户'}
+            <span style={{ fontWeight: 600, color: 'var(--color-codex-ink)' }}>
+              {' '}{selectedUser.display_name}
+            </span>
+            ?{' '}
+            {t('users.deleteWarning') || '此操作无法撤销。'}
+          </p>
+
+          <div className="flex justify-end gap-2">
+            <button onClick={() => setShowDeleteDialog(false)} style={GHOST_BUTTON_STYLE}>
+              {t('common.cancel') || '取消'}
+            </button>
+            <button
+              onClick={handleDeleteUser}
+              disabled={formLoading}
+              className="inline-flex items-center gap-2 disabled:opacity-50"
+              style={DANGER_BUTTON_STYLE}
+            >
+              {formLoading && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+              {t('common.delete') || '删除'}
+            </button>
+          </div>
+        </DialogShell>
+      )}
+
+      {/* Reset password dialog */}
+      {showResetPasswordDialog && selectedUser && (
+        <DialogShell
+          icon={Lock}
+          iconTone="accent"
+          title={t('users.resetPassword') || '重置密码'}
+        >
+          <p
+            style={{
+              margin: '0 0 16px',
+              fontSize: 12.5,
+              color: 'var(--color-codex-ink-mute)',
+            }}
+          >
+            {t('users.resetPasswordFor') || '为'}
+            <span style={{ fontWeight: 500, color: 'var(--color-codex-ink)' }}>
+              {' '}{selectedUser.display_name}{' '}
+            </span>
+            {t('users.setNewPassword') || '设置新密码'}
+          </p>
+
+          <div>
+            <label style={LABEL_STYLE}>{t('users.newPassword') || '新密码'}</label>
+            <input
+              type="password"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              placeholder={t('users.passwordPlaceholder') || '至少6位字符'}
+              style={INPUT_STYLE}
+            />
+          </div>
+
+          <div className="mt-6 flex justify-end gap-2">
+            <button onClick={() => setShowResetPasswordDialog(false)} style={GHOST_BUTTON_STYLE}>
+              {t('common.cancel') || '取消'}
+            </button>
+            <button
+              onClick={handleResetPassword}
+              disabled={formLoading || !newPassword}
+              className="inline-flex items-center gap-2 disabled:opacity-50"
+              style={ACCENT_BUTTON_STYLE}
+            >
+              {formLoading && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+              {t('users.reset') || '重置'}
+            </button>
+          </div>
+        </DialogShell>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary

Brings the four admin/info Settings pages into the Codex parchment palette to match Profile / Server / Language / Migration / Appearance: `theme-codex` wrapper, codex h1 + ink-mute description, mono uppercase field labels, codex bg-elev cards with hairline borders, accent for primary actions, and the codex `--color-codex-bad` token for destructive actions.

- **MessageSettings** — codex hero with mono pill, accent-bg icon tile, bg-elev publish form, mono stat cards, mono uppercase status badges on the message list
- **ApiLimitsSettings** — parchment header replaces the emerald/teal/slate gradient hero, `StatusCard` with tone-mapped icon tiles (accent / warn / bad), accent budget bar, codex failure list rows with mono labels
- **AboutSettings** — identity card, mono stat grid (version / API / build date / environment), bg-tint tech-stack chips (no rainbow), codex quick-link cards, codex timeline changelog with accent dot, codex license cards, codex segmented tab control
- **UsersSettings** — codex list rows with bg-tint avatar tile, accent `Admin` / bad `Inactive` badges, codex Search + Refresh row, shared `DialogShell` primitive (icon tone → accent / neutral / danger) for Add / Edit / Delete / Reset-password flows, accent and `bad` button styles

No API surface changes; state machines and handlers identical.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 513 passed
- [x] `npx vite build` clean
- [ ] Visual smoke: visit /settings/messages, /settings/api-limits, /settings/about, /settings/users and confirm Codex palette throughout; open Add/Edit/Delete/Reset-password dialogs in Users and confirm dialog shells are consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)