### PR TITLE
fix: add contract_amount to DashboardProjectSummary type

### DIFF
--- a/web/src/pages/Workspace.tsx
+++ b/web/src/pages/Workspace.tsx
@@ -44,6 +44,7 @@ interface DashboardProjectSummary {
   name: string
   client: string
   status: string
+  contract_amount?: number
   updated_at: string
   memory_stale?: boolean
   memory_version?: number


### PR DESCRIPTION
CI green-build fix after #48. The dashboard summary endpoint already returns contract_amount; the local TS interface in Workspace.tsx hadn't declared the field.