### PR TITLE
Settings shell: match the prototype (inline sidebar + grouped nav)

### DIFF
--- a/web/src/pages/settings/SettingsLayout.test.tsx
+++ b/web/src/pages/settings/SettingsLayout.test.tsx
@@ -1,11 +1,13 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { SettingsLayout } from './SettingsLayout'
 
 vi.mock('react-router-dom', () => ({
-  NavLink: ({ children, to }: { children: any; to: string }) => {
-    const childContent = typeof children === 'function' ? children({ isActive: false }) : children
-    return <a href={to}>{childContent}</a>
+  NavLink: ({ children, to, style }: { children: any; to: string; style?: any }) => {
+    const props = { isActive: false }
+    const childContent = typeof children === 'function' ? children(props) : children
+    const resolvedStyle = typeof style === 'function' ? style(props) : style
+    return <a href={to} style={resolvedStyle}>{childContent}</a>
   },
   Outlet: () => <div data-testid="outlet">Outlet Content</div>,
 }))
@@ -22,18 +24,18 @@ describe('SettingsLayout', () => {
 
   it('renders navigation items', () => {
     render(<SettingsLayout />)
-    expect(screen.getByText('settings.profile')).toBeInTheDocument()
-    expect(screen.getByText('settings.aiModel')).toBeInTheDocument()
-    expect(screen.getByText('项目记忆')).toBeInTheDocument()
+    // Desktop sidebar + mobile/tablet pill row both render the items,
+    // so use getAllByText. As long as at least one match per item is
+    // there, the routes are wired.
+    expect(screen.getAllByText('settings.profile').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('settings.aiModel').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('项目记忆').length).toBeGreaterThan(0)
   })
 
-  it('toggles nav collapse and persists to localStorage', () => {
-    localStorage.clear()
+  it('groups items under the three section labels', () => {
     render(<SettingsLayout />)
-    const toggleBtn = screen.getByRole('button')
-    fireEvent.click(toggleBtn)
-    expect(localStorage.getItem('aria-settings-nav-collapsed')).toBe('true')
-    fireEvent.click(toggleBtn)
-    expect(localStorage.getItem('aria-settings-nav-collapsed')).toBe('false')
+    expect(screen.getByText('个人')).toBeInTheDocument()
+    expect(screen.getByText('AI 与记忆')).toBeInTheDocument()
+    expect(screen.getByText('管理员')).toBeInTheDocument()
   })
 })

--- a/web/src/pages/settings/SettingsLayout.tsx
+++ b/web/src/pages/settings/SettingsLayout.tsx
@@ -1,248 +1,189 @@
-import { useState } from 'react'
+/**
+ * Settings shell — Codex layout per
+ * ``design_handoff_aria_codex_redesign/direction-codex-settings.jsx:20``.
+ *
+ * Visible differences vs. the previous V0.0.5 / early-Codex shell:
+ * - Sidebar is **inline** with a hairline right border, not a separate
+ *   bg-elev card panel.
+ * - Nav items are grouped under three section labels (个人 / AI 与
+ *   记忆 / 管理员) with mono uppercase headers, instead of a single
+ *   flat list.
+ * - No icons in the nav, no collapse button, no global "设置" page
+ *   header in the top bar — each inner page brings its own ``<h1>``.
+ *
+ * Active state is the same quiet bg-tint + ink + 500 weight + 2px
+ * accent stripe on the left that's used across the top nav and the
+ * design's sidebar mock.
+ */
 import { NavLink, Outlet } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import {
-  Bell,
-  Brain,
-  ChevronLeft,
-  ChevronRight,
-  Database,
-  Gauge,
-  GitBranch,
-  Globe,
-  Info,
-  ListChecks,
-  Palette,
-  Server,
-  User,
-  Users,
-} from 'lucide-react'
 import { PageTitle } from '../../components/PageTitle'
 
-const SETTINGS_NAV_COLLAPSED_KEY = 'aria-settings-nav-collapsed'
+type SettingsGroupKey = 'personal' | 'ai' | 'admin'
+
+interface SettingsNavItem {
+  path: string
+  label: string
+  group: SettingsGroupKey
+}
 
 export function SettingsLayout() {
   const { i18n, t } = useTranslation()
   const isZh = i18n.language.startsWith('zh')
-  const [navCollapsed, setNavCollapsed] = useState(() => {
-    if (typeof window === 'undefined') return false
-    return window.localStorage.getItem(SETTINGS_NAV_COLLAPSED_KEY) === 'true'
-  })
 
-  const settingNavItems = [
-    { path: '', icon: User, label: t('settings.profile') },
-    { path: 'appearance', icon: Palette, label: t('settings.appearance') },
-    { path: 'ai', icon: Brain, label: t('settings.aiModel') },
-    { path: 'memory', icon: Database, label: isZh ? '项目记忆' : 'Project Memory' },
-    { path: 'client-memory', icon: Users, label: isZh ? '客户记忆' : 'Client Memory' },
-    { path: 'memory-ops', icon: ListChecks, label: isZh ? '记忆任务中心' : 'Memory Operations' },
-    { path: 'api-limits', icon: Gauge, label: isZh ? 'API 限流' : 'API Limits' },
-    { path: 'migrations', icon: GitBranch, label: isZh ? '迁移状态' : 'Migrations' },
-    { path: 'messages', icon: Bell, label: isZh ? '消息管理' : 'Message Manager' },
-    { path: 'server', icon: Server, label: t('settings.server.title') },
-    { path: 'language', icon: Globe, label: t('settings.language') },
-    { path: 'users', icon: Users, label: t('settings.users') },
-    { path: 'about', icon: Info, label: t('settings.about') },
+  const groupLabels: Record<SettingsGroupKey, string> = {
+    personal: isZh ? '个人' : 'Personal',
+    ai: isZh ? 'AI 与记忆' : 'AI & Memory',
+    admin: isZh ? '管理员' : 'Admin',
+  }
+
+  const settingNavItems: SettingsNavItem[] = [
+    { path: '', label: t('settings.profile'), group: 'personal' },
+    { path: 'appearance', label: t('settings.appearance'), group: 'personal' },
+    { path: 'language', label: t('settings.language'), group: 'personal' },
+    { path: 'about', label: t('settings.about'), group: 'personal' },
+    { path: 'ai', label: t('settings.aiModel'), group: 'ai' },
+    { path: 'memory', label: isZh ? '项目记忆' : 'Project Memory', group: 'ai' },
+    { path: 'client-memory', label: isZh ? '客户记忆' : 'Client Memory', group: 'ai' },
+    { path: 'memory-ops', label: isZh ? '记忆任务中心' : 'Memory Operations', group: 'ai' },
+    { path: 'api-limits', label: isZh ? 'API 限流' : 'API Limits', group: 'admin' },
+    { path: 'migrations', label: isZh ? '迁移状态' : 'Migrations', group: 'admin' },
+    { path: 'messages', label: isZh ? '消息管理' : 'Message Manager', group: 'admin' },
+    { path: 'server', label: t('settings.server.title'), group: 'admin' },
+    { path: 'users', label: t('settings.users'), group: 'admin' },
   ]
 
-  const toggleNavCollapsed = () => {
-    setNavCollapsed((current) => {
-      const next = !current
-      window.localStorage.setItem(SETTINGS_NAV_COLLAPSED_KEY, String(next))
-      return next
-    })
-  }
+  const orderedGroups: SettingsGroupKey[] = ['personal', 'ai', 'admin']
+  const itemsByGroup = orderedGroups.map((group) => ({
+    group,
+    label: groupLabels[group],
+    items: settingNavItems.filter((item) => item.group === group),
+  }))
 
   return (
     <>
       <PageTitle title={t('settings.title')} />
       <div
-        className="settings-ui theme-codex min-h-full"
+        className="settings-ui theme-codex flex min-h-full"
         style={{
           background: 'var(--color-codex-bg)',
           color: 'var(--color-codex-ink)',
         }}
       >
-        <div className="w-full px-4 py-5 sm:px-6 lg:px-8">
-          <div
-            className="mb-5 flex flex-col gap-2 pb-4 sm:flex-row sm:items-center sm:justify-between"
-            style={{ borderBottom: '1px solid var(--color-codex-line)' }}
+        {/* Sidebar — 240px fixed on desktop, full-width stacked on mobile.
+            Right hairline border replaces the previous bg-elev card. */}
+        <aside
+          className="hidden flex-shrink-0 lg:block"
+          style={{
+            width: 240,
+            padding: '24px 16px 24px 40px',
+            borderRight: '1px solid var(--color-codex-line)',
+          }}
+        >
+          <h2
+            style={{
+              margin: '0 0 18px',
+              fontSize: 18,
+              fontWeight: 500,
+              color: 'var(--color-codex-ink)',
+              letterSpacing: '-0.015em',
+            }}
           >
-            <div className="min-w-0">
-              <h1
+            {t('settings.title')}
+          </h2>
+          {itemsByGroup.map(({ group, label, items }) => (
+            <div key={group} style={{ marginBottom: 16 }}>
+              <div
+                className="font-mono"
                 style={{
-                  margin: 0,
-                  fontSize: 22,
-                  fontWeight: 500,
-                  color: 'var(--color-codex-ink)',
-                  letterSpacing: '-0.015em',
-                }}
-              >
-                {t('settings.title')}
-              </h1>
-              <p
-                className="mt-1 hidden max-w-3xl truncate lg:block"
-                style={{
-                  margin: '6px 0 0',
-                  fontSize: 13,
-                  color: 'var(--color-codex-ink-mute)',
-                  lineHeight: 1.6,
-                }}
-              >
-                {t('settings.description')}
-              </p>
-            </div>
-            <div className="flex items-center gap-2">
-              <span
-                className="font-mono hidden w-fit items-center sm:inline-flex"
-                style={{
-                  padding: '2px 8px',
+                  padding: '4px 10px 6px',
                   fontSize: 10.5,
-                  background: 'var(--color-codex-bg-tint)',
-                  color: 'var(--color-codex-ink-soft)',
-                  borderRadius: 'var(--codex-r-pill, 999px)',
+                  color: 'var(--color-codex-ink-faint)',
                   letterSpacing: '0.06em',
                   textTransform: 'uppercase',
                 }}
               >
-                {isZh ? '系统配置' : 'System settings'}
-              </span>
-              <span
-                className="lg:hidden"
-                style={{ fontSize: 11.5, color: 'var(--color-codex-ink-mute)' }}
-              >
-                {t('settings.description')}
-              </span>
-            </div>
-          </div>
-
-          <div className="flex w-full flex-col gap-5 lg:flex-row lg:items-start">
-            <aside
-              className={`w-full flex-shrink-0 transition-[width] duration-200 lg:sticky lg:top-6 ${
-                navCollapsed ? 'lg:w-[72px]' : 'lg:w-64'
-              }`}
-            >
-              <nav
-                style={{
-                  padding: 8,
-                  background: 'var(--color-codex-bg-elev)',
-                  border: '1px solid var(--color-codex-line)',
-                  borderRadius: 'var(--codex-r-md, 6px)',
-                }}
-              >
-                <div
-                  className={`mb-2 hidden items-center gap-2 p-2 lg:flex ${
-                    navCollapsed ? 'justify-center' : 'justify-between'
-                  }`}
-                  style={{
-                    background: 'var(--color-codex-bg-tint)',
+                {label}
+              </div>
+              {items.map((item) => (
+                <NavLink
+                  key={item.path}
+                  to={item.path}
+                  end={item.path === ''}
+                  className={({ isActive }) =>
+                    `row-hov relative block ${isActive ? 'cx-setting-nav-active' : 'cx-setting-nav'}`
+                  }
+                  style={({ isActive }) => ({
+                    padding: '7px 10px',
+                    marginBottom: 1,
+                    fontSize: 13,
+                    fontWeight: isActive ? 500 : 400,
+                    color: isActive ? 'var(--color-codex-ink)' : 'var(--color-codex-ink-soft)',
+                    background: isActive ? 'var(--color-codex-bg-tint)' : 'transparent',
                     borderRadius: 'var(--codex-r-sm, 3px)',
-                  }}
+                  })}
                 >
-                  <div className={`min-w-0 ${navCollapsed ? 'hidden' : ''}`}>
-                    <div
-                      className="font-mono"
-                      style={{
-                        fontSize: 10.5,
-                        fontWeight: 600,
-                        color: 'var(--color-codex-ink-soft)',
-                        letterSpacing: '0.06em',
-                        textTransform: 'uppercase',
-                      }}
-                    >
-                      {isZh ? '设置导航' : 'Settings nav'}
-                    </div>
-                    <div
-                      className="truncate"
-                      style={{
-                        marginTop: 2,
-                        fontSize: 11,
-                        color: 'var(--color-codex-ink-mute)',
-                      }}
-                    >
-                      {isZh ? '可随时收起左栏' : 'Collapse when you need space'}
-                    </div>
-                  </div>
-                  <button
-                    type="button"
-                    onClick={toggleNavCollapsed}
-                    className="grid h-7 w-7 flex-shrink-0 place-items-center transition-colors"
-                    style={{
-                      background: 'var(--color-codex-bg-elev)',
-                      color: 'var(--color-codex-ink-soft)',
-                      border: '1px solid var(--color-codex-line)',
-                      borderRadius: 'var(--codex-r-sm, 3px)',
-                    }}
-                    aria-label={navCollapsed ? (isZh ? '展开设置菜单' : 'Expand settings menu') : isZh ? '收起设置菜单' : 'Collapse settings menu'}
-                  >
-                    {navCollapsed ? <ChevronRight className="h-3.5 w-3.5" /> : <ChevronLeft className="h-3.5 w-3.5" />}
-                  </button>
-                </div>
-
-                <div className="flex gap-1 overflow-x-auto lg:block lg:space-y-0.5 lg:overflow-visible">
-                  {settingNavItems.map((item) => (
-                    <NavLink
-                      key={item.path}
-                      to={item.path}
-                      end={item.path === ''}
-                      title={navCollapsed ? item.label : undefined}
-                      className={({ isActive }) =>
-                        `row-hov relative flex shrink-0 items-center gap-3 lg:w-full ${
-                          navCollapsed ? 'lg:justify-center' : ''
-                        } ${isActive ? 'cx-setting-nav-active' : 'cx-setting-nav'}`
-                      }
-                      style={({ isActive }) => ({
-                        padding: navCollapsed ? '7px 8px' : '7px 10px',
-                        fontSize: 13,
-                        fontWeight: isActive ? 500 : 400,
-                        background: isActive
-                          ? 'var(--color-codex-bg-tint)'
-                          : 'transparent',
-                        color: isActive
-                          ? 'var(--color-codex-ink)'
-                          : 'var(--color-codex-ink-soft)',
-                        borderRadius: 'var(--codex-r-sm, 3px)',
-                      })}
-                    >
-                      {({ isActive }) => (
-                        <>
-                          {/* 2px accent stripe down the left edge for active
-                              item (see ``direction-codex-part2.jsx:259``). */}
-                          {isActive && (
-                            <span
-                              aria-hidden="true"
-                              style={{
-                                position: 'absolute',
-                                left: 0,
-                                top: 8,
-                                bottom: 8,
-                                width: 2,
-                                background: 'var(--color-codex-accent)',
-                                borderRadius: 999,
-                              }}
-                            />
-                          )}
-                          <item.icon
-                            className="h-3.5 w-3.5 flex-shrink-0"
-                            style={{
-                              color: isActive
-                                ? 'var(--color-codex-ink)'
-                                : 'var(--color-codex-ink-faint)',
-                            }}
-                          />
-                          <span className={`${navCollapsed ? 'lg:hidden' : ''}`}>{item.label}</span>
-                        </>
-                      )}
-                    </NavLink>
-                  ))}
-                </div>
-              </nav>
-            </aside>
-
-            <div className="min-w-0 flex-1 overflow-hidden" style={{ padding: '8px 16px' }}>
-              <Outlet />
+                  {({ isActive }) =>
+                    isActive ? (
+                      <>
+                        <span
+                          aria-hidden="true"
+                          style={{
+                            position: 'absolute',
+                            left: 0,
+                            top: 8,
+                            bottom: 8,
+                            width: 2,
+                            background: 'var(--color-codex-accent)',
+                            borderRadius: 999,
+                          }}
+                        />
+                        {item.label}
+                      </>
+                    ) : (
+                      <>{item.label}</>
+                    )
+                  }
+                </NavLink>
+              ))}
             </div>
-          </div>
+          ))}
+        </aside>
+
+        {/* Mobile/tablet nav — horizontal pill row above the content slot.
+            Same color tokens, no group labels (would crowd the row). */}
+        <nav
+          className="flex gap-1 overflow-x-auto px-4 py-3 lg:hidden"
+          style={{ borderBottom: '1px solid var(--color-codex-line)' }}
+        >
+          {settingNavItems.map((item) => (
+            <NavLink
+              key={item.path}
+              to={item.path}
+              end={item.path === ''}
+              className="row-hov flex-shrink-0"
+              style={({ isActive }) => ({
+                padding: '6px 12px',
+                fontSize: 13,
+                fontWeight: isActive ? 500 : 400,
+                color: isActive ? 'var(--color-codex-ink)' : 'var(--color-codex-ink-soft)',
+                background: isActive ? 'var(--color-codex-bg-tint)' : 'transparent',
+                borderRadius: 'var(--codex-r-sm, 3px)',
+                whiteSpace: 'nowrap',
+              })}
+            >
+              {item.label}
+            </NavLink>
+          ))}
+        </nav>
+
+        {/* Right column. Each settings page brings its own ``<h1>``,
+            so the shell just provides the padding scaffold. */}
+        <div
+          className="min-w-0 flex-1 overflow-hidden"
+          style={{ padding: '32px 48px 40px' }}
+        >
+          <Outlet />
         </div>
       </div>
     </>


### PR DESCRIPTION
## Summary

按你说的"设置导航也没有按照新 UI 来"，回去对照 `design_handoff_aria_codex_redesign/direction-codex-settings.jsx:20`，发现之前的 Settings shell 漏了几样东西：

### 改动
1. **侧边栏改成 inline + 右细线**，不再用 bg-elev 卡片包起来——原型就是 `borderRight: 1px solid var(--line)` 直接贴在页面 bg 上
2. **三组分类**，每组上面一行 mono uppercase 小标签：
   - **个人**：个人资料 / 外观 / 语言 / 关于
   - **AI 与记忆**：AI 模型 / 项目记忆 / 客户记忆 / 记忆任务中心
   - **管理员**：API 限流 / 迁移状态 / 消息管理 / 服务器配置 / 用户管理
3. **去掉了图标、折叠按钮、顶部"设置"全局标题**——原型里这些都没有，每个 settings 子页面本来就带自己的 `<h1>`
4. 侧栏顶部只留一个安静的 **`设置` h2**（18px / 500 / -0.015em）
5. 右栏 padding 改成 **`32px 48px 40px`**（按原型）

移动端 / 平板保留横向滑动的 pill 行，调色用同一套 bg-tint active / ink-soft idle。

### Tests
- 去掉了 collapse-toggle 测试（没了折叠按钮）
- 加了分组标签断言（个人 / AI 与记忆 / 管理员）
- 换成 `getAllByText` 因为每个 item 现在桌面 + 移动各出现一次

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 514 passed
- [x] `npx vite build` clean
- [ ] 部署后 visual smoke：/settings 应该看到左边是清爽的 inline 侧栏，三组导航，active 项 bg-tint + 左边 2px accent 竖条；右栏每个子页面有自己的 h1。

🤖 Generated with [Claude Code](https://claude.com/claude-code)