### PR TITLE
Workspace: match design strictly (logo + plain rows + 金额 column)

### DIFF
--- a/web/src/components/Layout.test.tsx
+++ b/web/src/components/Layout.test.tsx
@@ -57,7 +57,7 @@ describe('Layout', () => {
   it('renders brand name', async () => {
     renderLayout()
     await waitFor(() => {
-      expect(screen.getByText('Aria AI')).toBeInTheDocument()
+      expect(screen.getByTestId('cx-logo')).toBeInTheDocument()
     })
   })
 
@@ -76,7 +76,7 @@ describe('Layout', () => {
   it('hides primary navigation on project detail routes', async () => {
     renderLayout('/projects/27')
     await waitFor(() => {
-      expect(screen.queryByText('Aria AI')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('cx-logo')).not.toBeInTheDocument()
     })
   })
 
@@ -119,7 +119,7 @@ describe('Layout', () => {
   it('does not redirect to /onboarding when onboarding_seen is true', async () => {
     renderLayout()
     await waitFor(() => {
-      expect(screen.getByText('Aria AI')).toBeInTheDocument()
+      expect(screen.getByTestId('cx-logo')).toBeInTheDocument()
     })
     expect(screen.queryByTestId('onboarding-stub')).not.toBeInTheDocument()
   })
@@ -143,6 +143,6 @@ describe('Layout', () => {
       expect(screen.getByTestId('onboarding-stub')).toBeInTheDocument()
     })
     // The Layout header should NOT render once the redirect lands.
-    expect(screen.queryByText('Aria AI')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('cx-logo')).not.toBeInTheDocument()
   })
 })

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -18,6 +18,7 @@ import { api } from '../api/client'
 import type { User } from '../types/api'
 import { primaryRouteLoaders, warmPrimaryRoutes } from '../routeLoaders'
 import { DEFAULT_APP_TIMEZONE, setAppTimeZone } from '../utils/timezone'
+import { CxLogo } from './codex/CxLogo'
 
 interface UserMemoryFetchResponse {
   preferences: Record<string, unknown>
@@ -233,18 +234,10 @@ export function Layout() {
         >
           <div className="flex h-14 items-center justify-between px-4 sm:px-6">
             <div className="flex items-center gap-6">
-              <NavLink to="/" className="flex flex-shrink-0 items-center gap-2">
-                <span
-                  className="font-manrope"
-                  style={{
-                    fontSize: 16,
-                    fontWeight: 700,
-                    color: 'var(--color-codex-ink)',
-                    letterSpacing: '-0.01em',
-                  }}
-                >
-                  Aria AI
-                </span>
+              <NavLink to="/" className="flex flex-shrink-0 items-center" aria-label="Aria AI">
+                {/* Matches ``direction-codex-part1.jsx:101`` — small ink
+                    monogram + "Aria" wordmark, no "AI" suffix. */}
+                <CxLogo size={22} />
               </NavLink>
 
               <nav className="hidden items-center gap-0.5 md:flex">

--- a/web/src/pages/Workspace.tsx
+++ b/web/src/pages/Workspace.tsx
@@ -608,7 +608,9 @@ export function Workspace() {
                 }
               />
 
-              {/* Column header */}
+              {/* 5-column grid per the prototype (see
+                  ``direction-codex-part1.jsx:191``):
+                  项目 / 阶段 / 金额 / 记忆 / arrow. */}
               <div
                 className="grid items-center"
                 style={{
@@ -616,7 +618,7 @@ export function Workspace() {
                   color: "var(--color-codex-ink-faint)",
                   padding: "6px 4px 8px",
                   borderBottom: "1px solid var(--color-codex-line)",
-                  gridTemplateColumns: "1fr 110px 120px 14px",
+                  gridTemplateColumns: "1fr 110px 100px 110px 14px",
                   columnGap: 14,
                   letterSpacing: "0.04em",
                   textTransform: "uppercase",
@@ -624,6 +626,7 @@ export function Workspace() {
               >
                 <span>{isZh ? "项目" : "Project"}</span>
                 <span>{isZh ? "阶段" : "Stage"}</span>
+                <span>{isZh ? "金额" : "Amount"}</span>
                 <span>{isZh ? "记忆" : "Memory"}</span>
                 <span />
               </div>
@@ -638,7 +641,7 @@ export function Workspace() {
                     style={{
                       padding: "13px 4px",
                       columnGap: 14,
-                      gridTemplateColumns: "1fr 110px 120px 14px",
+                      gridTemplateColumns: "1fr 110px 100px 110px 14px",
                       borderBottom:
                         index === arr.length - 1
                           ? "none"
@@ -674,6 +677,20 @@ export function Workspace() {
                     <CxStatus tone={statusTone(project.status)}>
                       {getStageLabel(project.status, isZh)}
                     </CxStatus>
+                    <span
+                      className="font-mono"
+                      style={{
+                        fontSize: 13,
+                        color: "var(--color-codex-ink-soft)",
+                        fontVariantNumeric: "tabular-nums",
+                      }}
+                    >
+                      {project.contract_amount
+                        ? isZh
+                          ? `¥${Math.round(project.contract_amount / 10000)}万`
+                          : `$${(project.contract_amount / 1000).toFixed(0)}k`
+                        : "—"}
+                    </span>
                     {project.memory_stale || (project.memory_version ?? 0) === 0 ? (
                       <CxStatus tone="warn">{isZh ? "记忆过期" : "stale"}</CxStatus>
                     ) : (
@@ -735,12 +752,14 @@ export function Workspace() {
                 }
               />
               {todayTodos.length ? (
+                // Plain ``<div>`` rows per the prototype (see
+                // ``direction-codex-part1.jsx:216``) — no hover, no
+                // navigation. The list is a status read-out, not a
+                // jump-target.
                 todayTodos.slice(0, 5).map((todo) => (
-                  <button
+                  <div
                     key={todo.id}
-                    type="button"
-                    onClick={() => navigate(`/projects/${todo.project_id}/todos`)}
-                    className="codex-row-hov flex w-full items-start text-left"
+                    className="flex items-start"
                     style={{
                       gap: 10,
                       padding: "8px 0",
@@ -801,7 +820,7 @@ export function Workspace() {
                         }}
                       />
                     )}
-                  </button>
+                  </div>
                 ))
               ) : (
                 <p
@@ -834,12 +853,13 @@ export function Workspace() {
                 }
               />
               {upcomingTodos.length ? (
+                // Plain ``<div>`` rows per the prototype (see
+                // ``direction-codex-part1.jsx:231``) — date prefix in
+                // accent + title + project. Static like the todos above.
                 upcomingTodos.slice(0, 4).map((todo) => (
-                  <button
+                  <div
                     key={todo.id}
-                    type="button"
-                    onClick={() => navigate(`/projects/${todo.project_id}/todos`)}
-                    className="codex-row-hov flex w-full items-start text-left"
+                    className="flex items-start"
                     style={{
                       gap: 12,
                       padding: "8px 0",
@@ -880,7 +900,7 @@ export function Workspace() {
                         {todo.project_name || "—"}
                       </div>
                     </div>
-                  </button>
+                  </div>
                 ))
               ) : (
                 <p


### PR DESCRIPTION
## Summary

按你说的，严格对照 `design_handoff_aria_codex_redesign/direction-codex-part1.jsx`，不再自己发挥。

### 1. 顶部 logo
- 原来只有 "Aria AI" 文字 wordmark，没有 logo glyph
- 现在用上原型里的 `<CxLogo size={22}/>` —— 小的墨色方块 + 小写 mono `a` + "Aria" wordmark（注意是 "Aria" 不是 "Aria AI"）
- `CxLogo` primitive 在 `components/codex/CxLogo.tsx` 早就有了，只是没接到 shell
- `Layout.test.tsx` 改用 `cx-logo` testid 断言（不再查找 "Aria AI" 字串）

### 2. 右侧待办 + 即将里程碑
- 原型用的是纯 `<div>` 行（`direction-codex-part1.jsx:216`、`:231`），没有 row-hov，不可点击 —— 它是"状态读出板"不是"跳转入口"
- 我之前把它包成 `<button className="codex-row-hov">` 加了悬停 + 跳转，那是自己发挥
- 改回纯 `<div>`，跟原型一致
- 最近对话保持 `codex-row-hov` 锚点不变（这一个原型里就是带 row-hov 的）

### 3. 进行中项目表 —— 加回 金额 列
- 原型是 5 列 grid：项目 / 阶段 / **金额** / 记忆 / arrow（`direction-codex-part1.jsx:191`）
- 我之前没确认 `Project` 是否有金额字段就缩成 4 列，其实 `Project.contract_amount?: number` 一直在
- 加了金额列，mono tabular numerics，中文显示 `万`，英文显示 `k`，`ink-soft` 颜色

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 513 passed
- [x] `npx vite build` clean
- [ ] Visual smoke 部署后：顶部能看见 logo 小方块 + Aria wordmark；右侧今日待办和即将里程碑是静态行（hover 没反应、不可点）；左侧进行中项目表有 金额 列显示 `¥xx万`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)