### PR TITLE
Loading skeletons: Workspace + Skills per the prototype's CxLoading

### DIFF
--- a/web/src/components/codex/CxTopProgress.tsx
+++ b/web/src/components/codex/CxTopProgress.tsx
@@ -1,0 +1,52 @@
+/**
+ * Codex top-of-page progress bar — 2px accent slider that animates
+ * across a bg-tint track. Drop it at the very top of a page that's
+ * waiting for data to give the impression of "something's happening"
+ * without committing to a spinner.
+ *
+ * Port of the prototype's top progress bar in
+ * ``design_handoff_aria_codex_redesign/direction-codex-states.jsx:26``.
+ *
+ * Uses the ``codex-progress`` keyframe registered in
+ * ``web/src/styles/codex.css``.
+ */
+import type { CSSProperties } from "react";
+
+interface CxTopProgressProps {
+  height?: number;
+  /** Width of the moving accent slider as a percentage. */
+  sliderWidth?: string;
+  className?: string;
+  style?: CSSProperties;
+}
+
+export function CxTopProgress({
+  height = 2,
+  sliderWidth = "40%",
+  className,
+  style,
+}: CxTopProgressProps) {
+  return (
+    <div
+      role="progressbar"
+      aria-busy="true"
+      aria-label="Loading"
+      className={["overflow-hidden", className ?? ""].join(" ").trim()}
+      style={{
+        height,
+        background: "var(--color-codex-bg-tint)",
+        flexShrink: 0,
+        ...style,
+      }}
+    >
+      <div
+        style={{
+          height: "100%",
+          width: sliderWidth,
+          background: "var(--color-codex-accent)",
+          animation: "codex-progress 1.8s ease-in-out infinite",
+        }}
+      />
+    </div>
+  );
+}

--- a/web/src/components/codex/index.ts
+++ b/web/src/components/codex/index.ts
@@ -15,3 +15,4 @@ export { CxPanel } from "./CxPanel";
 export { CxFormRow } from "./CxFormRow";
 export { CxSwitch } from "./CxSwitch";
 export { CxSkeleton } from "./CxSkeleton";
+export { CxTopProgress } from "./CxTopProgress";

--- a/web/src/pages/Workspace.tsx
+++ b/web/src/pages/Workspace.tsx
@@ -20,7 +20,6 @@ import {
   ArrowRight,
   Calendar,
   FileText,
-  Loader2,
   MessageSquare,
   RefreshCw,
   Sparkles,
@@ -29,7 +28,7 @@ import {
 import type { AxiosError } from "axios";
 
 import { api } from "../api/client";
-import { CxLogo, CxStatus, type CxStatusTone } from "../components/codex";
+import { CxLogo, CxSkeleton, CxStatus, CxTopProgress, type CxStatusTone } from "../components/codex";
 import { PageTitle } from "../components/PageTitle";
 import { parseAppDateTime } from "../utils/timezone";
 import type {
@@ -351,15 +350,7 @@ export function Workspace() {
     return (
       <>
         <PageTitle title={isZh ? "今日工作台" : "Workspace"} />
-        <div
-          className="theme-codex flex h-full items-center justify-center"
-          style={{
-            background: "var(--color-codex-bg)",
-            color: "var(--color-codex-ink-mute)",
-          }}
-        >
-          <Loader2 className="h-5 w-5 animate-spin" />
-        </div>
+        <WorkspaceSkeleton />
       </>
     );
   }
@@ -1011,6 +1002,142 @@ export function Workspace() {
 }
 
 // ----------------------------------------------------------------------------
+
+/**
+ * Workspace skeleton — structured placeholder that mirrors the real
+ * Workspace layout per the design's CxLoading in
+ * ``design_handoff_aria_codex_redesign/direction-codex-states.jsx:23``.
+ *
+ * Shows greeting block + Skill cards row + projects table on the left,
+ * todos + recent chats on the right, plus a 2px accent slider at the
+ * very top so the page reads as "fetching" not "broken".
+ */
+function WorkspaceSkeleton() {
+  return (
+    <div
+      className="theme-codex flex h-full flex-col overflow-hidden"
+      style={{ background: "var(--color-codex-bg)", color: "var(--color-codex-ink)" }}
+    >
+      <CxTopProgress />
+      <div
+        className="grid min-w-0 flex-1 overflow-hidden"
+        style={{
+          padding: "36px 36px 40px",
+          gap: 48,
+          gridTemplateColumns: "minmax(0,1fr) 300px",
+        }}
+      >
+        {/* Left column */}
+        <div className="flex flex-col" style={{ gap: 40, minWidth: 0 }}>
+          {/* Greeting */}
+          <div>
+            <CxSkeleton w={140} h={11} style={{ marginBottom: 12 }} />
+            <CxSkeleton w={320} h={28} />
+            <div style={{ marginTop: 14, display: "flex", flexDirection: "column", gap: 6 }}>
+              <CxSkeleton w="80%" h={14} />
+              <CxSkeleton w="55%" h={14} />
+            </div>
+          </div>
+
+          {/* Skill cards */}
+          <section>
+            <div style={{ marginBottom: 14 }}>
+              <CxSkeleton w={100} h={13} />
+            </div>
+            <div
+              className="grid"
+              style={{ gridTemplateColumns: "1fr 1fr 1fr", gap: 14 }}
+            >
+              {[0, 1, 2].map((i) => (
+                <div
+                  key={i}
+                  className="flex flex-col"
+                  style={{
+                    padding: 18,
+                    gap: 10,
+                    minHeight: 140,
+                    background: "var(--color-codex-bg-elev)",
+                    border: "1px solid var(--color-codex-line)",
+                    borderRadius: "var(--codex-r-md, 6px)",
+                  }}
+                >
+                  <CxSkeleton w={30} h={30} radius="var(--codex-r-sm, 3px)" />
+                  <CxSkeleton w="70%" h={16} />
+                  <CxSkeleton w="90%" h={12} />
+                  <CxSkeleton w="50%" h={11} style={{ marginTop: "auto" }} />
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {/* Projects table */}
+          <section>
+            <div style={{ marginBottom: 12 }}>
+              <CxSkeleton w={120} h={13} />
+            </div>
+            {[0, 1, 2, 3].map((i) => (
+              <div
+                key={i}
+                className="grid items-center"
+                style={{
+                  gridTemplateColumns: "1fr 110px 100px 110px 14px",
+                  padding: "13px 4px",
+                  gap: 14,
+                  borderBottom: "1px solid var(--color-codex-line-soft)",
+                }}
+              >
+                <div>
+                  <CxSkeleton w="60%" h={14} />
+                  <div style={{ marginTop: 5 }}>
+                    <CxSkeleton w="40%" h={11} />
+                  </div>
+                </div>
+                <CxSkeleton w={70} h={14} radius={999} />
+                <CxSkeleton w={50} h={13} />
+                <CxSkeleton w={80} h={13} radius={999} />
+                <CxSkeleton w={10} h={10} />
+              </div>
+            ))}
+          </section>
+        </div>
+
+        {/* Right rail */}
+        <aside
+          className="flex flex-col"
+          style={{
+            gap: 28,
+            minWidth: 0,
+            borderLeft: "1px solid var(--color-codex-line)",
+            paddingLeft: 36,
+          }}
+        >
+          {[0, 1].map((s) => (
+            <div key={s}>
+              <div style={{ marginBottom: 12 }}>
+                <CxSkeleton w={90} h={13} />
+              </div>
+              {[0, 1, 2, 3].map((i) => (
+                <div
+                  key={i}
+                  className="flex items-start"
+                  style={{ gap: 10, padding: "8px 0" }}
+                >
+                  <CxSkeleton w={14} h={14} radius={3} style={{ flexShrink: 0 }} />
+                  <div style={{ flex: 1 }}>
+                    <CxSkeleton w="85%" h={13} />
+                    <div style={{ marginTop: 5 }}>
+                      <CxSkeleton w="50%" h={11} />
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          ))}
+        </aside>
+      </div>
+    </div>
+  );
+}
 
 function SectionHeader({
   title,

--- a/web/src/pages/skills/Skills.test.tsx
+++ b/web/src/pages/skills/Skills.test.tsx
@@ -45,7 +45,11 @@ describe('SkillCategoryPage', () => {
         </Routes>
       </MemoryRouter>
     )
-    expect(document.querySelector('.animate-pulse')).toBeInTheDocument()
+    // SkillsLoading now renders a structured skeleton (CxSkeleton +
+    // CxTopProgress) per the design's CxLoading pattern. At least one
+    // ``cx-skeleton`` block being present is enough to assert the
+    // loading shell rendered.
+    expect(document.querySelectorAll('[data-testid="cx-skeleton"]').length).toBeGreaterThan(0)
   })
 
   it('renders skills after loading', async () => {

--- a/web/src/pages/skills/Skills.tsx
+++ b/web/src/pages/skills/Skills.tsx
@@ -30,6 +30,7 @@ import {
 } from "lucide-react";
 
 import { api } from "../../api/client";
+import { CxSkeleton, CxTopProgress } from "../../components/codex";
 import { PageTitle } from "../../components/PageTitle";
 import type { Skill, SkillSummary } from "../../types/api";
 
@@ -1729,12 +1730,115 @@ export function SkillDetailPage() {
   );
 }
 
+/**
+ * Skills 库 skeleton — mirrors the real page layout (220px sidebar +
+ * grouped list) per the design's CxLoading approach in
+ * ``design_handoff_aria_codex_redesign/direction-codex-states.jsx:23``.
+ *
+ * Top progress bar gives a "fetching" cue without committing to a
+ * spinner that hides the fact that the page is structured.
+ */
 function SkillsLoading({ title }: { title: string }) {
   return (
     <>
       <PageTitle title={title} />
-      <div className="flex min-h-full items-center justify-center bg-slate-50">
-        <Zap className="h-8 w-8 animate-pulse text-primary" />
+      <div
+        className="theme-codex flex h-full flex-col"
+        style={{
+          background: "var(--color-codex-bg)",
+          color: "var(--color-codex-ink)",
+        }}
+      >
+        <CxTopProgress />
+        <div className="flex flex-1 overflow-hidden">
+          {/* Sidebar skeleton — matches the 220px panel with categories
+              and stats from the real page. */}
+          <aside
+            className="hidden flex-shrink-0 lg:block"
+            style={{
+              width: 220,
+              padding: "28px 18px 28px 40px",
+              borderRight: "1px solid var(--color-codex-line)",
+            }}
+          >
+            <div style={{ marginBottom: 10 }}>
+              <CxSkeleton w={48} h={11} />
+            </div>
+            {[0, 1, 2, 3, 4, 5].map((i) => (
+              <div
+                key={i}
+                className="flex items-center justify-between"
+                style={{ padding: "7px 10px", marginBottom: 1 }}
+              >
+                <CxSkeleton w="55%" h={12} />
+                <CxSkeleton w={18} h={11} />
+              </div>
+            ))}
+            <div style={{ margin: "26px 0 8px" }}>
+              <CxSkeleton w={48} h={11} />
+            </div>
+            <div style={{ padding: "4px 10px" }}>
+              {[0, 1].map((i) => (
+                <div
+                  key={i}
+                  className="flex items-center justify-between"
+                  style={{ padding: "6px 0" }}
+                >
+                  <CxSkeleton w="40%" h={11} />
+                  <CxSkeleton w={24} h={11} />
+                </div>
+              ))}
+            </div>
+          </aside>
+
+          {/* Main column skeleton — heading + 2 grouped sections of
+              skill rows. */}
+          <div className="min-w-0 flex-1 overflow-auto" style={{ padding: "32px 56px 40px" }}>
+            <div style={{ marginBottom: 28 }}>
+              <CxSkeleton w={160} h={28} />
+              <div style={{ marginTop: 12, display: "flex", flexDirection: "column", gap: 6 }}>
+                <CxSkeleton w="60%" h={14} />
+                <CxSkeleton w="40%" h={14} />
+              </div>
+            </div>
+            {[0, 1].map((group) => (
+              <section key={group} style={{ marginBottom: 28 }}>
+                <div
+                  className="flex items-baseline justify-between"
+                  style={{ marginBottom: 14 }}
+                >
+                  <CxSkeleton w={80} h={13} />
+                  <CxSkeleton w={48} h={11} />
+                </div>
+                {[0, 1, 2].map((i, _, arr) => (
+                  <div
+                    key={i}
+                    className="grid items-center"
+                    style={{
+                      gridTemplateColumns: "1fr 90px 80px 14px",
+                      columnGap: 16,
+                      padding: "14px 8px",
+                      borderBottom:
+                        i === arr.length - 1
+                          ? "none"
+                          : "1px solid var(--color-codex-line-soft)",
+                    }}
+                  >
+                    <div>
+                      <CxSkeleton w="50%" h={15} />
+                      <div style={{ marginTop: 5 }}>
+                        <CxSkeleton w="80%" h={12} />
+                      </div>
+                    </div>
+                    <CxSkeleton w={70} h={14} radius={999} />
+                    <CxSkeleton w={50} h={12} />
+                    <CxSkeleton w={10} h={10} />
+                  </div>
+                ))}
+              </section>
+            ))}
+          </div>
+        </div>
       </div>
     </>
   );


### PR DESCRIPTION
## Summary

按 `design_handoff_aria_codex_redesign/direction-codex-states.jsx` 里的 `CxLoading` 模式，把 Workspace 和 Skills 库的 loading 状态从"页面中间一颗 spinner"换成结构化骨架屏。

### 新加的 primitive：`CxTopProgress`
- 2px 高的 bg-tint 轨道 + 40% 宽的 accent 滑块来回跑（用已有的 `codex-progress` keyframe）
- 放在任何 loading 页顶部，表达"在拉数据"

### WorkspaceSkeleton
- 镜像真实 Workspace 的两栏布局
- 左栏：问候块（小 meta + 28px 标题 + 两行段落）/ 3 列 quick skill 卡片骨架（含真实的 bg-elev 外壳）/ 4 行项目表骨架（5 列 grid 跟真实表一致）
- 右栏：两组 checkbox+内容行（今日待办 + 即将里程碑的骨架样子）

### SkillsLoading 重写
- 220px 侧栏：分类列表骨架（item + 数字 pill）+ 统计块骨架
- 主栏：28px 标题骨架 + 两组分组 section（每组 3 行 4 列 grid）
- 直接替换原来居中的 Zap pulse

### Tests
- `Skills.test.tsx` 之前查 `.animate-pulse`（旧 Zap 图标），改成查 `[data-testid="cx-skeleton"]` 至少出现一个 —— 514 vitest pass

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 514 passed
- [x] `npx vite build` clean
- [ ] 部署后 visual smoke：刷新 `/workspace`，加载瞬间看到 2px accent 进度条 + 结构化骨架（左侧问候/卡片/表，右侧 todos）；同样测 `/skills`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)