### PR TITLE
AI Model settings — Codex (V0.0.6 · 15/N)

### DIFF
--- a/web/src/pages/settings/AISettings.tsx
+++ b/web/src/pages/settings/AISettings.tsx
@@ -1,18 +1,18 @@
 import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { 
-  Check, 
-  Loader2, 
-  AlertCircle, 
-  RefreshCw, 
-  Key, 
-  Sliders, 
+import {
+  Check,
+  Loader2,
+  AlertCircle,
+  RefreshCw,
+  Key,
+  Sliders,
   Bot,
   ChevronDown,
   ChevronUp,
   Zap,
   Sparkles,
-  TestTube
+  TestTube,
 } from 'lucide-react'
 import { api } from '../../api/client'
 
@@ -25,7 +25,7 @@ interface AIModel {
   supportsTools: boolean
   supportsVision: boolean
   icon: string
-  fixedParams?: {  // If set, these parameters are fixed for the model
+  fixedParams?: {
     temperature: number
     topP: number
     presencePenalty: number
@@ -116,6 +116,7 @@ const models: AIModel[] = [
     icon: 'MP',
   },
 ]
+
 const providerNames: Record<string, string> = {
   anthropic: 'Anthropic',
   moonshot: 'Moonshot',
@@ -124,21 +125,102 @@ const providerNames: Record<string, string> = {
   mimo: 'Xiaomi MiMo',
 }
 
-const providerColors: Record<string, string> = {
-  anthropic: 'bg-orange-500/10 text-orange-600 border-orange-200',
-  moonshot: 'bg-purple-500/10 text-purple-600 border-purple-200',
-  deepseek: 'bg-emerald-500/10 text-emerald-600 border-emerald-200',
-  bigmodel: 'bg-blue-500/10 text-blue-600 border-blue-200',
-  mimo: 'bg-rose-500/10 text-rose-600 border-rose-200',
+// Shared Codex style tokens (avoid repeating them inline 30+ times).
+const INPUT_STYLE: React.CSSProperties = {
+  width: '100%',
+  padding: '8px 12px',
+  fontSize: 13.5,
+  background: 'var(--color-codex-bg)',
+  border: '1px solid var(--color-codex-line)',
+  borderRadius: 'var(--codex-r-sm, 3px)',
+  color: 'var(--color-codex-ink)',
+  outline: 'none',
 }
+
+const LABEL_STYLE: React.CSSProperties = {
+  fontSize: 12.5,
+  fontWeight: 500,
+  color: 'var(--color-codex-ink-soft)',
+}
+
+const SECTION_BOX_STYLE: React.CSSProperties = {
+  background: 'var(--color-codex-bg-elev)',
+  border: '1px solid var(--color-codex-line)',
+  borderRadius: 'var(--codex-r-md, 6px)',
+  overflow: 'hidden',
+}
+
+const SECTION_HEADER_STYLE: React.CSSProperties = {
+  background: 'var(--color-codex-bg-tint)',
+  borderBottom: '1px solid var(--color-codex-line-soft)',
+}
+
+const SECTION_BODY_STYLE: React.CSSProperties = {
+  padding: 16,
+}
+
+const CHIP_STYLE: React.CSSProperties = {
+  padding: '2px 8px',
+  fontSize: 10.5,
+  background: 'var(--color-codex-bg-tint)',
+  color: 'var(--color-codex-ink-soft)',
+  borderRadius: 'var(--codex-r-pill, 999px)',
+  fontFamily: 'var(--font-mono, ui-monospace, monospace)',
+  letterSpacing: '0.04em',
+  textTransform: 'uppercase',
+}
+
+const ACCENT_CHIP_STYLE: React.CSSProperties = {
+  ...CHIP_STYLE,
+  background: 'var(--color-codex-accent-bg)',
+  color: 'var(--color-codex-accent-ink)',
+}
+
+type ProviderKey = 'anthropic' | 'moonshot' | 'deepseek' | 'bigmodel' | 'mimo'
+
+interface ApiKeyRowConfig {
+  provider: ProviderKey
+  label: string
+  placeholder: (configured: boolean) => string
+  link?: { href: string; label: string }
+}
+
+const API_KEY_ROWS: ApiKeyRowConfig[] = [
+  {
+    provider: 'anthropic',
+    label: 'Anthropic API Key',
+    placeholder: (c) => (c ? 'Configured (enter to update)' : 'sk-ant-api03-...'),
+  },
+  {
+    provider: 'moonshot',
+    label: 'Moonshot API Key',
+    placeholder: (c) => (c ? 'Configured (enter to update)' : '...'),
+  },
+  {
+    provider: 'deepseek',
+    label: 'DeepSeek API Key',
+    placeholder: (c) => (c ? 'Configured (enter to update)' : 'sk-...'),
+    link: { href: 'https://platform.deepseek.com/api_keys', label: 'platform.deepseek.com' },
+  },
+  {
+    provider: 'bigmodel',
+    label: 'BigModel API Key',
+    placeholder: (c) => (c ? 'Configured (enter to update)' : 'Enter BigModel API Key'),
+    link: { href: 'https://open.bigmodel.cn/usercenter/apikeys', label: 'open.bigmodel.cn' },
+  },
+  {
+    provider: 'mimo',
+    label: 'Xiaomi MiMo API Key',
+    placeholder: (c) => (c ? 'Configured (enter to update)' : 'Enter MiMo API Key'),
+    link: { href: 'https://platform.xiaomimimo.com', label: 'platform.xiaomimimo.com' },
+  },
+]
 
 export function AISettings() {
   const { t } = useTranslation()
-  
-  // Model Selection (default to claude-sonnet-4-6 to match backend default)
+
   const [selectedModel, setSelectedModel] = useState('claude-sonnet-4-6')
-  
-  // API Keys
+
   const [apiKeys, setApiKeys] = useState<Record<string, string>>({
     anthropic: '',
     moonshot: '',
@@ -146,31 +228,26 @@ export function AISettings() {
     bigmodel: '',
     mimo: '',
   })
-  
-  // Parameters
+
   const [temperature, setTemperature] = useState(0.7)
   const [maxTokens, setMaxTokens] = useState(8192)
   const [topP, setTopP] = useState(1.0)
   const [presencePenalty, setPresencePenalty] = useState(0)
   const [frequencyPenalty, setFrequencyPenalty] = useState(0)
-  
-  // UI State
+
   const [saved, setSaved] = useState(false)
   const [loading, setLoading] = useState(false)
   const [initialLoading, setInitialLoading] = useState(true)
   const [error, setError] = useState('')
   const [successMessage, setSuccessMessage] = useState('')
-  
-  // Status
+
   const [apiKeyStatus, setApiKeyStatus] = useState<Record<string, boolean>>({})
   const [testingProvider, setTestingProvider] = useState<string | null>(null)
   const [expandedSection, setExpandedSection] = useState<string | null>('model')
-  
-  // Test message
+
   const [testMessage, setTestMessage] = useState('')
   const [isTesting, setIsTesting] = useState(false)
 
-  // Load settings on mount
   useEffect(() => {
     loadSettings()
   }, [])
@@ -179,31 +256,16 @@ export function AISettings() {
     try {
       setInitialLoading(true)
       setError('')
-      
-      // Load all settings
-      const settings = await api.get<Record<string, string>>('/settings/')
-      
-      // Load model settings (Mac App uses 'selected_model' and 'llm_provider')
-      if (settings.selected_model) {
-        setSelectedModel(settings.selected_model)
-      }
-      if (settings.temperature) {
-        setTemperature(parseFloat(settings.temperature))
-      }
-      if (settings.max_tokens) {
-        setMaxTokens(parseInt(settings.max_tokens))
-      }
-      if (settings.top_p) {
-        setTopP(parseFloat(settings.top_p))
-      }
-      if (settings.presence_penalty) {
-        setPresencePenalty(parseFloat(settings.presence_penalty))
-      }
-      if (settings.frequency_penalty) {
-        setFrequencyPenalty(parseFloat(settings.frequency_penalty))
-      }
 
-      // Check API key status for supported providers
+      const settings = await api.get<Record<string, string>>('/settings/')
+
+      if (settings.selected_model) setSelectedModel(settings.selected_model)
+      if (settings.temperature) setTemperature(parseFloat(settings.temperature))
+      if (settings.max_tokens) setMaxTokens(parseInt(settings.max_tokens))
+      if (settings.top_p) setTopP(parseFloat(settings.top_p))
+      if (settings.presence_penalty) setPresencePenalty(parseFloat(settings.presence_penalty))
+      if (settings.frequency_penalty) setFrequencyPenalty(parseFloat(settings.frequency_penalty))
+
       const providerEndpoints: Record<string, string> = {
         anthropic: '/settings/api-key-status',
         moonshot: '/settings/kimi-api-key-status',
@@ -212,18 +274,17 @@ export function AISettings() {
         mimo: '/settings/mimo-api-key-status',
       }
       const newStatus: Record<string, boolean> = {}
-      
+
       for (const [provider, endpoint] of Object.entries(providerEndpoints)) {
         try {
           const result = await api.get<{ configured: boolean }>(endpoint)
           newStatus[provider] = result.configured
-          console.log(`[AISettings] ${provider} API key status:`, result.configured)
         } catch (err) {
           console.error(`[AISettings] Failed to get ${provider} API key status:`, err)
           newStatus[provider] = false
         }
       }
-      
+
       setApiKeyStatus(newStatus)
     } catch (err: any) {
       setError(err.message || 'Failed to load settings')
@@ -239,7 +300,6 @@ export function AISettings() {
     setSuccessMessage('')
 
     try {
-      // Determine provider from selected model
       let provider = 'claude'
       if (selectedModel.startsWith('moonshot-') || selectedModel.startsWith('kimi-')) {
         provider = 'kimi'
@@ -250,20 +310,18 @@ export function AISettings() {
       } else if (selectedModel.startsWith('mimo-') || selectedModel.startsWith('xiaomi/mimo-')) {
         provider = 'mimo'
       }
-      
-      // Save settings (use same keys as Mac App)
+
       const settingsToSave = [
         api.put('/settings/selected_model', { value: selectedModel }),
         api.put('/settings/llm_provider', { value: provider }),
-        api.put('/settings/ai_model', { value: selectedModel }),  // for backward compatibility
+        api.put('/settings/ai_model', { value: selectedModel }),
         api.put('/settings/temperature', { value: temperature.toString() }),
         api.put('/settings/max_tokens', { value: maxTokens.toString() }),
         api.put('/settings/top_p', { value: topP.toString() }),
         api.put('/settings/presence_penalty', { value: presencePenalty.toString() }),
         api.put('/settings/frequency_penalty', { value: frequencyPenalty.toString() }),
       ]
-      
-      // Save API keys if provided
+
       Object.entries(apiKeys).forEach(([keyProvider, key]) => {
         if (key.trim()) {
           let endpoint: string
@@ -276,18 +334,15 @@ export function AISettings() {
           } else {
             endpoint = `/settings/${keyProvider}-api-key`
           }
-          settingsToSave.push(
-            api.post(endpoint, { api_key: key.trim() })
-          )
+          settingsToSave.push(api.post(endpoint, { api_key: key.trim() }))
         }
       })
-      
+
       await Promise.all(settingsToSave)
 
       setSaved(true)
       setSuccessMessage(t('settings.saved') || 'Settings saved successfully')
-      
-      // Clear API key inputs after save
+
       setApiKeys({
         anthropic: '',
         moonshot: '',
@@ -295,10 +350,9 @@ export function AISettings() {
         bigmodel: '',
         mimo: '',
       })
-      
-      // Refresh status
+
       await loadSettings()
-      
+
       setTimeout(() => {
         setSaved(false)
         setSuccessMessage('')
@@ -314,21 +368,20 @@ export function AISettings() {
     setTestingProvider(provider)
     setError('')
     setSuccessMessage('')
-    
+
     try {
-      // Use the current model's provider or the specific provider being tested
-      const result = await api.post('/chat/test-connection', { 
+      const result = await api.post('/chat/test-connection', {
         provider,
-        model: selectedModel 
+        model: selectedModel,
       })
-      
+
       const res = result as { success: boolean; message?: string }
       if (res.success) {
         setSuccessMessage(
-          t('settings.ai.testSuccess', { provider: providerNames[provider] }) || 
-          `${providerNames[provider]} connection successful`
+          t('settings.ai.testSuccess', { provider: providerNames[provider] }) ||
+            `${providerNames[provider]} connection successful`,
         )
-        setApiKeyStatus(prev => ({ ...prev, [provider]: true }))
+        setApiKeyStatus((prev) => ({ ...prev, [provider]: true }))
       } else {
         setError(res.message || 'Connection test failed')
       }
@@ -341,20 +394,19 @@ export function AISettings() {
 
   const handleTestModel = async () => {
     if (!testMessage.trim()) return
-    
+
     setIsTesting(true)
     setError('')
-    
+
     try {
-      // Use fixed params for Moonshot models
-      const modelData = models.find(m => m.id === selectedModel)
+      const modelData = models.find((m) => m.id === selectedModel)
       const effectiveParams = modelData?.fixedParams || {
         temperature,
         topP,
         presencePenalty,
-        frequencyPenalty
+        frequencyPenalty,
       }
-      
+
       const result = await api.post('/chat/test-model', {
         message: testMessage,
         model: selectedModel,
@@ -364,7 +416,7 @@ export function AISettings() {
         presence_penalty: effectiveParams.presencePenalty,
         frequency_penalty: effectiveParams.frequencyPenalty,
       })
-      
+
       const res = result as { success: boolean; message?: string }
       if (res.success) {
         setSuccessMessage('Model test successful! Response received.')
@@ -378,7 +430,7 @@ export function AISettings() {
     }
   }
 
-  const selectedModelData = models.find(m => m.id === selectedModel)
+  const selectedModelData = models.find((m) => m.id === selectedModel)
   const selectedProvider = selectedModelData?.provider || 'anthropic'
 
   useEffect(() => {
@@ -390,528 +442,501 @@ export function AISettings() {
     setSelectedModel(model.id)
     setMaxTokens((current) => Math.min(current, model.maxTokens))
   }
-  
+
   const toggleSection = (section: string) => {
     setExpandedSection(expandedSection === section ? null : section)
   }
 
   if (initialLoading) {
     return (
-      <div className="flex items-center justify-center py-12">
-        <Loader2 className="w-6 h-6 text-primary animate-spin" />
+      <div
+        className="theme-codex flex items-center justify-center py-12"
+        style={{ background: 'var(--color-codex-bg)' }}
+      >
+        <Loader2 className="h-6 w-6 animate-spin" style={{ color: 'var(--color-codex-accent)' }} />
+      </div>
+    )
+  }
+
+  const renderSectionHeader = (
+    sectionKey: string,
+    Icon: typeof Bot,
+    label: string,
+  ) => (
+    <button
+      onClick={() => toggleSection(sectionKey)}
+      className="flex w-full items-center justify-between p-4 transition-colors"
+      style={SECTION_HEADER_STYLE}
+    >
+      <div className="flex items-center gap-3">
+        <Icon className="h-4 w-4" style={{ color: 'var(--color-codex-accent)' }} />
+        <span style={{ fontSize: 14, fontWeight: 600, color: 'var(--color-codex-ink)' }}>
+          {label}
+        </span>
+      </div>
+      {expandedSection === sectionKey ? (
+        <ChevronUp className="h-4 w-4" style={{ color: 'var(--color-codex-ink-soft)' }} />
+      ) : (
+        <ChevronDown className="h-4 w-4" style={{ color: 'var(--color-codex-ink-soft)' }} />
+      )}
+    </button>
+  )
+
+  const renderParamSlider = (
+    label: string,
+    value: number,
+    fixed: number | undefined,
+    min: number,
+    max: number,
+    step: number,
+    onChange: (n: number) => void,
+    extra?: React.ReactNode,
+  ) => {
+    const displayValue = fixed ?? value
+    const disabled = fixed !== undefined
+    return (
+      <div>
+        <div className="mb-2 flex items-center justify-between">
+          <label style={LABEL_STYLE}>
+            {label}
+            {disabled && (
+              <span
+                className="ml-2 font-mono"
+                style={{ fontSize: 10.5, color: 'var(--color-codex-warn)' }}
+              >
+                (Fixed: {fixed})
+              </span>
+            )}
+          </label>
+          <span
+            className="font-mono"
+            style={{
+              fontSize: 12,
+              color: 'var(--color-codex-accent-ink)',
+            }}
+          >
+            {displayValue}
+          </span>
+        </div>
+        <input
+          type="range"
+          min={min}
+          max={max}
+          step={step}
+          value={displayValue}
+          onChange={(e) => onChange(parseFloat(e.target.value))}
+          disabled={disabled}
+          className="w-full disabled:cursor-not-allowed disabled:opacity-50"
+          style={{ accentColor: 'var(--color-codex-accent)' }}
+        />
+        {extra}
       </div>
     )
   }
 
   return (
-    <div className="space-y-6">
-      {/* Header */}
-      <div>
-        <h2 className="text-lg font-semibold text-on-surface mb-1">
+    <div
+      className="theme-codex"
+      style={{
+        background: 'var(--color-codex-bg)',
+        color: 'var(--color-codex-ink)',
+        padding: '8px 4px 32px',
+      }}
+    >
+      <header style={{ marginBottom: 20 }}>
+        <h1
+          style={{
+            margin: 0,
+            fontSize: 22,
+            fontWeight: 500,
+            color: 'var(--color-codex-ink)',
+            letterSpacing: '-0.015em',
+          }}
+        >
           {t('settings.ai.title') || 'AI Model Configuration'}
-        </h2>
-        <p className="text-sm text-on-surface-muted">
+        </h1>
+        <p
+          style={{
+            margin: '6px 0 0',
+            fontSize: 13,
+            color: 'var(--color-codex-ink-mute)',
+            lineHeight: 1.6,
+          }}
+        >
           {t('settings.ai.subtitle') || 'Configure your AI providers and model parameters'}
         </p>
-      </div>
+      </header>
 
-      {/* Alerts */}
       {error && (
-        <div className="p-3 bg-error/10 border border-error/20 rounded-lg flex items-center gap-2 text-error text-sm">
-          <AlertCircle className="w-4 h-4 flex-shrink-0" />
+        <div
+          className="mb-4 flex items-center gap-2"
+          style={{
+            padding: '10px 14px',
+            fontSize: 13,
+            background: 'color-mix(in oklch, var(--color-codex-bad) 8%, transparent)',
+            border: '1px solid color-mix(in oklch, var(--color-codex-bad) 30%, transparent)',
+            borderRadius: 'var(--codex-r-sm, 3px)',
+            color: 'var(--color-codex-bad)',
+          }}
+        >
+          <AlertCircle className="h-4 w-4 flex-shrink-0" />
           {error}
         </div>
       )}
-      
+
       {successMessage && (
-        <div className="p-3 bg-success/10 border border-success/20 rounded-lg flex items-center gap-2 text-success text-sm">
-          <Check className="w-4 h-4 flex-shrink-0" />
+        <div
+          className="mb-4 flex items-center gap-2"
+          style={{
+            padding: '10px 14px',
+            fontSize: 13,
+            background: 'var(--color-codex-accent-bg)',
+            border: '1px solid color-mix(in oklch, var(--color-codex-accent) 30%, transparent)',
+            borderRadius: 'var(--codex-r-sm, 3px)',
+            color: 'var(--color-codex-accent-ink)',
+          }}
+        >
+          <Check className="h-4 w-4 flex-shrink-0" />
           {successMessage}
         </div>
       )}
 
-      {/* Model Selection Section */}
-      <div className="border border-outline/20 rounded-xl overflow-hidden">
-        <button
-          onClick={() => toggleSection('model')}
-          className="w-full flex items-center justify-between p-4 bg-surface-container-low/50 hover:bg-surface-container-low transition-colors"
-        >
-          <div className="flex items-center gap-3">
-            <Bot className="w-5 h-5 text-primary" />
-            <span className="font-medium text-on-surface">
-              {t('settings.ai.modelSelection') || 'Model Selection'}
-            </span>
-          </div>
-          {expandedSection === 'model' ? (
-            <ChevronUp className="w-4 h-4 text-on-surface-muted" />
-          ) : (
-            <ChevronDown className="w-4 h-4 text-on-surface-muted" />
-          )}
-        </button>
-        
+      {/* Model Selection */}
+      <div className="mb-4" style={SECTION_BOX_STYLE}>
+        {renderSectionHeader('model', Bot, t('settings.ai.modelSelection') || 'Model Selection')}
         {expandedSection === 'model' && (
-          <div className="p-4 space-y-4">
-            <div className="grid gap-3">
-              {models.map(model => (
-                <div
-                  key={model.id}
-                  onClick={() => handleModelSelect(model)}
-                  className={`p-4 rounded-xl border-2 cursor-pointer transition-all ${
-                    selectedModel === model.id
-                      ? 'border-primary bg-primary/5'
-                      : 'border-outline/20 hover:border-outline/40'
-                  }`}
-                >
-                  <div className="flex items-start gap-3">
-                    <div className={`w-5 h-5 rounded-full border-2 flex items-center justify-center flex-shrink-0 mt-0.5 ${
-                      selectedModel === model.id ? 'border-primary' : 'border-outline/40'
-                    }`}>
-                      {selectedModel === model.id && (
-                        <div className="w-2.5 h-2.5 bg-primary rounded-full" />
-                      )}
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2 flex-wrap">
-                        <span className="text-2xl">{model.icon}</span>
-                        <span className="font-semibold text-on-surface">{model.name}</span>
-                        <span className={`px-2 py-0.5 text-xs rounded-full border ${providerColors[model.provider]}`}>
-                          {providerNames[model.provider]}
-                        </span>
-                        {model.supportsTools && (
-                          <span className="px-2 py-0.5 text-xs bg-secondary-container text-on-secondary-container rounded-full">
-                            Tools
-                          </span>
-                        )}
-                        {model.supportsVision && (
-                          <span className="px-2 py-0.5 text-xs bg-tertiary-container text-on-tertiary-container rounded-full">
-                            Vision
-                          </span>
+          <div style={SECTION_BODY_STYLE}>
+            <div className="grid gap-2">
+              {models.map((model) => {
+                const isSelected = selectedModel === model.id
+                return (
+                  <div
+                    key={model.id}
+                    onClick={() => handleModelSelect(model)}
+                    className="cursor-pointer transition-all"
+                    style={{
+                      padding: 14,
+                      background: isSelected
+                        ? 'var(--color-codex-accent-bg)'
+                        : 'var(--color-codex-bg)',
+                      border: isSelected
+                        ? '1px solid color-mix(in oklch, var(--color-codex-accent) 40%, transparent)'
+                        : '1px solid var(--color-codex-line-soft)',
+                      borderRadius: 'var(--codex-r-sm, 3px)',
+                    }}
+                  >
+                    <div className="flex items-start gap-3">
+                      <div
+                        className="mt-0.5 flex h-4 w-4 flex-shrink-0 items-center justify-center"
+                        style={{
+                          background: isSelected
+                            ? 'var(--color-codex-accent)'
+                            : 'var(--color-codex-bg-elev)',
+                          border: isSelected
+                            ? '1px solid var(--color-codex-accent)'
+                            : '1px solid var(--color-codex-line)',
+                          borderRadius: 'var(--codex-r-pill, 999px)',
+                        }}
+                      >
+                        {isSelected && (
+                          <div
+                            style={{
+                              width: 6,
+                              height: 6,
+                              background: 'var(--color-codex-bg-elev)',
+                              borderRadius: 'var(--codex-r-pill, 999px)',
+                            }}
+                          />
                         )}
                       </div>
-                      <p className="text-sm text-on-surface-muted mt-1">{model.description}</p>
-                      <p className="text-xs text-on-surface-muted mt-1">
-                        Max tokens: {model.maxTokens.toLocaleString()}
-                      </p>
+                      <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span
+                            className="font-mono"
+                            style={{
+                              padding: '2px 6px',
+                              fontSize: 10.5,
+                              fontWeight: 600,
+                              background: 'var(--color-codex-bg-tint)',
+                              color: 'var(--color-codex-ink-soft)',
+                              borderRadius: 'var(--codex-r-sm, 3px)',
+                              letterSpacing: '0.04em',
+                            }}
+                          >
+                            {model.icon}
+                          </span>
+                          <span
+                            style={{
+                              fontSize: 14,
+                              fontWeight: 600,
+                              color: 'var(--color-codex-ink)',
+                            }}
+                          >
+                            {model.name}
+                          </span>
+                          <span style={CHIP_STYLE}>{providerNames[model.provider]}</span>
+                          {model.supportsTools && <span style={ACCENT_CHIP_STYLE}>Tools</span>}
+                          {model.supportsVision && <span style={ACCENT_CHIP_STYLE}>Vision</span>}
+                        </div>
+                        <p
+                          style={{
+                            margin: '6px 0 0',
+                            fontSize: 12,
+                            lineHeight: 1.55,
+                            color: 'var(--color-codex-ink-mute)',
+                          }}
+                        >
+                          {model.description}
+                        </p>
+                        <p
+                          className="font-mono"
+                          style={{
+                            margin: '4px 0 0',
+                            fontSize: 11,
+                            color: 'var(--color-codex-ink-mute)',
+                          }}
+                        >
+                          max tokens: {model.maxTokens.toLocaleString()}
+                        </p>
+                      </div>
                     </div>
                   </div>
-                </div>
-              ))}
+                )
+              })}
             </div>
-            
-
           </div>
         )}
       </div>
 
-      {/* API Keys Section */}
-      <div className="border border-outline/20 rounded-xl overflow-hidden">
-        <button
-          onClick={() => toggleSection('apikeys')}
-          className="w-full flex items-center justify-between p-4 bg-surface-container-low/50 hover:bg-surface-container-low transition-colors"
-        >
-          <div className="flex items-center gap-3">
-            <Key className="w-5 h-5 text-primary" />
-            <span className="font-medium text-on-surface">
-              {t('settings.ai.apiKeys') || 'API Keys'}
-            </span>
-          </div>
-          {expandedSection === 'apikeys' ? (
-            <ChevronUp className="w-4 h-4 text-on-surface-muted" />
-          ) : (
-            <ChevronDown className="w-4 h-4 text-on-surface-muted" />
-          )}
-        </button>
-        
+      {/* API Keys */}
+      <div className="mb-4" style={SECTION_BOX_STYLE}>
+        {renderSectionHeader('apikeys', Key, t('settings.ai.apiKeys') || 'API Keys')}
         {expandedSection === 'apikeys' && (
-          <div className="p-4 space-y-4">
-            {/* Refresh Status */}
-            <div className="flex items-center justify-between">
-              <p className="text-sm text-on-surface-muted">
+          <div style={SECTION_BODY_STYLE}>
+            <div className="mb-3 flex items-center justify-between">
+              <p
+                style={{
+                  margin: 0,
+                  fontSize: 12.5,
+                  color: 'var(--color-codex-ink-mute)',
+                }}
+              >
                 API keys are stored securely and encrypted.
               </p>
               <button
                 onClick={loadSettings}
                 disabled={initialLoading}
-                className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-primary hover:bg-primary/10 rounded-lg transition-colors disabled:opacity-50"
+                className="flex items-center gap-1.5 disabled:opacity-50"
+                style={{
+                  padding: '5px 10px',
+                  fontSize: 11.5,
+                  background: 'var(--color-codex-bg)',
+                  color: 'var(--color-codex-ink-soft)',
+                  border: '1px solid var(--color-codex-line)',
+                  borderRadius: 'var(--codex-r-sm, 3px)',
+                }}
               >
                 {initialLoading ? (
-                  <RefreshCw className="w-3 h-3 animate-spin" />
+                  <RefreshCw className="h-3 w-3 animate-spin" />
                 ) : (
-                  <RefreshCw className="w-3 h-3" />
+                  <RefreshCw className="h-3 w-3" />
                 )}
                 Refresh Status
               </button>
             </div>
-            
-            {/* Anthropic */}
-            <div className="p-4 bg-surface-container-low rounded-xl">
-              <div className="flex items-center justify-between mb-2">
-                <label className="text-sm font-medium text-on-surface-secondary">
-                  Anthropic API Key
-                  {apiKeyStatus.anthropic && (
-                    <span className="ml-2 text-xs text-success">● Configured</span>
-                  )}
-                </label>
-                <button
-                  onClick={() => handleTestConnection('anthropic')}
-                  disabled={testingProvider === 'anthropic'}
-                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-primary hover:bg-primary/10 rounded-lg transition-colors disabled:opacity-50"
-                >
-                  {testingProvider === 'anthropic' ? (
-                    <RefreshCw className="w-3 h-3 animate-spin" />
-                  ) : (
-                    <TestTube className="w-3 h-3" />
-                  )}
-                  Test
-                </button>
-              </div>
-              <input
-                type="password"
-                value={apiKeys.anthropic}
-                onChange={(e) => setApiKeys(prev => ({ ...prev, anthropic: e.target.value }))}
-                placeholder={apiKeyStatus.anthropic ? 'Configured (enter to update)' : 'sk-ant-api03-...'}
-                className="w-full px-4 py-2.5 bg-surface-container-lowest border border-outline/20 rounded-lg text-on-surface placeholder:text-on-surface-muted focus:outline-none focus:border-primary/40 transition-colors"
-              />
-            </div>
 
-            {/* Moonshot */}
-            <div className="p-4 bg-surface-container-low rounded-xl">
-              <div className="flex items-center justify-between mb-2">
-                <label className="text-sm font-medium text-on-surface-secondary">
-                  Moonshot API Key
-                  {apiKeyStatus.moonshot && (
-                    <span className="ml-2 text-xs text-success">● Configured</span>
-                  )}
-                </label>
-                <button
-                  onClick={() => handleTestConnection('moonshot')}
-                  disabled={testingProvider === 'moonshot'}
-                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-primary hover:bg-primary/10 rounded-lg transition-colors disabled:opacity-50"
-                >
-                  {testingProvider === 'moonshot' ? (
-                    <RefreshCw className="w-3 h-3 animate-spin" />
-                  ) : (
-                    <TestTube className="w-3 h-3" />
-                  )}
-                  Test
-                </button>
-              </div>
-              <input
-                type="password"
-                value={apiKeys.moonshot}
-                onChange={(e) => setApiKeys(prev => ({ ...prev, moonshot: e.target.value }))}
-                placeholder={apiKeyStatus.moonshot ? 'Configured (enter to update)' : '...'}
-                className="w-full px-4 py-2.5 bg-surface-container-lowest border border-outline/20 rounded-lg text-on-surface placeholder:text-on-surface-muted focus:outline-none focus:border-primary/40 transition-colors"
-              />
-            </div>
-
-            {/* DeepSeek */}
-            <div className="p-4 bg-surface-container-low rounded-xl">
-              <div className="flex items-center justify-between mb-2">
-                <label className="text-sm font-medium text-on-surface-secondary">
-                  DeepSeek API Key
-                  {apiKeyStatus.deepseek && (
-                    <span className="ml-2 text-xs text-success">鈼?Configured</span>
-                  )}
-                </label>
-                <button
-                  onClick={() => handleTestConnection('deepseek')}
-                  disabled={testingProvider === 'deepseek'}
-                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-primary hover:bg-primary/10 rounded-lg transition-colors disabled:opacity-50"
-                >
-                  {testingProvider === 'deepseek' ? (
-                    <RefreshCw className="w-3 h-3 animate-spin" />
-                  ) : (
-                    <TestTube className="w-3 h-3" />
-                  )}
-                  Test
-                </button>
-              </div>
-              <input
-                type="password"
-                value={apiKeys.deepseek}
-                onChange={(e) => setApiKeys(prev => ({ ...prev, deepseek: e.target.value }))}
-                placeholder={apiKeyStatus.deepseek ? 'Configured (enter to update)' : 'sk-...'}
-                className="w-full px-4 py-2.5 bg-surface-container-lowest border border-outline/20 rounded-lg text-on-surface placeholder:text-on-surface-muted focus:outline-none focus:border-primary/40 transition-colors"
-              />
-              <p className="text-xs text-on-surface-muted mt-1.5">
-                Get your API key from {' '}
-                <a
-                  href="https://platform.deepseek.com/api_keys"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-primary hover:underline"
-                >
-                  platform.deepseek.com
-                </a>
-              </p>
-            </div>
-
-            {/* BigModel */}
-            <div className="p-4 bg-surface-container-low rounded-xl">
-              <div className="flex items-center justify-between mb-2">
-                <label className="text-sm font-medium text-on-surface-secondary">
-                  BigModel API Key
-                  {apiKeyStatus.bigmodel && (
-                    <span className="ml-2 text-xs text-success">● Configured</span>
-                  )}
-                </label>
-                <button
-                  onClick={() => handleTestConnection('bigmodel')}
-                  disabled={testingProvider === 'bigmodel'}
-                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-primary hover:bg-primary/10 rounded-lg transition-colors disabled:opacity-50"
-                >
-                  {testingProvider === 'bigmodel' ? (
-                    <RefreshCw className="w-3 h-3 animate-spin" />
-                  ) : (
-                    <TestTube className="w-3 h-3" />
-                  )}
-                  Test
-                </button>
-              </div>
-              <input
-                type="password"
-                value={apiKeys.bigmodel}
-                onChange={(e) => setApiKeys(prev => ({ ...prev, bigmodel: e.target.value }))}
-                placeholder={apiKeyStatus.bigmodel ? 'Configured (enter to update)' : 'Enter BigModel API Key'}
-                className="w-full px-4 py-2.5 bg-surface-container-lowest border border-outline/20 rounded-lg text-on-surface placeholder:text-on-surface-muted focus:outline-none focus:border-primary/40 transition-colors"
-              />
-              <p className="text-xs text-on-surface-muted mt-1.5">
-                Get your API key from {' '}
-                <a 
-                  href="https://open.bigmodel.cn/usercenter/apikeys" 
-                  target="_blank" 
-                  rel="noopener noreferrer"
-                  className="text-primary hover:underline"
-                >
-                  open.bigmodel.cn
-                </a>
-              </p>
-            </div>
-
-            {/* Xiaomi MiMo */}
-            <div className="p-4 bg-surface-container-low rounded-xl">
-              <div className="flex items-center justify-between mb-2">
-                <label className="text-sm font-medium text-on-surface-secondary">
-                  Xiaomi MiMo API Key
-                  {apiKeyStatus.mimo && (
-                    <span className="ml-2 text-xs text-success">Configured</span>
-                  )}
-                </label>
-                <button
-                  onClick={() => handleTestConnection('mimo')}
-                  disabled={testingProvider === 'mimo'}
-                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-primary hover:bg-primary/10 rounded-lg transition-colors disabled:opacity-50"
-                >
-                  {testingProvider === 'mimo' ? (
-                    <RefreshCw className="w-3 h-3 animate-spin" />
-                  ) : (
-                    <TestTube className="w-3 h-3" />
-                  )}
-                  Test
-                </button>
-              </div>
-              <input
-                type="password"
-                value={apiKeys.mimo}
-                onChange={(e) => setApiKeys(prev => ({ ...prev, mimo: e.target.value }))}
-                placeholder={apiKeyStatus.mimo ? 'Configured (enter to update)' : 'Enter MiMo API Key'}
-                className="w-full px-4 py-2.5 bg-surface-container-lowest border border-outline/20 rounded-lg text-on-surface placeholder:text-on-surface-muted focus:outline-none focus:border-primary/40 transition-colors"
-              />
-              <p className="text-xs text-on-surface-muted mt-1.5">
-                Get your API key from{' '}
-                <a
-                  href="https://platform.xiaomimimo.com"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-primary hover:underline"
-                >
-                  platform.xiaomimimo.com
-                </a>
-              </p>
+            <div className="space-y-3">
+              {API_KEY_ROWS.map((row) => {
+                const configured = apiKeyStatus[row.provider]
+                const isTesting = testingProvider === row.provider
+                return (
+                  <div
+                    key={row.provider}
+                    style={{
+                      padding: 14,
+                      background: 'var(--color-codex-bg)',
+                      border: '1px solid var(--color-codex-line-soft)',
+                      borderRadius: 'var(--codex-r-sm, 3px)',
+                    }}
+                  >
+                    <div className="mb-2 flex items-center justify-between">
+                      <label style={LABEL_STYLE}>
+                        {row.label}
+                        {configured && (
+                          <span
+                            className="ml-2 font-mono"
+                            style={{ fontSize: 10.5, color: 'var(--color-codex-accent-ink)' }}
+                          >
+                            ● Configured
+                          </span>
+                        )}
+                      </label>
+                      <button
+                        onClick={() => handleTestConnection(row.provider)}
+                        disabled={isTesting}
+                        className="flex items-center gap-1.5 disabled:opacity-50"
+                        style={{
+                          padding: '5px 10px',
+                          fontSize: 11.5,
+                          background: 'var(--color-codex-bg-elev)',
+                          color: 'var(--color-codex-ink-soft)',
+                          border: '1px solid var(--color-codex-line)',
+                          borderRadius: 'var(--codex-r-sm, 3px)',
+                        }}
+                      >
+                        {isTesting ? (
+                          <RefreshCw className="h-3 w-3 animate-spin" />
+                        ) : (
+                          <TestTube className="h-3 w-3" />
+                        )}
+                        Test
+                      </button>
+                    </div>
+                    <input
+                      type="password"
+                      value={apiKeys[row.provider]}
+                      onChange={(e) =>
+                        setApiKeys((prev) => ({ ...prev, [row.provider]: e.target.value }))
+                      }
+                      placeholder={row.placeholder(configured)}
+                      style={INPUT_STYLE}
+                    />
+                    {row.link && (
+                      <p
+                        style={{
+                          margin: '6px 0 0',
+                          fontSize: 11,
+                          color: 'var(--color-codex-ink-mute)',
+                        }}
+                      >
+                        Get your API key from{' '}
+                        <a
+                          href={row.link.href}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="hover:underline"
+                          style={{ color: 'var(--color-codex-accent-ink)' }}
+                        >
+                          {row.link.label}
+                        </a>
+                      </p>
+                    )}
+                  </div>
+                )
+              })}
             </div>
           </div>
         )}
       </div>
 
-      {/* Parameters Section */}
-      <div className="border border-outline/20 rounded-xl overflow-hidden">
-        <button
-          onClick={() => toggleSection('parameters')}
-          className="w-full flex items-center justify-between p-4 bg-surface-container-low/50 hover:bg-surface-container-low transition-colors"
-        >
-          <div className="flex items-center gap-3">
-            <Sliders className="w-5 h-5 text-primary" />
-            <span className="font-medium text-on-surface">
-              {t('settings.ai.parameters') || 'Model Parameters'}
-            </span>
-          </div>
-          {expandedSection === 'parameters' ? (
-            <ChevronUp className="w-4 h-4 text-on-surface-muted" />
-          ) : (
-            <ChevronDown className="w-4 h-4 text-on-surface-muted" />
-          )}
-        </button>
-        
+      {/* Parameters */}
+      <div className="mb-4" style={SECTION_BOX_STYLE}>
+        {renderSectionHeader('parameters', Sliders, t('settings.ai.parameters') || 'Model Parameters')}
         {expandedSection === 'parameters' && (
-          <div className="p-4 space-y-6">
-            {/* Temperature */}
+          <div style={{ ...SECTION_BODY_STYLE, display: 'flex', flexDirection: 'column', gap: 24 }}>
+            {renderParamSlider(
+              'Temperature',
+              temperature,
+              selectedModelData?.fixedParams?.temperature,
+              0,
+              2,
+              0.1,
+              setTemperature,
+              <div
+                className="mt-1 flex justify-between font-mono"
+                style={{ fontSize: 10.5, color: 'var(--color-codex-ink-mute)' }}
+              >
+                <span>Precise (0)</span>
+                <span>Balanced ({selectedProvider === 'anthropic' ? '0.7' : '1.0'})</span>
+                <span>Creative (2)</span>
+              </div>,
+            )}
+
+            {/* Max Tokens — own slider (no fixedParams) */}
             <div>
-              <div className="flex items-center justify-between mb-2">
-                <label className="text-sm font-medium text-on-surface-secondary">
-                  Temperature
-                  {selectedModelData?.fixedParams && (
-                    <span className="ml-2 text-xs text-warning">(Fixed: {selectedModelData.fixedParams.temperature})</span>
-                  )}
-                </label>
-                <span className="text-sm font-mono text-primary">
-                  {selectedModelData?.fixedParams?.temperature ?? temperature}
+              <div className="mb-2 flex items-center justify-between">
+                <label style={LABEL_STYLE}>Max Tokens</label>
+                <span
+                  className="font-mono"
+                  style={{ fontSize: 12, color: 'var(--color-codex-accent-ink)' }}
+                >
+                  {maxTokens.toLocaleString()}
                 </span>
               </div>
               <input
                 type="range"
-                min="0"
-                max="2"
-                step="0.1"
-                value={selectedModelData?.fixedParams?.temperature ?? temperature}
-                onChange={(e) => setTemperature(parseFloat(e.target.value))}
-                disabled={!!selectedModelData?.fixedParams}
-                className="w-full accent-primary disabled:opacity-50 disabled:cursor-not-allowed"
-              />
-              <div className="flex justify-between text-xs text-on-surface-muted mt-1">
-                <span>More precise (0)</span>
-                <span>Balanced ({selectedProvider === 'anthropic' ? '0.7' : '1.0'})</span>
-                <span>More creative (2)</span>
-              </div>
-            </div>
-
-            {/* Max Tokens */}
-            <div>
-              <div className="flex items-center justify-between mb-2">
-                <label className="text-sm font-medium text-on-surface-secondary">
-                  Max Tokens
-                </label>
-                <span className="text-sm font-mono text-primary">{maxTokens.toLocaleString()}</span>
-              </div>
-              <input
-                type="range"
-                min="256"
+                min={256}
                 max={selectedModelData?.maxTokens || 8192}
-                step="256"
+                step={256}
                 value={maxTokens}
                 onChange={(e) => setMaxTokens(parseInt(e.target.value))}
-                className="w-full accent-primary"
+                className="w-full"
+                style={{ accentColor: 'var(--color-codex-accent)' }}
               />
-              <div className="flex justify-between text-xs text-on-surface-muted mt-1">
+              <div
+                className="mt-1 flex justify-between font-mono"
+                style={{ fontSize: 10.5, color: 'var(--color-codex-ink-mute)' }}
+              >
                 <span>256</span>
                 <span>{((selectedModelData?.maxTokens || 8192) / 2).toLocaleString()}</span>
                 <span>{(selectedModelData?.maxTokens || 8192).toLocaleString()}</span>
               </div>
             </div>
 
-            {/* Top P */}
-            <div>
-              <div className="flex items-center justify-between mb-2">
-                <label className="text-sm font-medium text-on-surface-secondary">
-                  Top P
-                  {selectedModelData?.fixedParams && (
-                    <span className="ml-2 text-xs text-warning">(Fixed: {selectedModelData.fixedParams.topP})</span>
-                  )}
-                </label>
-                <span className="text-sm font-mono text-primary">
-                  {selectedModelData?.fixedParams?.topP ?? topP}
-                </span>
-              </div>
-              <input
-                type="range"
-                min="0"
-                max="1"
-                step="0.1"
-                value={selectedModelData?.fixedParams?.topP ?? topP}
-                onChange={(e) => setTopP(parseFloat(e.target.value))}
-                disabled={!!selectedModelData?.fixedParams}
-                className="w-full accent-primary disabled:opacity-50 disabled:cursor-not-allowed"
-              />
-              <p className="text-xs text-on-surface-muted mt-1">
+            {renderParamSlider(
+              'Top P',
+              topP,
+              selectedModelData?.fixedParams?.topP,
+              0,
+              1,
+              0.1,
+              setTopP,
+              <p
+                style={{
+                  margin: '6px 0 0',
+                  fontSize: 11,
+                  color: 'var(--color-codex-ink-mute)',
+                }}
+              >
                 Alternative to temperature. 1.0 means no filtering.
-              </p>
-            </div>
+              </p>,
+            )}
 
-            {/* Presence Penalty */}
-            <div>
-              <div className="flex items-center justify-between mb-2">
-                <label className="text-sm font-medium text-on-surface-secondary">
-                  Presence Penalty
-                  {selectedModelData?.fixedParams && (
-                    <span className="ml-2 text-xs text-warning">(Fixed: {selectedModelData.fixedParams.presencePenalty})</span>
-                  )}
-                </label>
-                <span className="text-sm font-mono text-primary">
-                  {selectedModelData?.fixedParams?.presencePenalty ?? presencePenalty}
-                </span>
-              </div>
-              <input
-                type="range"
-                min="-2"
-                max="2"
-                step="0.1"
-                value={selectedModelData?.fixedParams?.presencePenalty ?? presencePenalty}
-                onChange={(e) => setPresencePenalty(parseFloat(e.target.value))}
-                disabled={!!selectedModelData?.fixedParams}
-                className="w-full accent-primary disabled:opacity-50 disabled:cursor-not-allowed"
-              />
-            </div>
+            {renderParamSlider(
+              'Presence Penalty',
+              presencePenalty,
+              selectedModelData?.fixedParams?.presencePenalty,
+              -2,
+              2,
+              0.1,
+              setPresencePenalty,
+            )}
 
-            {/* Frequency Penalty */}
-            <div>
-              <div className="flex items-center justify-between mb-2">
-                <label className="text-sm font-medium text-on-surface-secondary">
-                  Frequency Penalty
-                  {selectedModelData?.fixedParams && (
-                    <span className="ml-2 text-xs text-warning">(Fixed: {selectedModelData.fixedParams.frequencyPenalty})</span>
-                  )}
-                </label>
-                <span className="text-sm font-mono text-primary">
-                  {selectedModelData?.fixedParams?.frequencyPenalty ?? frequencyPenalty}
-                </span>
-              </div>
-              <input
-                type="range"
-                min="-2"
-                max="2"
-                step="0.1"
-                value={selectedModelData?.fixedParams?.frequencyPenalty ?? frequencyPenalty}
-                onChange={(e) => setFrequencyPenalty(parseFloat(e.target.value))}
-                disabled={!!selectedModelData?.fixedParams}
-                className="w-full accent-primary disabled:opacity-50 disabled:cursor-not-allowed"
-              />
-            </div>
+            {renderParamSlider(
+              'Frequency Penalty',
+              frequencyPenalty,
+              selectedModelData?.fixedParams?.frequencyPenalty,
+              -2,
+              2,
+              0.1,
+              setFrequencyPenalty,
+            )}
           </div>
         )}
       </div>
 
-      {/* Test Model Section */}
-      <div className="border border-outline/20 rounded-xl overflow-hidden">
-        <button
-          onClick={() => toggleSection('test')}
-          className="w-full flex items-center justify-between p-4 bg-surface-container-low/50 hover:bg-surface-container-low transition-colors"
-        >
-          <div className="flex items-center gap-3">
-            <Zap className="w-5 h-5 text-primary" />
-            <span className="font-medium text-on-surface">
-              {t('settings.ai.testModel') || 'Test Model'}
-            </span>
-          </div>
-          {expandedSection === 'test' ? (
-            <ChevronUp className="w-4 h-4 text-on-surface-muted" />
-          ) : (
-            <ChevronDown className="w-4 h-4 text-on-surface-muted" />
-          )}
-        </button>
-        
+      {/* Test Model */}
+      <div className="mb-4" style={SECTION_BOX_STYLE}>
+        {renderSectionHeader('test', Zap, t('settings.ai.testModel') || 'Test Model')}
         {expandedSection === 'test' && (
-          <div className="p-4 space-y-4">
-            <p className="text-sm text-on-surface-muted">
+          <div style={SECTION_BODY_STYLE}>
+            <p
+              style={{
+                margin: '0 0 12px',
+                fontSize: 12.5,
+                color: 'var(--color-codex-ink-mute)',
+              }}
+            >
               Send a test message to verify your {selectedModelData?.name || 'selected model'} configuration.
             </p>
             <div className="flex gap-2">
@@ -920,18 +945,26 @@ export function AISettings() {
                 value={testMessage}
                 onChange={(e) => setTestMessage(e.target.value)}
                 placeholder="Enter a test message..."
-                className="flex-1 px-4 py-2.5 bg-surface-container-lowest border border-outline/20 rounded-lg text-on-surface placeholder:text-on-surface-muted focus:outline-none focus:border-primary/40 transition-colors"
+                style={{ ...INPUT_STYLE, flex: 1 }}
                 onKeyDown={(e) => e.key === 'Enter' && handleTestModel()}
               />
               <button
                 onClick={handleTestModel}
                 disabled={isTesting || !testMessage.trim()}
-                className="flex items-center gap-2 px-4 py-2.5 bg-primary text-white rounded-lg font-medium transition-all disabled:opacity-50 hover:bg-primary/90"
+                className="flex items-center gap-2 disabled:opacity-50"
+                style={{
+                  padding: '8px 16px',
+                  fontSize: 13,
+                  fontWeight: 500,
+                  background: 'var(--color-codex-accent)',
+                  color: 'var(--color-codex-bg-elev)',
+                  borderRadius: 'var(--codex-r-sm, 3px)',
+                }}
               >
                 {isTesting ? (
-                  <Loader2 className="w-4 h-4 animate-spin" />
+                  <Loader2 className="h-4 w-4 animate-spin" />
                 ) : (
-                  <Sparkles className="w-4 h-4" />
+                  <Sparkles className="h-4 w-4" />
                 )}
                 Test
               </button>
@@ -940,12 +973,22 @@ export function AISettings() {
         )}
       </div>
 
-      {/* Save Button */}
-      <div className="flex items-center justify-between pt-4 border-t border-outline/20">
-        <p className="text-sm text-on-surface-muted">
+      {/* Save bar */}
+      <div
+        className="flex items-center justify-between"
+        style={{
+          marginTop: 24,
+          paddingTop: 16,
+          borderTop: '1px solid var(--color-codex-line)',
+        }}
+      >
+        <p style={{ margin: 0, fontSize: 12.5, color: 'var(--color-codex-ink-mute)' }}>
           {saved ? (
-            <span className="text-success flex items-center gap-1">
-              <Check className="w-4 h-4" />
+            <span
+              className="flex items-center gap-1"
+              style={{ color: 'var(--color-codex-accent-ink)' }}
+            >
+              <Check className="h-4 w-4" />
               {t('settings.saved') || 'Settings saved'}
             </span>
           ) : (
@@ -955,16 +998,24 @@ export function AISettings() {
         <button
           onClick={handleSave}
           disabled={loading}
-          className="flex items-center gap-2 px-6 py-2.5 bg-primary hover:bg-primary/90 disabled:opacity-50 text-white rounded-xl font-medium transition-all"
+          className="flex items-center gap-2 disabled:opacity-50"
+          style={{
+            padding: '10px 20px',
+            fontSize: 13,
+            fontWeight: 500,
+            background: 'var(--color-codex-accent)',
+            color: 'var(--color-codex-bg-elev)',
+            borderRadius: 'var(--codex-r-sm, 3px)',
+          }}
         >
           {loading ? (
             <>
-              <Loader2 className="w-4 h-4 animate-spin" />
+              <Loader2 className="h-4 w-4 animate-spin" />
               {t('settings.saving') || 'Saving...'}
             </>
           ) : (
             <>
-              <Check className="w-4 h-4" />
+              <Check className="h-4 w-4" />
               {t('settings.save') || 'Save Settings'}
             </>
           )}


### PR DESCRIPTION
## Summary

Last Settings page. Brings AISettings into the Codex parchment palette. State machine, API calls, save/test/load flows unchanged.

- **theme-codex wrapper**, codex h1 + ink-mute description, codex-bad error banner, accent-bg success banner
- **Section headers** — shared bg-tint header with accent icon + codex ink-soft chevron; bg-elev card body with hairline border
- **Model selection** — codex bg / accent-bg cards with codex accent radio dot, mono uppercase icon badge, mono provider chip, accent-bg Tools / Vision chips (no rainbow), mono max-tokens hint
- **API Keys** — deduped into a single `API_KEY_ROWS` table driving codex bg sub-cards with `● Configured` accent-ink mono badge and a single codex ghost Test button; each row reuses the shared `INPUT_STYLE`
- **Parameters** — shared `renderParamSlider` helper drives codex accent sliders with mono current-value readouts, mono uppercase tick labels, and a warn-color `(Fixed: …)` annotation when the selected model locks the parameter
- **Test Model** — codex input + accent send button
- **Save bar** — codex-line divider, accent-ink "saved" state, accent Save button

With this PR all 13 Settings pages are on Codex tokens.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 513 passed
- [x] `npx vite build` clean
- [ ] Visual smoke: visit /settings/ai, open each of the four sections (Model / API Keys / Parameters / Test), pick a fixed-params model (Kimi K2.6) and confirm sliders disable with the `(Fixed: …)` annotation, hit Test for a provider, and Save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)