### PR TITLE
Codex button hover: add brightness for dark backgrounds

### DIFF
--- a/web/src/styles/codex.css
+++ b/web/src/styles/codex.css
@@ -435,13 +435,23 @@
     color 150ms ease, border-color 150ms ease;
 }
 
-/* Use ``box-shadow inset`` rather than ``background-color`` so the wash
- * works across all four button surface variants (solid accent, bg-elev,
- * bg-tint, fully transparent) without clobbering the inline style the
- * caller already set on the element. */
+/* Hover combines two effects so feedback is visible regardless of how
+ * the caller styled the button background:
+ *
+ * - ``filter: brightness(0.93)`` darkens any solid background. This is
+ *   what makes the moss accent button (which reads almost-black) and
+ *   the codex-bad destructive button feel responsive — a 7% ink wash
+ *   alone was too subtle on dark surfaces.
+ * - ``box-shadow inset`` adds a 6% ink wash on top. This is what keeps
+ *   transparent / icon-only buttons (chevrons, dropdown rows) visible,
+ *   because brightness on transparent pixels has no effect.
+ *
+ * Together they cover all four button surface variants without
+ * clobbering the inline ``background`` the caller set. */
 .theme-codex button:not(:disabled):not(.cx-no-hover):hover,
 .theme-codex [role="button"]:not(:disabled):not(.cx-no-hover):hover {
-  box-shadow: inset 0 0 0 9999px color-mix(in oklab, var(--color-codex-ink) 7%, transparent);
+  filter: brightness(0.93);
+  box-shadow: inset 0 0 0 9999px color-mix(in oklab, var(--color-codex-ink) 6%, transparent);
 }
 
 .theme-codex button:focus-visible:not(:disabled),


### PR DESCRIPTION
## Summary

Follow-up to #44. You called this out: the moss accent button (which reads almost-black) didn't respond to hover. PR #44 used only a 7% inset ink wash, which is invisible on near-black surfaces.

This PR combines two effects so feedback is visible regardless of background luminance:

- `filter: brightness(0.93)` darkens any solid background — fixes the moss accent, codex-bad, and any other inline `background:` button.
- `box-shadow inset` keeps a 6% ink wash on top for transparent / icon-only buttons where `brightness` has nothing to darken.

Together they cover all four button surface variants (solid accent, bg-elev, bg-tint, transparent) without clobbering the inline `background` the caller set.

## Test plan

- [x] `npx vitest run` — 513 passed
- [x] `npx vite build` clean
- [ ] Visual smoke after deploy: hover the dark Save / Publish / Send (accent) buttons and the Delete (codex-bad) buttons — confirm each visibly darkens. Hover a transparent chevron / dropdown row — confirm the ink wash still shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)