### PR TITLE
Route fallback: Codex shell instead of MD3 bg-surface + blue spinner

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,6 @@
 import { Suspense, lazy } from 'react'
 import { Routes, Route, Navigate } from 'react-router-dom'
-import { Loader2 } from 'lucide-react'
+import { CxTopProgress } from './components/codex'
 import { AuthProvider, useAuth } from './contexts/AuthContext'
 import { Layout } from './components/Layout'
 import { ErrorBoundary } from './components/ErrorBoundary'
@@ -86,9 +86,19 @@ const Forbidden = lazy(() => loadForbidden().then((module) => ({ default: module
 const NotFound = lazy(() => loadNotFound().then((module) => ({ default: module.NotFound })))
 
 function RouteFallback() {
+  // ``bg-surface`` + ``text-primary`` (MD3 light + V0.0.5 blue) used
+  // to paint a white slab with a blue spinner here, which is what
+  // showed up as a "white flash" inside the Codex shell when a lazy
+  // route bundle was still downloading. Transparent now so the
+  // shell's ``html`` background (set by the inline bootstrap script
+  // in ``index.html``) shows through; the codex top progress bar
+  // gives a "loading" cue without committing to a centered spinner.
   return (
-    <div className="flex h-full min-h-[240px] items-center justify-center bg-surface">
-      <Loader2 className="h-6 w-6 animate-spin text-primary" />
+    <div
+      className="theme-codex flex h-full min-h-[240px] flex-col"
+      style={{ background: 'var(--color-codex-bg)', color: 'var(--color-codex-ink)' }}
+    >
+      <CxTopProgress />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

你截图里头部已经是黑的，但内容区还是白色一块加一个蓝色 spinner —— 真正的元凶在这里。

`App.tsx` 的 `RouteFallback`（每个 lazy route 加载时的 Suspense fallback）一直硬编码 `bg-surface`（MD3 浅色）+ `text-primary`（V0.0.5 蓝）。它渲染在 codex shell 里，所以每次 bundle 没下载完，就会闪一块白色出来。

改成 codex shell：
- `theme-codex` 包装，`background: var(--color-codex-bg)`，跟主题 + warmth 走
- 顶部 `CxTopProgress`（2px accent 滑块）替代居中蓝 spinner

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 514 passed
- [x] `npx vite build` clean
- [ ] 部署后 visual smoke：暗黑模式硬刷新 `/`、`/chat`、`/skills`，从顶部 nav 到下面内容区**全部**深色，不再有白块；加载时顶部能看到 accent 进度条划过

🤖 Generated with [Claude Code](https://claude.com/claude-code)