### PR TITLE
Chat markdown tables: fix bright white slab in dark mode

### DIFF
--- a/web/src/styles/codex.css
+++ b/web/src/styles/codex.css
@@ -587,12 +587,24 @@
 .theme-codex .md-root .md-table-head {
   background: var(--color-codex-bg-tint);
 }
+.theme-codex .md-root .md-table-body {
+  /* Both rule sets in index.css give ``.md-table-body`` a hardcoded
+     MD3 light background (``--color-surface-container-lowest`` /
+     ``-low``) that doesn't track Codex dark mode — those values stay
+     near-white and produce the bright cream slab visible in dark
+     screenshots of chat tables. Reset to ``bg-elev`` so the table
+     surface adapts to light / dark / warmth. */
+  background: var(--color-codex-bg-elev);
+}
 .theme-codex .md-root .md-table-header {
   color: var(--color-codex-ink);
   border-bottom-color: var(--color-codex-line);
 }
 .theme-codex .md-root .md-table-cell {
   color: var(--color-codex-ink-soft);
+  border-bottom-color: var(--color-codex-line-soft);
+}
+.theme-codex .md-root .md-table-row {
   border-bottom-color: var(--color-codex-line-soft);
 }
 .theme-codex .md-root .md-table-row:hover {


### PR DESCRIPTION
## Summary

你截图里那个对话回复带了一张 27 项目的清单表，暗黑模式下每一行都是亮白条挤在深色页面上。根因：`index.css` 里 `.md-table-*` 规则**写了两遍**（547-596 行和 723-769 行），第二份硬编码了：

```css
.md-root .md-table-body { background-color: var(--color-surface-container-lowest); }
```

这是 MD3 浅色 token，不跟 `theme-codex.dark`。我上次 PR #57 加的 codex override 只覆盖了 head 和 cell 文本，漏了 body 和行分割线，所以表格体一直保留 MD3 浅色背景。

补两条 override：
- `.md-table-body` → `--color-codex-bg-elev`，表格表面跟 light / dark / warmth 走
- `.md-table-row` 下边框 → `--color-codex-line-soft`，行分割线在暗黑下也看得见，不会糊成一片

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 514 passed
- [x] `npx vite build` clean
- [ ] 部署后 visual smoke：暗黑模式下进 `/chat?conversation=257`，那张项目清单表格 body 应该是 bg-elev（不再是亮白），行分割线是 codex line-soft，hover 行是 bg-tint。

🤖 Generated with [Claude Code](https://claude.com/claude-code)