### PR TITLE
perf: cut vendor preloads + memoize Chat conversation grouping

### DIFF
--- a/web/src/pages/chat/Chat.tsx
+++ b/web/src/pages/chat/Chat.tsx
@@ -1833,12 +1833,22 @@ export function Chat() {
     : []
   const liveProgressTitle = skillRunActive ? 'Skill 执行清单' : 'Aria 正在处理'
 
-  const filteredConversations = sidebarSearch.trim()
-    ? conversations.filter(c =>
-        (c.title || '').toLowerCase().includes(sidebarSearch.toLowerCase())
-      )
-    : conversations
-  const conversationGroups = groupConversations(filteredConversations, t, resolvedTimeZone)
+  // Memoize the conversation filter + grouping. Without this they
+  // run on every render (62 hooks tick on every state change in this
+  // component), and the grouping walks every conversation parsing
+  // dates with the user's timezone — non-trivial CPU on the main
+  // thread that piles into the "transition pending" window when the
+  // user navigates into /chat. Now they only recompute when the
+  // sources actually change.
+  const filteredConversations = useMemo(() => {
+    const term = sidebarSearch.trim().toLowerCase()
+    if (!term) return conversations
+    return conversations.filter((c) => (c.title || '').toLowerCase().includes(term))
+  }, [conversations, sidebarSearch])
+  const conversationGroups = useMemo(
+    () => groupConversations(filteredConversations, t, resolvedTimeZone),
+    [filteredConversations, t, resolvedTimeZone],
+  )
 
   // ── Render ────────────────────────────────────────────────────────────────
   // ``theme-codex`` wraps the page so the sidebar + chrome (refactored in

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -11,11 +11,24 @@ export default defineConfig({
   build: {
     rollupOptions: {
       output: {
+        // Conservative chunking: only carve out a small ``react-vendor``
+        // for the React runtime that every page needs. Everything else
+        // is left to Rollup's automatic chunking so heavy deps end up
+        // *inside* the route bundle that actually uses them — e.g.
+        // ``react-markdown`` rides with Chat, not as a preloaded
+        // top-level chunk.
+        //
+        // The earlier setup carved 6 named vendor chunks (react /
+        // markdown / i18n / ui / network / catch-all). Vite emits a
+        // ``<link rel="modulepreload">`` for every chunk in the entry
+        // import graph, so visiting ``/workspace`` raced 7 vendor
+        // files in parallel — each one tiny but each one paying the
+        // same RTT cost. On a slow connection that produced ~12s
+        // DOMContentLoaded for a 250 kB total transfer.
         manualChunks(id) {
           if (!id.includes('node_modules')) {
             return undefined
           }
-
           if (
             id.includes('/react/') ||
             id.includes('/react-dom/') ||
@@ -24,33 +37,7 @@ export default defineConfig({
           ) {
             return 'react-vendor'
           }
-
-          if (
-            id.includes('/react-markdown/') ||
-            id.includes('/remark-gfm/')
-          ) {
-            return 'markdown-vendor'
-          }
-
-          if (
-            id.includes('/i18next/') ||
-            id.includes('/react-i18next/')
-          ) {
-            return 'i18n-vendor'
-          }
-
-          if (
-            id.includes('/@dnd-kit/') ||
-            id.includes('/lucide-react/')
-          ) {
-            return 'ui-vendor'
-          }
-
-          if (id.includes('/axios/')) {
-            return 'network-vendor'
-          }
-
-          return 'vendor'
+          return undefined
         },
       },
     },


### PR DESCRIPTION
## Summary

治本：你说的"点对话再点别的像被吃掉了"，根因不是有 overlay 挡住，是 **React 19 + React Router 7 的导航 transition** 会保留旧 UI 不切，等新 bundle 下完才切。所以你看着还是工作台，其实点的是工作台上已经"死"的按钮。窗口期取决于 bundle 下载 + 新页首次 render，越长越像"卡住"。

两件事一起缩短这个窗口期：

### 1. Vite chunk 瘦身 → bundle 下得快
之前 `manualChunks` 把 `node_modules` 拆成 6 个命名 chunk（react / markdown / i18n / ui / network / 兜底）。Vite 给每个 chunk 加 `<link rel=modulepreload>`，所以进 `/workspace` 也并行下载 markdown-vendor、ui-vendor 等等。每个再小也要付一次 round-trip 的钱，慢网络上叠成 ~12s。

砍到只剩 **`react-vendor`**（React + DOM + Router + Helmet，每个页面都要），其他交给 Rollup 自动 chunking —— `react-markdown` 现在跟 Chat 一起打包，不再单独预载。`dist/index.html` 的 modulepreload 从 7 个降到 4 个。

### 2. Chat 首次 render 减负 → 主线程更快空出来
Chat 的 sidebar 里 `filteredConversations` + `groupConversations(conversations, t, tz)` 每次 render 都跑，没 memo。后者要遍历所有会话按时区解析日期。100+ 条会话时，每次任意 state 变化（62 个 hook，键盘敲一下都触发）都加几百 ms 主线程时间。包了 `useMemo` 后只在 `conversations` / 搜索 / locale / tz 真的变了才重算。

两个加起来：bundle 下完更快，render 也更快，transition 窗口从"好几秒"缩到几乎感觉不到。

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 514 passed
- [x] `npx vite build` clean
- [ ] 部署后 visual smoke：硬刷新 `/workspace`，Network 面板应该只看到 4 个 modulepreload 链接；点工作台 ↔ 对话来回切，旧 UI 停留的时间应该明显缩短，再也不会让"还在加载中点别的"感觉像被吃掉了。

🤖 Generated with [Claude Code](https://claude.com/claude-code)