### PR TITLE
Nav active state: match design's quiet bg-tint pattern

### DIFF
--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -188,20 +188,24 @@ export function Layout() {
       const loader = primaryRouteLoaders[item.path]
       if (loader) void loader()
     }
+    // Per ``direction-codex-part1.jsx:106``: bg-tint + ink + 500 active,
+    // transparent + ink-mute + 400 idle, the ``.row-hov`` class supplies
+    // hover via bg-tint background.
     return (
       <NavLink
         key={item.path}
         to={item.path}
         onMouseEnter={preloadRoute}
         onFocus={preloadRoute}
-        className={`flex items-center gap-1.5 px-3 py-2 transition-all ${options?.mobile ? 'min-w-fit' : ''}`}
+        className={`row-hov flex items-center gap-1.5 ${options?.mobile ? 'min-w-fit' : ''}`}
         style={{
-          fontSize: 12.5,
-          fontWeight: 500,
-          background: isActive ? 'var(--color-codex-accent-bg)' : 'transparent',
+          padding: '6px 12px',
+          fontSize: 13.5,
+          fontWeight: isActive ? 500 : 400,
+          background: isActive ? 'var(--color-codex-bg-tint)' : 'transparent',
           color: isActive
-            ? 'var(--color-codex-accent-ink)'
-            : 'var(--color-codex-ink-soft)',
+            ? 'var(--color-codex-ink)'
+            : 'var(--color-codex-ink-mute)',
           borderRadius: 'var(--codex-r-sm, 3px)',
         }}
       >
@@ -359,19 +363,11 @@ export function Layout() {
                         key={entry.to}
                         to={entry.to}
                         onClick={() => setShowUserMenu(false)}
-                        className="flex w-full items-center gap-2 px-4 py-2 transition-colors"
+                        className="row-hov flex w-full items-center gap-2 px-4 py-2"
                         style={{
                           fontSize: 12.5,
                           lineHeight: '20px',
                           color: 'var(--color-codex-ink-soft)',
-                        }}
-                        onMouseEnter={(e) => {
-                          e.currentTarget.style.background = 'var(--color-codex-bg-tint)'
-                          e.currentTarget.style.color = 'var(--color-codex-ink)'
-                        }}
-                        onMouseLeave={(e) => {
-                          e.currentTarget.style.background = 'transparent'
-                          e.currentTarget.style.color = 'var(--color-codex-ink-soft)'
                         }}
                       >
                         <entry.icon className="h-4 w-4 flex-shrink-0" />
@@ -380,19 +376,11 @@ export function Layout() {
                     ))}
                     <button
                       onClick={handleLogout}
-                      className="flex w-full items-center gap-2 px-4 py-2 transition-colors"
+                      className="row-hov cx-no-hover flex w-full items-center gap-2 px-4 py-2"
                       style={{
                         fontSize: 12.5,
                         lineHeight: '20px',
                         color: 'var(--color-codex-ink-soft)',
-                      }}
-                      onMouseEnter={(e) => {
-                        e.currentTarget.style.background = 'var(--color-codex-bg-tint)'
-                        e.currentTarget.style.color = 'var(--color-codex-ink)'
-                      }}
-                      onMouseLeave={(e) => {
-                        e.currentTarget.style.background = 'transparent'
-                        e.currentTarget.style.color = 'var(--color-codex-ink-soft)'
                       }}
                     >
                       <LogOut className="h-4 w-4 flex-shrink-0" />

--- a/web/src/pages/settings/SettingsLayout.tsx
+++ b/web/src/pages/settings/SettingsLayout.tsx
@@ -187,29 +187,46 @@ export function SettingsLayout() {
                       end={item.path === ''}
                       title={navCollapsed ? item.label : undefined}
                       className={({ isActive }) =>
-                        `group flex shrink-0 items-center gap-3 px-3 py-2.5 transition-all lg:w-full ${
-                          navCollapsed ? 'lg:justify-center lg:px-2' : ''
+                        `row-hov relative flex shrink-0 items-center gap-3 lg:w-full ${
+                          navCollapsed ? 'lg:justify-center' : ''
                         } ${isActive ? 'cx-setting-nav-active' : 'cx-setting-nav'}`
                       }
                       style={({ isActive }) => ({
-                        fontSize: 12.5,
-                        fontWeight: 500,
+                        padding: navCollapsed ? '7px 8px' : '7px 10px',
+                        fontSize: 13,
+                        fontWeight: isActive ? 500 : 400,
                         background: isActive
-                          ? 'var(--color-codex-accent-bg)'
+                          ? 'var(--color-codex-bg-tint)'
                           : 'transparent',
                         color: isActive
-                          ? 'var(--color-codex-accent-ink)'
+                          ? 'var(--color-codex-ink)'
                           : 'var(--color-codex-ink-soft)',
                         borderRadius: 'var(--codex-r-sm, 3px)',
                       })}
                     >
                       {({ isActive }) => (
                         <>
+                          {/* 2px accent stripe down the left edge for active
+                              item (see ``direction-codex-part2.jsx:259``). */}
+                          {isActive && (
+                            <span
+                              aria-hidden="true"
+                              style={{
+                                position: 'absolute',
+                                left: 0,
+                                top: 8,
+                                bottom: 8,
+                                width: 2,
+                                background: 'var(--color-codex-accent)',
+                                borderRadius: 999,
+                              }}
+                            />
+                          )}
                           <item.icon
                             className="h-3.5 w-3.5 flex-shrink-0"
                             style={{
                               color: isActive
-                                ? 'var(--color-codex-accent)'
+                                ? 'var(--color-codex-ink)'
                                 : 'var(--color-codex-ink-faint)',
                             }}
                           />

--- a/web/src/styles/codex.css
+++ b/web/src/styles/codex.css
@@ -313,9 +313,13 @@
   height: 1px;
 }
 
-/* Row hover — subtle tinted background, no shadow. */
+/* Row hover — subtle tinted background, no shadow. ``!important`` is
+ * required so the class wins over the inline ``style={{ background:
+ * '...' }}`` that workspace skill cards and other row callers set for
+ * their idle state (inline ``style`` has higher specificity than any
+ * class rule). */
 .theme-codex .codex-row-hov:hover {
-  background: var(--color-codex-bg-tint);
+  background: var(--color-codex-bg-tint) !important;
 }
 
 /* Status dot pulse — "alive" indicator for in-progress states. */
@@ -459,8 +463,13 @@
  * Net: every surface variant moves visibly. The direction differs
  * (dark surfaces brighten, light surfaces darken), but both register
  * as "you're hovering me" without per-call-site styling. */
-.theme-codex button:not(:disabled):not(.cx-no-hover):hover,
-.theme-codex [role="button"]:not(:disabled):not(.cx-no-hover):hover {
+/* Exclude ``.row-hov`` / ``.codex-row-hov`` so list-row buttons (e.g.
+ * the workspace project rows, chat thread rows) get only the quiet
+ * bg-tint hover the design specifies — the brightness(1.18) would
+ * lighten that bg-tint back toward white and make the hover look
+ * washed-out instead of crisp. */
+.theme-codex button:not(:disabled):not(.cx-no-hover):not(.row-hov):not(.codex-row-hov):hover,
+.theme-codex [role="button"]:not(:disabled):not(.cx-no-hover):not(.row-hov):not(.codex-row-hov):hover {
   filter: brightness(1.18);
   box-shadow: inset 0 0 0 9999px color-mix(in oklab, var(--color-codex-ink) 7%, transparent);
 }
@@ -477,7 +486,9 @@
  * the element with bg-tint, which matches the active-state background
  * the design uses on nav links — so hovering an idle link "previews"
  * what it'll look like when active. Apply this to anchors / divs that
- * shouldn't get the brightness-1.18 button hover. */
+ * shouldn't get the brightness-1.18 button hover. ``!important`` so the
+ * hover wins over the inline ``style.background`` callers set for the
+ * idle state. */
 .theme-codex .row-hov:hover {
-  background: var(--color-codex-bg-tint);
+  background: var(--color-codex-bg-tint) !important;
 }

--- a/web/src/styles/codex.css
+++ b/web/src/styles/codex.css
@@ -470,3 +470,14 @@
   outline: 2px solid color-mix(in oklab, var(--color-codex-accent) 40%, transparent);
   outline-offset: 2px;
 }
+
+/* `row-hov` — the design's quiet hover pattern for nav links, list rows,
+ * and dropdown items (see ``design_handoff_aria_codex_redesign/codex.css``
+ * and the ``.row-hov`` callers throughout the prototype). Hover fills
+ * the element with bg-tint, which matches the active-state background
+ * the design uses on nav links — so hovering an idle link "previews"
+ * what it'll look like when active. Apply this to anchors / divs that
+ * shouldn't get the brightness-1.18 button hover. */
+.theme-codex .row-hov:hover {
+  background: var(--color-codex-bg-tint);
+}


### PR DESCRIPTION
## Summary

你说得对——我之前把一级导航做得太"branded"了。回去对照 `direction-codex-part1.jsx:108` 和 `direction-codex-part2.jsx:258`，发现原型用的是非常安静的 bg-tint，不是 accent-bg。

### 顶部 nav（`direction-codex-part1.jsx:108`）
- Active：`bg-tint + ink + weight 500`
- Idle：`transparent + ink-mute + weight 400`
- fontSize 13.5, padding 6/12
- 用 `.row-hov` 类提供 bg-tint hover

之前我用的 `accent-bg + accent-ink` 太抢眼，看着像"品牌色"而不是"被选中"。

### Settings 侧边栏（`direction-codex-part2.jsx:258`）
- 同样的 bg-tint + ink 调色板
- fontSize 13, padding 7/10
- **加了 2px accent 竖条**贴在 active 项左边沿（这是 active 状态里 accent 唯一登场的地方，做个安静的指示器，而不是整块 accent 背景）

### 顶部右上头像下拉菜单
- 拿掉了原本 inline 的 onMouseEnter/onMouseLeave color-swap handlers
- 改用 `.row-hov` 类，跟 nav links 共用同一份 hover 来源

### codex.css 加 `.row-hov`
- `.theme-codex .row-hov:hover { background: var(--color-codex-bg-tint); }`
- 对应原型 `codex.css` 里的 `.row-hov` 规则
- Logout button 是 `<button>` 会同时触发全局 button:hover 的 brightness(1.18)，跟 row-hov 的 bg swap 打架——所以给它加了 `.cx-no-hover` 退出 brightness 规则

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 513 passed
- [x] `npx vite build` clean
- [ ] Visual smoke after deploy: 看顶部导航 active 项应该是 bg-tint + 深墨色文字（不是绿背景）；hover idle 项变 bg-tint 但文字保持 ink-mute；Settings 左侧导航 active 项左边沿一条 2px accent 绿竖条。

🤖 Generated with [Claude Code](https://claude.com/claude-code)