### PR TITLE
perf: drop eager warmPrimaryRoutes (keep hover-prefetch path)

### DIFF
--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -16,7 +16,7 @@ import {
 import { useState, useEffect } from 'react'
 import { api } from '../api/client'
 import type { User } from '../types/api'
-import { primaryRouteLoaders, warmPrimaryRoutes } from '../routeLoaders'
+import { primaryRouteLoaders } from '../routeLoaders'
 import { DEFAULT_APP_TIMEZONE, setAppTimeZone } from '../utils/timezone'
 import { CxLogo } from './codex/CxLogo'
 
@@ -131,19 +131,14 @@ export function Layout() {
       })
   }, [])
 
-  useEffect(() => {
-    const scheduleWarmup = () => {
-      void warmPrimaryRoutes()
-    }
-
-    if (typeof window !== 'undefined' && 'requestIdleCallback' in window) {
-      const idleId = window.requestIdleCallback(scheduleWarmup, { timeout: 1200 })
-      return () => window.cancelIdleCallback(idleId)
-    }
-
-    const timer = setTimeout(scheduleWarmup, 400)
-    return () => clearTimeout(timer)
-  }, [])
+  // Per-route bundles are still preloaded on nav-link hover/focus via
+  // ``primaryRouteLoaders[item.path]`` below, so the most-likely-next
+  // route is already warmed up by the time the user clicks. The
+  // previous blanket ``warmPrimaryRoutes()`` (which prefetched all 9
+  // primary routes on every mount) created several seconds of network
+  // contention on slow connections — fast users got faster, slow users
+  // got 10s+ of background traffic competing with the current page's
+  // own data calls. Dropped in favor of the hover-only path.
 
   useEffect(() => {
     const loadUnreadCount = () => {


### PR DESCRIPTION
## Summary

你截图的 Network panel 上：硬刷新进 `/` 一共发了 35-39 个 JS 请求，里面除了当前页 (Workspace) 自己的 bundle，还有 Chat / Skills / Projects / Clients / Contacts / Knowledge / MessagesPage / SettingsLayout —— 全部 8 个其他主路由的 bundle 都在背后下载。

罪魁是 `Layout.tsx` 里 mount 之后的 `warmPrimaryRoutes()`：一次性预热所有主路由，让"用户下一步可能去的页"提前到位。在快速网络上这是优化；在你那个 ~2s/请求的连接上，等于花 10-39s 跟当前页的数据接口抢带宽。

### 改动
删掉 `Layout.tsx` 里那块 `requestIdleCallback(warmPrimaryRoutes)` 的 effect。

**hover 预取还在**：nav 链接 `onMouseEnter` / `onFocus` 还是会调 `primaryRouteLoaders[item.path]`，鼠标悬停时下一页就开始下载，跟以前体验一样。

`warmPrimaryRoutes` 函数本身保留在 `routeLoaders.ts` 里没动，以后想换成"真闲下来再预热"的策略可以重新接进来。

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 514 passed
- [x] `npx vite build` clean
- [ ] 部署后 visual smoke：硬刷新 `/`、`/chat`、`/skills`，Network 面板应该只看到当前页的 bundle + 公共 vendor + 该页的 XHR 调用，不再有 Clients / Contacts / Knowledge / MessagesPage 等无关 bundle。鼠标悬停其他 nav 链接，目标页 bundle 应该开始下载（hover 预取还在工作）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)