### PR TITLE
Appearance: background warmth picker + cool down default bg-tint

### DIFF
--- a/web/src/hooks/useCodexAppearance.test.tsx
+++ b/web/src/hooks/useCodexAppearance.test.tsx
@@ -22,6 +22,7 @@ function Probe() {
             accent: "azure",
             density: "comfy",
             radius: "round",
+            warmth: "paper",
           })
         }
       />
@@ -45,6 +46,7 @@ describe("useCodexAppearance", () => {
       accent: "amber",
       density: "comfy",
       radius: "round",
+      warmth: "paper",
     });
     render(<Probe />);
     expect(screen.getByTestId("theme").textContent).toBe("dark");

--- a/web/src/pages/settings/AppearanceSettings.tsx
+++ b/web/src/pages/settings/AppearanceSettings.tsx
@@ -23,6 +23,7 @@ import type {
   CodexDensity,
   CodexRadius,
   CodexTheme,
+  CodexWarmth,
 } from "../../utils/codexAppearance";
 
 interface ChipOption<T extends string> {
@@ -65,6 +66,15 @@ const RADIUS_OPTIONS: { value: CodexRadius; label_zh: string; label_en: string; 
   { value: "sharp", label_zh: "锐利", label_en: "Sharp", px: 0 },
   { value: "soft", label_zh: "柔和", label_en: "Soft", px: 6 },
   { value: "round", label_zh: "圆润", label_en: "Round", px: 14 },
+];
+
+// Warmth swatches use the same color the CSS class will set as
+// ``--color-codex-bg`` — keeps the picker honest. See the
+// ``.warmth-*`` rules in ``styles/codex.css``.
+const WARMTH_OPTIONS: { value: CodexWarmth; label_zh: string; label_en: string; bg: string }[] = [
+  { value: "white", label_zh: "纯白", label_en: "White", bg: "#ffffff" },
+  { value: "paper", label_zh: "中性", label_en: "Paper", bg: "#fafaf7" },
+  { value: "parchment", label_zh: "暖羊皮", label_en: "Parchment", bg: "#fcfbf7" },
 ];
 
 export function AppearanceSettings() {
@@ -136,6 +146,66 @@ export function AppearanceSettings() {
             </>
           )}
         />
+      </CxFormRow>
+
+      {/* Background warmth — page color from pure white to warm
+          parchment. Only affects the light theme; dark mode ignores it. */}
+      <CxFormRow
+        label={isZh ? "页面背景" : "Page background"}
+        hint={
+          isZh
+            ? "羊皮偏暖、纯白偏冷 — 选你看着最舒服的那一档。深色主题不受影响。"
+            : "Parchment is warm, white is cool — pick whatever's easiest on your eyes. Dark theme is unaffected."
+        }
+      >
+        <div className="flex flex-wrap gap-2.5" data-testid="appearance-warmth">
+          {WARMTH_OPTIONS.map((opt) => {
+            const active = appearance.warmth === opt.value;
+            return (
+              <button
+                key={opt.value}
+                type="button"
+                role="radio"
+                aria-checked={active}
+                aria-label={isZh ? opt.label_zh : opt.label_en}
+                onClick={() => patchAppearance({ warmth: opt.value })}
+                className="flex flex-col items-center gap-1.5 transition"
+                style={{ padding: 4, cursor: "pointer" }}
+              >
+                <span
+                  aria-hidden="true"
+                  style={{
+                    width: 56,
+                    height: 36,
+                    borderRadius: 6,
+                    background: opt.bg,
+                    border: `1px solid ${
+                      active
+                        ? "var(--color-codex-accent)"
+                        : "var(--color-codex-line-strong)"
+                    }`,
+                    boxShadow: active
+                      ? "0 0 0 2px var(--color-codex-bg), 0 0 0 4px var(--color-codex-accent)"
+                      : "none",
+                    transition: "box-shadow 0.15s",
+                    display: "inline-block",
+                  }}
+                />
+                <span
+                  style={{
+                    fontSize: 12,
+                    color: active
+                      ? "var(--color-codex-ink)"
+                      : "var(--color-codex-ink-mute)",
+                    fontWeight: active ? 500 : 400,
+                  }}
+                >
+                  {isZh ? opt.label_zh : opt.label_en}
+                </span>
+              </button>
+            );
+          })}
+        </div>
       </CxFormRow>
 
       {/* Accent */}

--- a/web/src/styles/codex.css
+++ b/web/src/styles/codex.css
@@ -23,11 +23,17 @@
    ============================================================ */
 
 @theme {
-  /* ---- Backgrounds ---- */
+  /* ---- Backgrounds ----
+     The bg-tint shade is what shows up on row hover / active nav and
+     was originally tuned warm (#f3f0e7) to match the parchment vibe.
+     Users found that too yellow against the also-warm bg, so the tint
+     and sunken values now keep most of the parchment character with a
+     little less amber — a smaller R/B gap. Users who want a cooler
+     page can opt into ``warmth-paper`` or ``warmth-white`` below. */
   --color-codex-bg: #fcfbf7;        /* App background, page canvas */
   --color-codex-bg-elev: #ffffff;   /* Elevated cards, panels, headers, inputs */
-  --color-codex-bg-sunken: #f4f1ea; /* Sunken areas (footers, secondary chrome) */
-  --color-codex-bg-tint: #f3f0e7;   /* Active rows, chip backgrounds */
+  --color-codex-bg-sunken: #f1efe8; /* Sunken areas (footers, secondary chrome) */
+  --color-codex-bg-tint: #efede7;   /* Active rows, chip backgrounds */
 
   /* ---- Ink (text) ---- */
   --color-codex-ink: #1a1815;       /* Primary text */
@@ -200,6 +206,41 @@
   --color-codex-accent-soft: oklch(0.28 0.06 15);
   --color-codex-accent-ink: oklch(0.82 0.13 15);
   --color-codex-accent-bg: oklch(0.22 0.04 15);
+}
+
+/* ----------------------------------------------------------------
+   Warmth variants — let the user dial the page background between
+   pure white and warm parchment. ``parchment`` is the @theme default
+   (kept explicit here so the class is meaningful when applied). The
+   bg-sunken / bg-tint / line tokens shift together so any cards or
+   chips rendered against the new background still feel coherent.
+
+   Only the light theme is affected — the dark theme bg is already
+   nearly black and warmth doesn't read meaningfully against it.
+   ---------------------------------------------------------------- */
+.theme-codex.warmth-white {
+  --color-codex-bg: #ffffff;
+  --color-codex-bg-elev: #ffffff;
+  --color-codex-bg-sunken: #f4f4f4;
+  --color-codex-bg-tint: #f0f0f0;
+  --color-codex-line: oklch(0.9 0.001 0);
+  --color-codex-line-soft: oklch(0.94 0.001 0);
+  --color-codex-line-strong: oklch(0.82 0.001 0);
+}
+
+.theme-codex.warmth-paper {
+  --color-codex-bg: #fafaf7;
+  --color-codex-bg-elev: #ffffff;
+  --color-codex-bg-sunken: #efeeea;
+  --color-codex-bg-tint: #ededea;
+  /* Lines stay the same as default — they're already warmth-neutral. */
+}
+
+.theme-codex.warmth-parchment {
+  --color-codex-bg: #fcfbf7;
+  --color-codex-bg-elev: #ffffff;
+  --color-codex-bg-sunken: #f1efe8;
+  --color-codex-bg-tint: #efede7;
 }
 
 /* ----------------------------------------------------------------

--- a/web/src/utils/codexAppearance.test.ts
+++ b/web/src/utils/codexAppearance.test.ts
@@ -21,15 +21,21 @@ describe("normalizeAppearance", () => {
   it("falls back per-field for invalid values", () => {
     expect(
       normalizeAppearance({ theme: "neon", accent: "moss", density: "regular", radius: "soft" }),
-    ).toEqual({ theme: "light", accent: "moss", density: "regular", radius: "soft" });
+    ).toEqual({ theme: "light", accent: "moss", density: "regular", radius: "soft", warmth: "parchment" });
     expect(
       normalizeAppearance({ accent: "lime", density: "compact" }),
-    ).toEqual({ theme: "light", accent: "moss", density: "compact", radius: "soft" });
+    ).toEqual({ theme: "light", accent: "moss", density: "compact", radius: "soft", warmth: "parchment" });
   });
 
   it("preserves a fully valid payload unchanged", () => {
-    const value = { theme: "dark", accent: "azure", density: "comfy", radius: "round" } as const;
+    const value = { theme: "dark", accent: "azure", density: "comfy", radius: "round", warmth: "white" } as const;
     expect(normalizeAppearance(value)).toEqual(value);
+  });
+
+  it("falls back to the default warmth when missing or invalid", () => {
+    expect(
+      normalizeAppearance({ theme: "light", accent: "moss", density: "regular", radius: "soft", warmth: "neon" }),
+    ).toEqual({ theme: "light", accent: "moss", density: "regular", radius: "soft", warmth: "parchment" });
   });
 });
 
@@ -43,13 +49,14 @@ describe("readSavedAppearance / writeSavedAppearance", () => {
   });
 
   it("round-trips a written value", () => {
-    writeSavedAppearance({ theme: "dark", accent: "amber", density: "comfy", radius: "round" });
+    writeSavedAppearance({ theme: "dark", accent: "amber", density: "comfy", radius: "round", warmth: "paper" });
     expect(window.localStorage.getItem(CODEX_APPEARANCE_STORAGE_KEY)).toContain('"theme":"dark"');
     expect(readSavedAppearance()).toEqual({
       theme: "dark",
       accent: "amber",
       density: "comfy",
       radius: "round",
+      warmth: "paper",
     });
   });
 
@@ -128,6 +135,7 @@ describe("bootstrapCodexAppearance", () => {
       accent: "amber",
       density: "comfy",
       radius: "round",
+      warmth: "paper",
     });
     const result = bootstrapCodexAppearance();
     expect(result).toEqual({
@@ -135,9 +143,11 @@ describe("bootstrapCodexAppearance", () => {
       accent: "amber",
       density: "comfy",
       radius: "round",
+      warmth: "paper",
     });
     expect(document.documentElement.classList.contains("dark")).toBe(true);
     expect(document.documentElement.classList.contains("accent-amber")).toBe(true);
+    expect(document.documentElement.classList.contains("warmth-paper")).toBe(true);
   });
 
   it("applies the default when nothing has been saved", () => {

--- a/web/src/utils/codexAppearance.ts
+++ b/web/src/utils/codexAppearance.ts
@@ -26,12 +26,22 @@ export type CodexTheme = "light" | "dark" | "auto";
 export type CodexAccent = "moss" | "amber" | "azure" | "rose";
 export type CodexDensity = "compact" | "regular" | "comfy";
 export type CodexRadius = "sharp" | "soft" | "round";
+/**
+ * Page background warmth. The default ``parchment`` (#FCFBF7) reads as
+ * slightly yellow; users who find it too warm can dial it back to
+ * ``paper`` (cool off-white) or ``white`` (pure). Affects
+ * ``--color-codex-bg`` plus the matched bg-sunken / bg-tint values so
+ * the related surfaces shift together. Dark theme ignores this — the
+ * dark bg is already nearly black.
+ */
+export type CodexWarmth = "white" | "paper" | "parchment";
 
 export interface CodexAppearance {
   theme: CodexTheme;
   accent: CodexAccent;
   density: CodexDensity;
   radius: CodexRadius;
+  warmth: CodexWarmth;
 }
 
 export const CODEX_APPEARANCE_DEFAULT: CodexAppearance = {
@@ -39,12 +49,14 @@ export const CODEX_APPEARANCE_DEFAULT: CodexAppearance = {
   accent: "moss",
   density: "regular",
   radius: "soft",
+  warmth: "parchment",
 };
 
 const THEME_VALUES: readonly CodexTheme[] = ["light", "dark", "auto"];
 const ACCENT_VALUES: readonly CodexAccent[] = ["moss", "amber", "azure", "rose"];
 const DENSITY_VALUES: readonly CodexDensity[] = ["compact", "regular", "comfy"];
 const RADIUS_VALUES: readonly CodexRadius[] = ["sharp", "soft", "round"];
+const WARMTH_VALUES: readonly CodexWarmth[] = ["white", "paper", "parchment"];
 
 function isOneOf<T extends string>(value: unknown, allowed: readonly T[]): value is T {
   return typeof value === "string" && (allowed as readonly string[]).includes(value);
@@ -67,6 +79,9 @@ export function normalizeAppearance(input: unknown): CodexAppearance {
     radius: isOneOf(raw.radius, RADIUS_VALUES)
       ? raw.radius
       : CODEX_APPEARANCE_DEFAULT.radius,
+    warmth: isOneOf(raw.warmth, WARMTH_VALUES)
+      ? raw.warmth
+      : CODEX_APPEARANCE_DEFAULT.warmth,
   };
 }
 
@@ -106,7 +121,12 @@ export function resolveTheme(theme: CodexTheme): "light" | "dark" {
   }
 }
 
-const APPEARANCE_CLASS_PREFIXES = ["accent-", "density-", "radius-"] as const;
+const APPEARANCE_CLASS_PREFIXES = [
+  "accent-",
+  "density-",
+  "radius-",
+  "warmth-",
+] as const;
 
 /**
  * Toggle the appearance classes on ``<html>``:
@@ -140,6 +160,7 @@ export function applyAppearance(
   root.classList.add(`accent-${appearance.accent}`);
   root.classList.add(`density-${appearance.density}`);
   root.classList.add(`radius-${appearance.radius}`);
+  root.classList.add(`warmth-${appearance.warmth}`);
 }
 
 /**


### PR DESCRIPTION
## Summary

按你的两个反馈做了：
1. 你说外观设置里想能调"整个页面的背景色"，给我"白色 / 黄色 / 中间过渡"
2. 你又说"这个选中的颜色太黄了"——指的是 hover 时那块 bg-tint

两件事根因是同一个：parchment 调色太暖，hover 那块 bg-tint 在同样偏暖的 bg 旁边显出"黄斑"感。

### 1. 外观 → 页面背景 选项
新增 `CodexWarmth` 轴：`white` / `paper` / `parchment`，跟 theme / accent / density / radius 一样存 localStorage，应用为 `warmth-*` class 在 `<html>` 上。CSS 同时覆盖 bg / bg-elev / bg-sunken / bg-tint 让相关 surface 协同变化：
- **白** `warmth-white` — 纯白 + 中性灰 hover
- **中性** `warmth-paper` — 偏冷的米白
- **暖羊皮** `warmth-parchment` — 原来的暖羊皮（默认）

深色主题不受影响——本来就接近全黑，warmth 看不出来。

### 2. 默认 bg-tint 调冷一点
- bg-tint `#f3f0e7` → `#efede7`（R/B 差从 12 降到 8）
- bg-sunken `#f4f1ea` → `#f1efe8`

原来的 bg-tint 在 hover 上太突出（R-B 差 12 显黄），现在保留 parchment 的暖感但 hover 不再"发光"。`warmth-parchment` 用同一组新值；想更冷就切到 `warmth-paper` 或 `warmth-white`。

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 514 passed（多了 1 个 warmth fallback 测试）
- [x] `npx vite build` clean
- [ ] 部署后 visual smoke：登录 → 设置 → 外观，看到 **页面背景** 这一行有 3 个色卡（纯白 / 中性 / 暖羊皮），点切换，整个 app 背景立即换色，hover 那块也不再发黄。

🤖 Generated with [Claude Code](https://claude.com/claude-code)