### PR TITLE
Codex chrome: button hover + drop selection override

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -116,10 +116,6 @@ body {
   letter-spacing: 0;
 }
 
-::selection {
-  background: rgba(0, 63, 177, 0.14);
-}
-
 /* Element reset kept in @layer base so Tailwind utilities (e.g. text-[13px] on a
    <button>) still win — an unlayered rule here would override all layered
    utilities regardless of specificity (Tailwind v4 cascade layers). */
@@ -407,12 +403,6 @@ samp {
 
 .animate-slide-in {
   animation: slideInRight 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
-}
-
-/* === Selection === */
-::selection {
-  background-color: #d5e0f8;
-  color: #003fb1;
 }
 
 /* === Gradient Backgrounds === */

--- a/web/src/styles/codex.css
+++ b/web/src/styles/codex.css
@@ -413,3 +413,39 @@
   user-select: none;
   white-space: pre;
 }
+
+/* Universal interactive feedback inside the Codex theme.
+ *
+ * Codex pages style their controls with inline styles (no shared button
+ * class), so adding a global hover state through tokens is the cheapest
+ * way to give every button a "you moved over me" affordance without
+ * sweeping every call site. The rules:
+ *
+ * - cursor: pointer for any enabled interactive element
+ * - hover: a small brightness shift plus a subtle bg-tint wash that
+ *   shows up even on transparent buttons
+ * - opt-out via .cx-no-hover for cases that need to look pinned (the
+ *   currently-selected nav pill already has its own visible bg, etc.)
+ */
+.theme-codex button:not(:disabled):not(.cx-no-hover),
+.theme-codex [role="button"]:not(:disabled):not(.cx-no-hover),
+.theme-codex a:not(.cx-no-hover) {
+  cursor: pointer;
+  transition: filter 150ms ease, background-color 150ms ease,
+    color 150ms ease, border-color 150ms ease;
+}
+
+/* Use ``box-shadow inset`` rather than ``background-color`` so the wash
+ * works across all four button surface variants (solid accent, bg-elev,
+ * bg-tint, fully transparent) without clobbering the inline style the
+ * caller already set on the element. */
+.theme-codex button:not(:disabled):not(.cx-no-hover):hover,
+.theme-codex [role="button"]:not(:disabled):not(.cx-no-hover):hover {
+  box-shadow: inset 0 0 0 9999px color-mix(in oklab, var(--color-codex-ink) 7%, transparent);
+}
+
+.theme-codex button:focus-visible:not(:disabled),
+.theme-codex [role="button"]:focus-visible:not(:disabled) {
+  outline: 2px solid color-mix(in oklab, var(--color-codex-accent) 40%, transparent);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Summary

Two small fixes on the shared layer that affect every Codex page.

### 1. Hover affordance on every button
Codex pages style their controls with inline styles, so adding hover at each call site is a sweep. Instead, a single rule under `.theme-codex` gives any enabled `button` / `[role="button"]` a 7% ink wash via inset `box-shadow` and `cursor: pointer`.

`box-shadow inset` was chosen over a `background-color` change so the wash works on **all four** button surface variants (solid accent, bg-elev, bg-tint, fully transparent) without clobbering the inline background the caller already set.

Opt-out with `.cx-no-hover` for elements that should look pinned (the currently-active nav pill, etc.). Also adds a matching accent-tinted focus-visible outline.

### 2. Drop the custom `::selection` rules
There were two of them in `index.css` (one blue background, one tinted blue) — they fought with the parchment palette. Removed both; text selection now uses the OS default.

No JS / TSX changes — purely CSS.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 513 passed
- [x] `npx vite build` clean
- [ ] Visual smoke: hover any Codex button (accent Save, codex ghost Refresh, transparent chevron, accent-bg active nav pill) — confirm each gives visible feedback. Select text on a Codex page — confirm the highlight is the browser default, not the old blue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)