### PR TITLE
App shell (Layout + SettingsLayout) — Codex (V0.0.6 · 16/N)

### DIFF
--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -177,55 +177,110 @@ export function Layout() {
     return <Navigate to="/onboarding" replace />
   }
 
+  const renderNavLink = (
+    item: { path: string; label: string; icon: typeof LayoutDashboard },
+    options?: { mobile?: boolean },
+  ) => {
+    const isActive =
+      location.pathname === item.path ||
+      (item.path !== '/' && location.pathname.startsWith(item.path))
+    const preloadRoute = () => {
+      const loader = primaryRouteLoaders[item.path]
+      if (loader) void loader()
+    }
+    return (
+      <NavLink
+        key={item.path}
+        to={item.path}
+        onMouseEnter={preloadRoute}
+        onFocus={preloadRoute}
+        className={`flex items-center gap-1.5 px-3 py-2 transition-all ${options?.mobile ? 'min-w-fit' : ''}`}
+        style={{
+          fontSize: 12.5,
+          fontWeight: 500,
+          background: isActive ? 'var(--color-codex-accent-bg)' : 'transparent',
+          color: isActive
+            ? 'var(--color-codex-accent-ink)'
+            : 'var(--color-codex-ink-soft)',
+          borderRadius: 'var(--codex-r-sm, 3px)',
+        }}
+      >
+        <item.icon className="h-3.5 w-3.5" />
+        <span>{item.label}</span>
+      </NavLink>
+    )
+  }
+
   return (
-    <div className="flex h-full flex-col bg-surface">
+    <div
+      className="theme-codex flex h-full flex-col"
+      style={{
+        background: 'var(--color-codex-bg)',
+        color: 'var(--color-codex-ink)',
+      }}
+    >
       {isProjectDetailRoute ? null : (
-        <header className="glass sticky top-0 z-50 border-b border-outline/10">
+        <header
+          className="sticky top-0 z-50"
+          style={{
+            background: 'var(--color-codex-bg)',
+            borderBottom: '1px solid var(--color-codex-line)',
+          }}
+        >
           <div className="flex h-14 items-center justify-between px-4 sm:px-6">
             <div className="flex items-center gap-6">
               <NavLink to="/" className="flex flex-shrink-0 items-center gap-2">
-                <span className="font-manrope text-lg font-bold text-primary">Aria AI</span>
+                <span
+                  className="font-manrope"
+                  style={{
+                    fontSize: 16,
+                    fontWeight: 700,
+                    color: 'var(--color-codex-ink)',
+                    letterSpacing: '-0.01em',
+                  }}
+                >
+                  Aria AI
+                </span>
               </NavLink>
 
               <nav className="hidden items-center gap-0.5 md:flex">
-                {navItems.map((item) => {
-                  const isActive =
-                    location.pathname === item.path ||
-                    (item.path !== '/' && location.pathname.startsWith(item.path))
-                  const preloadRoute = () => {
-                    const loader = primaryRouteLoaders[item.path]
-                    if (loader) void loader()
-                  }
-
-                  return (
-                    <NavLink
-                      key={item.path}
-                      to={item.path}
-                      onMouseEnter={preloadRoute}
-                      onFocus={preloadRoute}
-                      className={`flex items-center gap-1.5 rounded-lg px-3 py-2 text-sm font-medium transition-all ${
-                        isActive
-                          ? 'bg-secondary-container/50 text-primary'
-                          : 'text-on-surface-variant hover:bg-surface-container-low hover:text-on-surface'
-                      }`}
-                    >
-                      <item.icon className="h-4 w-4" />
-                      {item.label}
-                    </NavLink>
-                  )
-                })}
+                {navItems.map((item) => renderNavLink(item))}
               </nav>
             </div>
 
             <div className="flex items-center gap-1">
               <button
                 onClick={() => navigate('/messages')}
-                className="relative flex h-7 w-7 items-center justify-center rounded-full text-on-surface-variant transition hover:bg-surface-container-low hover:text-on-surface"
+                className="relative flex h-7 w-7 items-center justify-center transition-colors"
+                style={{
+                  color: 'var(--color-codex-ink-soft)',
+                  borderRadius: 'var(--codex-r-sm, 3px)',
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.background = 'var(--color-codex-bg-tint)'
+                  e.currentTarget.style.color = 'var(--color-codex-ink)'
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.background = 'transparent'
+                  e.currentTarget.style.color = 'var(--color-codex-ink-soft)'
+                }}
                 title="Messages"
               >
                 <Bell className="h-3.5 w-3.5" />
                 {unreadCount > 0 ? (
-                  <span className="absolute -right-0.5 -top-0.5 min-w-[18px] rounded-full bg-error px-1.5 py-0.5 text-xs font-semibold leading-none text-white">
+                  <span
+                    className="absolute -right-0.5 -top-0.5 font-mono"
+                    style={{
+                      minWidth: 18,
+                      padding: '2px 5px',
+                      fontSize: 10.5,
+                      fontWeight: 600,
+                      lineHeight: 1,
+                      background: 'var(--color-codex-bad)',
+                      color: 'var(--color-codex-bg-elev)',
+                      borderRadius: 'var(--codex-r-pill, 999px)',
+                    }}
+                  >
                     {unreadCount > 99 ? '99+' : unreadCount}
                   </span>
                 ) : null}
@@ -234,7 +289,12 @@ export function Layout() {
               <div className="relative">
                 <button
                   onClick={() => setShowUserMenu(!showUserMenu)}
-                  className="flex h-7 w-7 items-center justify-center overflow-hidden rounded-full bg-gradient-primary text-white"
+                  className="flex h-7 w-7 items-center justify-center overflow-hidden"
+                  style={{
+                    background: 'var(--color-codex-accent-bg)',
+                    color: 'var(--color-codex-accent-ink)',
+                    borderRadius: 'var(--codex-r-pill, 999px)',
+                  }}
                   aria-label="User menu"
                   title={user?.display_name || 'User'}
                 >
@@ -243,7 +303,7 @@ export function Layout() {
                       className="block text-center font-semibold leading-none"
                       data-testid="user-initials"
                       style={{
-                        fontSize: '11px',
+                        fontSize: 11,
                         lineHeight: 1,
                         transform: `scale(${initialsScale})`,
                         transformOrigin: 'center',
@@ -257,30 +317,83 @@ export function Layout() {
                 </button>
 
                 {showUserMenu && (
-                  <div className="animate-fade-in absolute right-0 top-full z-50 mt-2 w-52 rounded-xl border border-outline/10 bg-surface-container-lowest py-1.5 shadow-lg">
-                    <div className="border-b border-outline/10 px-4 py-2.5">
-                      <p className="text-sm font-medium text-on-surface">{user?.display_name || 'User'}</p>
-                      <p className="truncate text-xs text-on-surface-muted">{user?.email || ''}</p>
+                  <div
+                    className="animate-fade-in absolute right-0 top-full z-50 mt-2 w-52 py-1.5"
+                    style={{
+                      background: 'var(--color-codex-bg-elev)',
+                      border: '1px solid var(--color-codex-line)',
+                      borderRadius: 'var(--codex-r-md, 6px)',
+                      boxShadow: '0 4px 16px -4px rgba(0,0,0,0.08)',
+                    }}
+                  >
+                    <div
+                      className="px-4 py-2.5"
+                      style={{ borderBottom: '1px solid var(--color-codex-line-soft)' }}
+                    >
+                      <p
+                        style={{
+                          margin: 0,
+                          fontSize: 13,
+                          fontWeight: 500,
+                          color: 'var(--color-codex-ink)',
+                        }}
+                      >
+                        {user?.display_name || 'User'}
+                      </p>
+                      <p
+                        className="truncate font-mono"
+                        style={{
+                          margin: '2px 0 0',
+                          fontSize: 11,
+                          color: 'var(--color-codex-ink-mute)',
+                        }}
+                      >
+                        {user?.email || ''}
+                      </p>
                     </div>
-                    <NavLink
-                      to="/messages"
-                      onClick={() => setShowUserMenu(false)}
-                      className="flex w-full items-center gap-2 px-4 py-2 text-[13px] leading-5 text-on-surface-variant transition-colors hover:bg-surface-container-low"
-                    >
-                      <Bell className="h-4 w-4 flex-shrink-0" />
-                      Messages
-                    </NavLink>
-                    <NavLink
-                      to="/settings"
-                      onClick={() => setShowUserMenu(false)}
-                      className="flex w-full items-center gap-2 px-4 py-2 text-[13px] leading-5 text-on-surface-variant transition-colors hover:bg-surface-container-low"
-                    >
-                      <Settings className="h-4 w-4 flex-shrink-0" />
-                      {t('settings.title')}
-                    </NavLink>
+                    {[
+                      { to: '/messages', icon: Bell, label: 'Messages' },
+                      { to: '/settings', icon: Settings, label: t('settings.title') },
+                    ].map((entry) => (
+                      <NavLink
+                        key={entry.to}
+                        to={entry.to}
+                        onClick={() => setShowUserMenu(false)}
+                        className="flex w-full items-center gap-2 px-4 py-2 transition-colors"
+                        style={{
+                          fontSize: 12.5,
+                          lineHeight: '20px',
+                          color: 'var(--color-codex-ink-soft)',
+                        }}
+                        onMouseEnter={(e) => {
+                          e.currentTarget.style.background = 'var(--color-codex-bg-tint)'
+                          e.currentTarget.style.color = 'var(--color-codex-ink)'
+                        }}
+                        onMouseLeave={(e) => {
+                          e.currentTarget.style.background = 'transparent'
+                          e.currentTarget.style.color = 'var(--color-codex-ink-soft)'
+                        }}
+                      >
+                        <entry.icon className="h-4 w-4 flex-shrink-0" />
+                        {entry.label}
+                      </NavLink>
+                    ))}
                     <button
                       onClick={handleLogout}
-                      className="flex w-full items-center gap-2 px-4 py-2 text-[13px] leading-5 text-on-surface-variant transition-colors hover:bg-surface-container-low"
+                      className="flex w-full items-center gap-2 px-4 py-2 transition-colors"
+                      style={{
+                        fontSize: 12.5,
+                        lineHeight: '20px',
+                        color: 'var(--color-codex-ink-soft)',
+                      }}
+                      onMouseEnter={(e) => {
+                        e.currentTarget.style.background = 'var(--color-codex-bg-tint)'
+                        e.currentTarget.style.color = 'var(--color-codex-ink)'
+                      }}
+                      onMouseLeave={(e) => {
+                        e.currentTarget.style.background = 'transparent'
+                        e.currentTarget.style.color = 'var(--color-codex-ink-soft)'
+                      }}
                     >
                       <LogOut className="h-4 w-4 flex-shrink-0" />
                       {t('settings.signOut')}
@@ -290,38 +403,19 @@ export function Layout() {
               </div>
             </div>
           </div>
-          <nav className="flex gap-1 overflow-x-auto border-t border-outline/10 px-3 py-2 md:hidden">
-            {navItems.map((item) => {
-              const isActive =
-                location.pathname === item.path ||
-                (item.path !== '/' && location.pathname.startsWith(item.path))
-              const preloadRoute = () => {
-                const loader = primaryRouteLoaders[item.path]
-                if (loader) void loader()
-              }
-
-              return (
-                <NavLink
-                  key={item.path}
-                  to={item.path}
-                  onMouseEnter={preloadRoute}
-                  onFocus={preloadRoute}
-                  className={`flex min-w-fit items-center gap-1.5 rounded-lg px-3 py-2 text-sm font-medium transition-all ${
-                    isActive
-                      ? 'bg-secondary-container/60 text-primary'
-                      : 'text-on-surface-variant hover:bg-surface-container-low hover:text-on-surface'
-                  }`}
-                >
-                  <item.icon className="h-4 w-4" />
-                  <span>{item.label}</span>
-                </NavLink>
-              )
-            })}
+          <nav
+            className="flex gap-1 overflow-x-auto px-3 py-2 md:hidden"
+            style={{ borderTop: '1px solid var(--color-codex-line-soft)' }}
+          >
+            {navItems.map((item) => renderNavLink(item, { mobile: true }))}
           </nav>
         </header>
       )}
 
-      <main className="app-ui flex-1 overflow-auto">
+      <main
+        className="app-ui flex-1 overflow-auto"
+        style={{ background: 'var(--color-codex-bg)' }}
+      >
         <Outlet />
       </main>
     </div>

--- a/web/src/pages/settings/SettingsLayout.tsx
+++ b/web/src/pages/settings/SettingsLayout.tsx
@@ -56,18 +56,63 @@ export function SettingsLayout() {
   return (
     <>
       <PageTitle title={t('settings.title')} />
-      <div className="settings-ui min-h-full bg-surface">
-        <div className="w-full px-4 py-4 sm:px-6 lg:px-8">
-          <div className="mb-4 flex flex-col gap-2 border-b border-outline/60 pb-3 sm:flex-row sm:items-center sm:justify-between">
+      <div
+        className="settings-ui theme-codex min-h-full"
+        style={{
+          background: 'var(--color-codex-bg)',
+          color: 'var(--color-codex-ink)',
+        }}
+      >
+        <div className="w-full px-4 py-5 sm:px-6 lg:px-8">
+          <div
+            className="mb-5 flex flex-col gap-2 pb-4 sm:flex-row sm:items-center sm:justify-between"
+            style={{ borderBottom: '1px solid var(--color-codex-line)' }}
+          >
             <div className="min-w-0">
-              <h1 className="text-xl font-semibold text-on-surface">{t('settings.title')}</h1>
-              <p className="mt-0.5 hidden max-w-3xl truncate text-sm text-on-surface-muted lg:block">{t('settings.description')}</p>
+              <h1
+                style={{
+                  margin: 0,
+                  fontSize: 22,
+                  fontWeight: 500,
+                  color: 'var(--color-codex-ink)',
+                  letterSpacing: '-0.015em',
+                }}
+              >
+                {t('settings.title')}
+              </h1>
+              <p
+                className="mt-1 hidden max-w-3xl truncate lg:block"
+                style={{
+                  margin: '6px 0 0',
+                  fontSize: 13,
+                  color: 'var(--color-codex-ink-mute)',
+                  lineHeight: 1.6,
+                }}
+              >
+                {t('settings.description')}
+              </p>
             </div>
             <div className="flex items-center gap-2">
-              <span className="hidden w-fit items-center rounded-full bg-surface-container-low px-3 py-1 text-xs font-medium text-on-surface-muted sm:inline-flex">
+              <span
+                className="font-mono hidden w-fit items-center sm:inline-flex"
+                style={{
+                  padding: '2px 8px',
+                  fontSize: 10.5,
+                  background: 'var(--color-codex-bg-tint)',
+                  color: 'var(--color-codex-ink-soft)',
+                  borderRadius: 'var(--codex-r-pill, 999px)',
+                  letterSpacing: '0.06em',
+                  textTransform: 'uppercase',
+                }}
+              >
                 {isZh ? '系统配置' : 'System settings'}
               </span>
-              <span className="text-xs text-on-surface-muted lg:hidden">{t('settings.description')}</span>
+              <span
+                className="lg:hidden"
+                style={{ fontSize: 11.5, color: 'var(--color-codex-ink-mute)' }}
+              >
+                {t('settings.description')}
+              </span>
             </div>
           </div>
 
@@ -78,28 +123,63 @@ export function SettingsLayout() {
               }`}
             >
               <nav
-                className={`rounded-2xl bg-surface-container-low p-2 ${navCollapsed ? 'lg:px-2' : ''}`}
+                style={{
+                  padding: 8,
+                  background: 'var(--color-codex-bg-elev)',
+                  border: '1px solid var(--color-codex-line)',
+                  borderRadius: 'var(--codex-r-md, 6px)',
+                }}
               >
                 <div
-                  className={`mb-2 hidden items-center gap-2 rounded-xl bg-surface/70 p-2 lg:flex ${
+                  className={`mb-2 hidden items-center gap-2 p-2 lg:flex ${
                     navCollapsed ? 'justify-center' : 'justify-between'
                   }`}
+                  style={{
+                    background: 'var(--color-codex-bg-tint)',
+                    borderRadius: 'var(--codex-r-sm, 3px)',
+                  }}
                 >
                   <div className={`min-w-0 ${navCollapsed ? 'hidden' : ''}`}>
-                    <div className="text-sm font-semibold text-on-surface">{isZh ? '设置导航' : 'Settings nav'}</div>
-                    <div className="truncate text-xs text-on-surface-muted">{isZh ? '可随时收起左栏' : 'Collapse when you need space'}</div>
+                    <div
+                      className="font-mono"
+                      style={{
+                        fontSize: 10.5,
+                        fontWeight: 600,
+                        color: 'var(--color-codex-ink-soft)',
+                        letterSpacing: '0.06em',
+                        textTransform: 'uppercase',
+                      }}
+                    >
+                      {isZh ? '设置导航' : 'Settings nav'}
+                    </div>
+                    <div
+                      className="truncate"
+                      style={{
+                        marginTop: 2,
+                        fontSize: 11,
+                        color: 'var(--color-codex-ink-mute)',
+                      }}
+                    >
+                      {isZh ? '可随时收起左栏' : 'Collapse when you need space'}
+                    </div>
                   </div>
                   <button
                     type="button"
                     onClick={toggleNavCollapsed}
-                    className="grid h-8 w-8 flex-shrink-0 place-items-center rounded-lg border border-outline/80 bg-surface text-on-surface-muted transition hover:bg-surface-container-high hover:text-on-surface"
+                    className="grid h-7 w-7 flex-shrink-0 place-items-center transition-colors"
+                    style={{
+                      background: 'var(--color-codex-bg-elev)',
+                      color: 'var(--color-codex-ink-soft)',
+                      border: '1px solid var(--color-codex-line)',
+                      borderRadius: 'var(--codex-r-sm, 3px)',
+                    }}
                     aria-label={navCollapsed ? (isZh ? '展开设置菜单' : 'Expand settings menu') : isZh ? '收起设置菜单' : 'Collapse settings menu'}
                   >
-                    {navCollapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronLeft className="h-4 w-4" />}
+                    {navCollapsed ? <ChevronRight className="h-3.5 w-3.5" /> : <ChevronLeft className="h-3.5 w-3.5" />}
                   </button>
                 </div>
 
-                <div className="flex gap-2 overflow-x-auto lg:block lg:space-y-1 lg:overflow-visible">
+                <div className="flex gap-1 overflow-x-auto lg:block lg:space-y-0.5 lg:overflow-visible">
                   {settingNavItems.map((item) => (
                     <NavLink
                       key={item.path}
@@ -107,18 +187,32 @@ export function SettingsLayout() {
                       end={item.path === ''}
                       title={navCollapsed ? item.label : undefined}
                       className={({ isActive }) =>
-                        `group flex shrink-0 items-center gap-3 rounded-xl px-4 py-3 text-sm font-medium transition-all lg:w-full ${
-                          navCollapsed ? 'lg:justify-center lg:px-3' : ''
-                        } ${
-                          isActive
-                            ? 'bg-secondary-container/50 text-primary shadow-sm'
-                            : 'text-on-surface-variant hover:bg-surface-container-high hover:text-on-surface'
-                        }`
+                        `group flex shrink-0 items-center gap-3 px-3 py-2.5 transition-all lg:w-full ${
+                          navCollapsed ? 'lg:justify-center lg:px-2' : ''
+                        } ${isActive ? 'cx-setting-nav-active' : 'cx-setting-nav'}`
                       }
+                      style={({ isActive }) => ({
+                        fontSize: 12.5,
+                        fontWeight: 500,
+                        background: isActive
+                          ? 'var(--color-codex-accent-bg)'
+                          : 'transparent',
+                        color: isActive
+                          ? 'var(--color-codex-accent-ink)'
+                          : 'var(--color-codex-ink-soft)',
+                        borderRadius: 'var(--codex-r-sm, 3px)',
+                      })}
                     >
                       {({ isActive }) => (
                         <>
-                          <item.icon className={`h-4 w-4 flex-shrink-0 ${isActive ? 'text-primary' : ''}`} />
+                          <item.icon
+                            className="h-3.5 w-3.5 flex-shrink-0"
+                            style={{
+                              color: isActive
+                                ? 'var(--color-codex-accent)'
+                                : 'var(--color-codex-ink-faint)',
+                            }}
+                          />
                           <span className={`${navCollapsed ? 'lg:hidden' : ''}`}>{item.label}</span>
                         </>
                       )}
@@ -128,7 +222,7 @@ export function SettingsLayout() {
               </nav>
             </aside>
 
-            <div className="card min-w-0 flex-1 overflow-hidden">
+            <div className="min-w-0 flex-1 overflow-hidden" style={{ padding: '8px 16px' }}>
               <Outlet />
             </div>
           </div>


### PR DESCRIPTION
## Summary

You called this out: 页面的框架我看还没换呢。导航。等. Right — the inner Chat / Workspace / Settings pages are on Codex, but the global `Layout` (top bar + nav) and `SettingsLayout` (left settings nav) were still on MD3 tokens, which is why the frame still felt V0.0.5.

This PR moves both shells.

### Layout.tsx (global top bar)
- `theme-codex` root, codex bg page background, codex hairline bottom border on the sticky header (no more glass / backdrop-blur)
- Logo: codex ink wordmark instead of `text-primary`
- Nav links (desktop + mobile): accent-bg + accent-ink when active, ink-soft default, 12.5px sizing; deduped into a shared `renderNavLink(item, { mobile? })` helper
- Bell button: codex ghost hover, codex-bad pill for unread count
- Avatar: solid accent-bg / accent-ink (no gradient)
- User dropdown: codex bg-elev shell with hairline border, mono email in ink-mute, bg-tint hover on each entry

### SettingsLayout.tsx (settings sidebar)
- `theme-codex` root, codex bg shell, codex hairline divider under the title
- "System settings" pill: mono uppercase bg-tint
- Nav sidebar: codex bg-elev panel with hairline border; sidebar header is bg-tint with mono uppercase label + codex ghost collapse button
- Nav links: accent-bg + accent-ink-mix when active, accent icon; ink-soft / ink-faint icon when idle
- Content slot: removed the legacy `card` wrapper so inner pages own their bg-elev panels (no double-stacking the same elevated background)

No semantic changes — `Layout.test.tsx` still asserts "Aria AI", initials testid, unread badge, route hrefs; `SettingsLayout.test.tsx` still asserts nav entries.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 513 passed
- [x] `npx vite build` clean
- [ ] Visual smoke: log in, walk through Workspace → Chat → Skills → Projects → Settings, confirm the top bar / settings sidebar feel consistent with the inner Codex pages and the active-route pill highlights match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)