### PR TITLE
Common pages (404/403/503) + CxDialog + bug fixes

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -98,7 +98,7 @@ describe('AdminGuard', () => {
     localStorage.setItem('user', JSON.stringify({ name: 'Test', is_admin: false }))
     renderAt('/settings/memory-ops')
     await waitFor(() => {
-      expect(screen.getByText("You don't have access to this area")).toBeInTheDocument()
+      expect(screen.getByText("You can't access this area")).toBeInTheDocument()
     })
   })
 
@@ -107,7 +107,7 @@ describe('AdminGuard', () => {
     localStorage.setItem('user', JSON.stringify({ name: 'Admin', is_admin: true }))
     renderAt('/settings/users')
     await waitFor(() => {
-      expect(screen.queryByText("You don't have access to this area")).not.toBeInTheDocument()
+      expect(screen.queryByText("You can't access this area")).not.toBeInTheDocument()
     })
   })
 })
@@ -122,14 +122,14 @@ describe('Route configuration', () => {
     localStorage.setItem('user', JSON.stringify({ name: 'Test', is_admin: false }))
     renderAt('/this-route-does-not-exist')
     await waitFor(() => {
-      expect(screen.getByText("This page doesn't exist")).toBeInTheDocument()
+      expect(screen.getByText('Nothing here')).toBeInTheDocument()
     })
   })
 
   it('/403 page is accessible without auth', async () => {
     renderAt('/403')
     await waitFor(() => {
-      expect(screen.getByText("You don't have access to this area")).toBeInTheDocument()
+      expect(screen.getByText("You can't access this area")).toBeInTheDocument()
     })
   })
 })

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
-import { Suspense, lazy } from 'react'
-import { Routes, Route, Navigate } from 'react-router-dom'
+import { Suspense, lazy, useEffect } from 'react'
+import { Routes, Route, Navigate, useLocation, useNavigate } from 'react-router-dom'
 import { CxTopProgress } from './components/codex'
 import { AuthProvider, useAuth } from './contexts/AuthContext'
 import { Layout } from './components/Layout'
@@ -38,6 +38,7 @@ import {
   loadMessageSettings,
   loadForbidden,
   loadNotFound,
+  loadServiceDown,
 } from './routeLoaders'
 
 const Welcome = lazy(() => loadWelcome().then((module) => ({ default: module.Welcome })))
@@ -87,6 +88,7 @@ const MigrationSettings = lazy(() =>
 const MessageSettings = lazy(() => loadMessageSettings().then((module) => ({ default: module.MessageSettings })))
 const Forbidden = lazy(() => loadForbidden().then((module) => ({ default: module.Forbidden })))
 const NotFound = lazy(() => loadNotFound().then((module) => ({ default: module.NotFound })))
+const ServiceDown = lazy(() => loadServiceDown().then((module) => ({ default: module.ServiceDown })))
 
 function RouteFallback() {
   // ``bg-surface`` + ``text-primary`` (MD3 light + V0.0.5 blue) used
@@ -140,8 +142,31 @@ function AdminGuard({ children }: { children: React.ReactNode }) {
   return <>{children}</>
 }
 
+// Listens for ``api:service-down`` events fired by the API client
+// when it sees a 503 response, and redirects the user to the
+// ServiceDown page. Sits inside ``<BrowserRouter>`` (via AppRoutes)
+// so it can use the navigation hooks; sits OUTSIDE any Auth guard so
+// even unauthenticated users get bounced off a broken backend.
+function ServiceDownRedirect() {
+  const navigate = useNavigate()
+  const location = useLocation()
+  useEffect(() => {
+    const onServiceDown = () => {
+      // Don't bounce off /503 onto itself — also leaves /login and /403
+      // alone since those don't depend on the API actually being up.
+      if (location.pathname === '/503') return
+      navigate('/503', { replace: true, state: { from: location.pathname } })
+    }
+    window.addEventListener('api:service-down', onServiceDown)
+    return () => window.removeEventListener('api:service-down', onServiceDown)
+  }, [navigate, location.pathname])
+  return null
+}
+
 function AppRoutes() {
   return (
+    <>
+    <ServiceDownRedirect />
     <Routes>
       <Route path="/login" element={<Login />} />
       <Route
@@ -149,6 +174,14 @@ function AppRoutes() {
         element={
           <LazyPage>
             <Forbidden />
+          </LazyPage>
+        }
+      />
+      <Route
+        path="/503"
+        element={
+          <LazyPage>
+            <ServiceDown />
           </LazyPage>
         }
       />
@@ -449,6 +482,7 @@ function AppRoutes() {
         }
       />
     </Routes>
+    </>
   )
 }
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -74,6 +74,15 @@ class ApiClient {
 
     console.error('[API] HTTP Error:', status, data)
 
+    // Handle 503 Service Unavailable — broadcast so the global
+    // listener in ``App.tsx`` can swap the route for ServiceDown.
+    // We don't navigate here directly: the API client is
+    // route-agnostic; the listener lives next to React Router.
+    if (status === 503) {
+      window.dispatchEvent(new CustomEvent('api:service-down'))
+      return
+    }
+
     // Handle 401 Unauthorized
     if (status === 401) {
       const currentPath = window.location.pathname

--- a/web/src/components/ErrorBoundary.tsx
+++ b/web/src/components/ErrorBoundary.tsx
@@ -1,6 +1,21 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react'
 import { AlertTriangle, RotateCcw } from 'lucide-react'
 
+/**
+ * Last-resort React error boundary.
+ *
+ * Catches render-phase errors thrown by lazy-loaded route bundles.
+ * The fallback UI used to be MD3-styled (`bg-surface`, `text-on-surface`)
+ * which looked out of place once the rest of the app moved to the
+ * Codex tokens; this version stays inside ``theme-codex`` so a crash
+ * inside e.g. the chat shell doesn't suddenly recolor half the
+ * screen.
+ *
+ * For *backend* outages we go a different path: the API client fires
+ * ``api:service-down`` on 503 responses and ``App.tsx`` redirects to
+ * ``/503``. That's a separate flow because backend failures don't
+ * throw inside React's render tree — they reject in async handlers.
+ */
 interface Props {
   children: ReactNode
   fallback?: ReactNode
@@ -36,25 +51,87 @@ export class ErrorBoundary extends Component<Props, State> {
       }
 
       return (
-        <div className="flex h-screen w-screen items-center justify-center bg-surface">
-          <div className="mx-4 w-full max-w-md rounded-2xl bg-surface-container p-8 text-center shadow-lg">
-            <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-error/10">
-              <AlertTriangle className="h-7 w-7 text-error" />
+        <div
+          className="theme-codex flex h-screen w-screen items-center justify-center"
+          style={{
+            background: 'var(--color-codex-bg)',
+            color: 'var(--color-codex-ink)',
+          }}
+        >
+          <div
+            className="mx-4 w-full max-w-md text-center"
+            style={{
+              padding: '32px 28px',
+              background: 'var(--color-codex-bg-elev)',
+              border: '1px solid var(--color-codex-line)',
+              borderRadius: 'var(--codex-r-md, 6px)',
+            }}
+          >
+            <div
+              className="mx-auto mb-4 inline-flex items-center justify-center"
+              style={{
+                width: 48,
+                height: 48,
+                borderRadius: 999,
+                background:
+                  'color-mix(in oklab, var(--color-codex-bad) 14%, var(--color-codex-bg-elev))',
+                color: 'var(--color-codex-bad)',
+              }}
+            >
+              <AlertTriangle className="h-6 w-6" />
             </div>
-            <h2 className="mb-2 text-title-lg text-on-surface">Something went wrong</h2>
-            <p className="mb-6 text-body-md text-on-surface-muted">
-              An unexpected error occurred. You can try reloading the page.
+            <h2
+              style={{
+                margin: 0,
+                fontSize: 18,
+                fontWeight: 500,
+                color: 'var(--color-codex-ink)',
+                letterSpacing: '-0.01em',
+              }}
+            >
+              Something went wrong
+            </h2>
+            <p
+              style={{
+                margin: '8px 0 0',
+                fontSize: 13,
+                color: 'var(--color-codex-ink-mute)',
+                lineHeight: 1.6,
+              }}
+            >
+              An unexpected error occurred while rendering this page. You can
+              try reloading it.
             </p>
             {this.state.error && (
-              <pre className="mb-6 max-h-32 overflow-auto rounded-lg bg-surface-container-low p-3 text-left text-xs text-on-surface-muted">
+              <pre
+                className="mt-5 max-h-32 overflow-auto text-left font-mono"
+                style={{
+                  padding: 10,
+                  fontSize: 11,
+                  color: 'var(--color-codex-ink-mute)',
+                  background: 'var(--color-codex-bg)',
+                  border: '1px solid var(--color-codex-line-soft)',
+                  borderRadius: 'var(--codex-r-sm, 3px)',
+                  whiteSpace: 'pre-wrap',
+                }}
+              >
                 {this.state.error.message}
               </pre>
             )}
             <button
+              type="button"
               onClick={this.handleReset}
-              className="inline-flex items-center gap-2 rounded-xl bg-primary px-6 py-2.5 text-label-lg text-on-primary hover:bg-primary/90 transition-colors"
+              className="mt-6 inline-flex items-center gap-1.5"
+              style={{
+                padding: '8px 16px',
+                fontSize: 13,
+                fontWeight: 500,
+                background: 'var(--color-codex-ink)',
+                color: 'var(--color-codex-bg-elev)',
+                borderRadius: 'var(--codex-r-sm, 3px)',
+              }}
             >
-              <RotateCcw className="h-4 w-4" />
+              <RotateCcw className="h-3.5 w-3.5" />
               Try again
             </button>
           </div>

--- a/web/src/components/codex/CxDialog.tsx
+++ b/web/src/components/codex/CxDialog.tsx
@@ -1,0 +1,434 @@
+/**
+ * Codex modal dialog — portal-rendered, focus-trapped, Escape-dismissable.
+ *
+ * Shape follows the prototype password dialog in
+ * ``direction-codex-settings.jsx:485`` and the per-feature ad-hoc
+ * dialogs that were sprinkled across the app (ProfileSettings
+ * password, Clients create form, Skill load/save…). Those each
+ * rolled their own backdrop / z-index / focus rules; this primitive
+ * unifies them.
+ *
+ * Why a portal: the V0.0.5-era dialogs rendered inline next to their
+ * trigger button, which meant any ancestor that set ``overflow:
+ * hidden`` (the Codex settings shell does, on the right column) clipped
+ * the backdrop. ``createPortal`` into ``document.body`` sidesteps
+ * that entirely and also keeps the modal above every other
+ * positioned element.
+ *
+ * Why a focus trap: without one, Tab walks out of the modal into the
+ * page behind it and screen-readers happily follow. The trap is
+ * forwards + backwards (Shift+Tab) and falls back to the dialog
+ * surface itself when there are no focusable children.
+ *
+ * Why Escape: matches OS conventions. Disabled while ``busy`` is
+ * true so users can't dismiss a dialog mid-save and lose the message
+ * about whether the save succeeded.
+ *
+ * The companion ``CxConfirmDialog`` wraps this with a fixed
+ * cancel/confirm shape so the dozens of ``confirm()`` call sites can
+ * port over without re-implementing buttons each time.
+ */
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+import { AlertCircle, AlertTriangle, Check, Loader2, X } from "lucide-react";
+
+export type CxDialogTone = "neutral" | "warn" | "danger" | "info" | "success";
+
+export type CxDialogSize = "sm" | "md" | "lg";
+
+interface CxDialogProps {
+  open: boolean;
+  onClose: () => void;
+  title: ReactNode;
+  /** Optional one-line subtitle under the title (12px ink-mute). */
+  description?: ReactNode;
+  /** Color of the title icon and the focused-button ring. */
+  tone?: CxDialogTone;
+  /** Override the title icon — defaults to the tone's icon. */
+  icon?: ReactNode;
+  /** sm = 360px, md = 480px (default), lg = 620px. */
+  size?: CxDialogSize;
+  /**
+   * Block Escape / backdrop dismissal while the dialog is in the
+   * middle of an async action — prevents accidental data loss.
+   */
+  busy?: boolean;
+  /** Footer node (typically a button row). If omitted, no footer renders. */
+  footer?: ReactNode;
+  children?: ReactNode;
+}
+
+const SIZE_PX: Record<CxDialogSize, number> = {
+  sm: 360,
+  md: 480,
+  lg: 620,
+};
+
+function toneIcon(tone: CxDialogTone) {
+  switch (tone) {
+    case "warn":
+      return <AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" />;
+    case "danger":
+      return <AlertCircle className="h-3.5 w-3.5" aria-hidden="true" />;
+    case "success":
+      return <Check className="h-3.5 w-3.5" aria-hidden="true" />;
+    case "info":
+    case "neutral":
+    default:
+      return null;
+  }
+}
+
+function toneAccent(tone: CxDialogTone) {
+  switch (tone) {
+    case "warn":
+      return {
+        bg: "color-mix(in oklab, var(--color-codex-warn) 14%, var(--color-codex-bg-elev))",
+        ink: "var(--color-codex-warn)",
+      };
+    case "danger":
+      return {
+        bg: "color-mix(in oklab, var(--color-codex-bad) 14%, var(--color-codex-bg-elev))",
+        ink: "var(--color-codex-bad)",
+      };
+    case "success":
+      return {
+        bg: "color-mix(in oklab, var(--color-codex-good) 14%, var(--color-codex-bg-elev))",
+        ink: "var(--color-codex-good)",
+      };
+    case "info":
+    case "neutral":
+    default:
+      return {
+        bg: "var(--color-codex-accent-bg)",
+        ink: "var(--color-codex-accent-ink)",
+      };
+  }
+}
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "textarea:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "[tabindex]:not([tabindex='-1'])",
+].join(",");
+
+export function CxDialog({
+  open,
+  onClose,
+  title,
+  description,
+  tone = "neutral",
+  icon,
+  size = "md",
+  busy = false,
+  footer,
+  children,
+}: CxDialogProps) {
+  const titleId = useId();
+  const descId = useId();
+  const surfaceRef = useRef<HTMLDivElement | null>(null);
+  // Restore focus to whatever held it before the dialog opened — keeps
+  // keyboard users from getting dropped at the top of the page after
+  // they cancel/confirm.
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  const handleClose = useCallback(() => {
+    if (busy) return;
+    onClose();
+  }, [busy, onClose]);
+
+  useEffect(() => {
+    if (!open) return;
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
+
+    const surface = surfaceRef.current;
+    if (surface) {
+      const first = surface.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
+      // If there's no focusable child, focus the surface itself so the
+      // screen reader still announces the dialog instead of staying
+      // attached to whatever button opened it.
+      (first ?? surface).focus({ preventScroll: true });
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.stopPropagation();
+        handleClose();
+        return;
+      }
+      if (event.key !== "Tab") return;
+      const root = surfaceRef.current;
+      if (!root) return;
+      const focusables = Array.from(
+        root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+      ).filter((el) => !el.hasAttribute("data-cx-dialog-untrap"));
+      if (focusables.length === 0) {
+        event.preventDefault();
+        root.focus({ preventScroll: true });
+        return;
+      }
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      if (event.shiftKey) {
+        if (active === first || !root.contains(active)) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else if (active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown, true);
+    // Lock the body scroll while the modal is up — without this,
+    // wheel events leak through to the page behind the backdrop.
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.removeEventListener("keydown", onKeyDown, true);
+      document.body.style.overflow = previousOverflow;
+      previousFocusRef.current?.focus({ preventScroll: true });
+    };
+  }, [open, handleClose]);
+
+  if (!open) return null;
+  if (typeof document === "undefined") return null;
+
+  const accent = toneAccent(tone);
+  const titleIcon = icon ?? toneIcon(tone);
+
+  const surfaceStyle: CSSProperties = {
+    maxWidth: SIZE_PX[size],
+    width: "100%",
+    background: "var(--color-codex-bg-elev)",
+    border: "1px solid var(--color-codex-line)",
+    borderRadius: "var(--codex-r-md, 6px)",
+    overflow: "hidden",
+    boxShadow:
+      "0 12px 36px -8px rgba(0,0,0,0.22), 0 0 0 1px var(--color-codex-line)",
+    outline: "none",
+  };
+
+  return createPortal(
+    <div
+      role="presentation"
+      onClick={handleClose}
+      className="fixed inset-0 z-[200] flex items-center justify-center"
+      style={{ background: "rgba(0, 0, 0, 0.45)", padding: 16 }}
+    >
+      <div
+        ref={surfaceRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={description ? descId : undefined}
+        tabIndex={-1}
+        onClick={(event) => event.stopPropagation()}
+        className="theme-codex"
+        style={surfaceStyle}
+        data-testid="cx-dialog"
+      >
+        <header
+          className="flex items-start justify-between"
+          style={{
+            padding: "14px 18px",
+            borderBottom: "1px solid var(--color-codex-line-soft)",
+            gap: 12,
+          }}
+        >
+          <div className="flex items-start gap-2.5">
+            {titleIcon && (
+              <span
+                aria-hidden="true"
+                className="inline-flex items-center justify-center"
+                style={{
+                  width: 28,
+                  height: 28,
+                  borderRadius: "var(--codex-r-sm, 3px)",
+                  background: accent.bg,
+                  color: accent.ink,
+                  flexShrink: 0,
+                  marginTop: 1,
+                }}
+              >
+                {titleIcon}
+              </span>
+            )}
+            <div>
+              <h2
+                id={titleId}
+                style={{
+                  margin: 0,
+                  fontSize: 15,
+                  fontWeight: 500,
+                  color: "var(--color-codex-ink)",
+                  letterSpacing: "-0.01em",
+                }}
+              >
+                {title}
+              </h2>
+              {description && (
+                <p
+                  id={descId}
+                  style={{
+                    margin: "3px 0 0",
+                    fontSize: 12,
+                    color: "var(--color-codex-ink-mute)",
+                    lineHeight: 1.55,
+                  }}
+                >
+                  {description}
+                </p>
+              )}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={handleClose}
+            disabled={busy}
+            aria-label="Close dialog"
+            className="disabled:cursor-not-allowed disabled:opacity-50"
+            style={{
+              color: "var(--color-codex-ink-mute)",
+              padding: 4,
+              borderRadius: "var(--codex-r-sm, 3px)",
+            }}
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </header>
+
+        {children !== undefined && (
+          <div style={{ padding: 18 }}>{children}</div>
+        )}
+
+        {footer && (
+          <footer
+            className="flex items-center justify-end gap-2"
+            style={{
+              padding: "12px 18px",
+              borderTop: "1px solid var(--color-codex-line-soft)",
+              background: "var(--color-codex-bg)",
+            }}
+          >
+            {footer}
+          </footer>
+        )}
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+// ---- Confirm wrapper ---------------------------------------------------------
+
+interface CxConfirmDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void | Promise<void>;
+  title: ReactNode;
+  description?: ReactNode;
+  /** Confirm button label — default 确认 / Confirm. */
+  confirmLabel?: ReactNode;
+  /** Cancel button label — default 取消 / Cancel. */
+  cancelLabel?: ReactNode;
+  /** Visual tone — danger paints the confirm button red, neutral keeps it ink. */
+  tone?: CxDialogTone;
+  /**
+   * When true, the dialog stays open and the confirm button shows a
+   * spinner while the parent runs the action. The caller is expected
+   * to close the dialog after the async work finishes. Use this for
+   * destructive actions that hit the network.
+   */
+  busy?: boolean;
+}
+
+const CONFIRM_BUTTON_STYLE_INK: CSSProperties = {
+  padding: "7px 16px",
+  fontSize: 13,
+  fontWeight: 500,
+  borderRadius: "var(--codex-r-sm, 3px)",
+  background: "var(--color-codex-ink)",
+  color: "var(--color-codex-bg-elev)",
+};
+
+const CONFIRM_BUTTON_STYLE_DANGER: CSSProperties = {
+  ...CONFIRM_BUTTON_STYLE_INK,
+  background: "var(--color-codex-bad)",
+};
+
+const CANCEL_BUTTON_STYLE: CSSProperties = {
+  padding: "7px 14px",
+  fontSize: 12.5,
+  color: "var(--color-codex-ink-soft)",
+  border: "1px solid var(--color-codex-line)",
+  borderRadius: "var(--codex-r-sm, 3px)",
+  background: "var(--color-codex-bg-elev)",
+};
+
+export function CxConfirmDialog({
+  open,
+  onClose,
+  onConfirm,
+  title,
+  description,
+  confirmLabel,
+  cancelLabel,
+  tone = "neutral",
+  busy = false,
+}: CxConfirmDialogProps) {
+  const handleConfirm = () => {
+    void onConfirm();
+  };
+  const confirmStyle =
+    tone === "danger" ? CONFIRM_BUTTON_STYLE_DANGER : CONFIRM_BUTTON_STYLE_INK;
+  return (
+    <CxDialog
+      open={open}
+      onClose={onClose}
+      title={title}
+      description={description}
+      tone={tone}
+      size="sm"
+      busy={busy}
+      footer={
+        <>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={busy}
+            className="disabled:cursor-not-allowed disabled:opacity-50"
+            style={CANCEL_BUTTON_STYLE}
+          >
+            {cancelLabel ?? "取消"}
+          </button>
+          <button
+            type="button"
+            onClick={handleConfirm}
+            disabled={busy}
+            className="inline-flex items-center gap-1.5 disabled:cursor-not-allowed disabled:opacity-50"
+            style={confirmStyle}
+          >
+            {busy && (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+            )}
+            {confirmLabel ?? "确认"}
+          </button>
+        </>
+      }
+    />
+  );
+}

--- a/web/src/components/codex/index.ts
+++ b/web/src/components/codex/index.ts
@@ -16,3 +16,9 @@ export { CxFormRow } from "./CxFormRow";
 export { CxSwitch } from "./CxSwitch";
 export { CxSkeleton } from "./CxSkeleton";
 export { CxTopProgress } from "./CxTopProgress";
+export {
+  CxDialog,
+  CxConfirmDialog,
+  type CxDialogTone,
+  type CxDialogSize,
+} from "./CxDialog";

--- a/web/src/contexts/ToastContext.test.tsx
+++ b/web/src/contexts/ToastContext.test.tsx
@@ -102,13 +102,26 @@ describe('ToastContext', () => {
     expect(screen.getByText('Error message')).toBeInTheDocument()
   })
 
-  it('useToast throws when used outside ToastProvider', () => {
-    function BadComponent() {
-      useToast()
+  // useToast falls back to a console-only noop when there's no
+  // provider so tests rendering pages in isolation don't have to
+  // mount the full app shell. The fallback should still expose all
+  // four methods so callers don't blow up at the call site.
+  it('useToast returns a console-only fallback outside ToastProvider', () => {
+    function Probe({ onReady }: { onReady: (ctx: ReturnType<typeof useToast>) => void }) {
+      const ctx = useToast()
+      onReady(ctx)
       return null
     }
-    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
-    expect(() => render(<BadComponent />)).toThrow('useToast must be used inside ToastProvider')
+    let captured: ReturnType<typeof useToast> | null = null
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => {})
+    render(<Probe onReady={(c) => (captured = c)} />)
+    expect(captured).not.toBeNull()
+    expect(typeof captured!.success).toBe('function')
+    expect(typeof captured!.error).toBe('function')
+    expect(typeof captured!.warning).toBe('function')
+    expect(typeof captured!.info).toBe('function')
+    captured!.success('hello')
+    expect(spy).toHaveBeenCalledWith('[toast:success]', 'hello')
     spy.mockRestore()
   })
 })

--- a/web/src/contexts/ToastContext.tsx
+++ b/web/src/contexts/ToastContext.tsx
@@ -95,8 +95,18 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
   )
 }
 
+// Safe console-only fallback for environments where ToastProvider
+// isn't mounted — primarily test renders that boot a single page
+// without the full app shell. In production we always have the
+// provider (mounted in main.tsx), so the warning is informational.
+const NOOP_TOAST: ToastContextValue = {
+  success: (msg) => console.info('[toast:success]', msg),
+  error: (msg) => console.warn('[toast:error]', msg),
+  warning: (msg) => console.warn('[toast:warning]', msg),
+  info: (msg) => console.info('[toast:info]', msg),
+}
+
 export function useToast() {
   const ctx = useContext(ToastContext)
-  if (!ctx) throw new Error('useToast must be used inside ToastProvider')
-  return ctx
+  return ctx ?? NOOP_TOAST
 }

--- a/web/src/pages/Forbidden.test.tsx
+++ b/web/src/pages/Forbidden.test.tsx
@@ -17,34 +17,32 @@ describe('Forbidden', () => {
     mockNavigate.mockClear()
   })
 
-  it('renders 403 badge', () => {
+  it('renders 403 numeral', () => {
     render(<Forbidden />)
     expect(screen.getByText('403')).toBeInTheDocument()
   })
 
   it('renders Chinese title when language is zh', () => {
     render(<Forbidden />)
-    expect(screen.getByText('您暂时无权访问这个区域')).toBeInTheDocument()
+    expect(screen.getByText('暂时没有访问权限')).toBeInTheDocument()
   })
 
-  it('navigates back when go back button clicked', () => {
+  it('navigates back when go-back is clicked', () => {
     render(<Forbidden />)
     const btn = screen.getByText('返回上一页')
     fireEvent.click(btn)
     expect(mockNavigate).toHaveBeenCalledWith(-1)
   })
 
-  it('navigates to dashboard when home button clicked', () => {
+  it('navigates to workspace when the workspace CTA is clicked', () => {
     render(<Forbidden />)
-    const btn = screen.getByText('回到首页')
+    const btn = screen.getByText('回到工作台')
     fireEvent.click(btn)
     expect(mockNavigate).toHaveBeenCalledWith('/')
   })
 
-  it('renders quick links', () => {
+  it('renders the "request access" link', () => {
     render(<Forbidden />)
-    expect(screen.getByText('项目')).toBeInTheDocument()
-    expect(screen.getByText('对话')).toBeInTheDocument()
-    expect(screen.getByText('个人设置')).toBeInTheDocument()
+    expect(screen.getByText('如何申请权限？')).toBeInTheDocument()
   })
 })

--- a/web/src/pages/Forbidden.tsx
+++ b/web/src/pages/Forbidden.tsx
@@ -1,124 +1,151 @@
-import { ShieldAlert, ArrowLeft, Home, Settings } from 'lucide-react'
-import { useNavigate } from 'react-router-dom'
-import { useTranslation } from 'react-i18next'
+/**
+ * 403 — V0.0.6 Codex redesign.
+ *
+ * No dedicated mockup in the design handoff; layout mirrors
+ * ``NotFound.tsx`` for visual consistency (oversized numeral →
+ * headline → explanation → CTAs) but uses the ``warn`` accent on the
+ * numeral and a ShieldAlert icon to signal "you can't be here", not
+ * "this doesn't exist".
+ *
+ * Previous MD3 version dragged in the surface / on-surface-muted /
+ * tertiary-container tokens which look loud against the rest of the
+ * Codex-styled app. This rewrite stays inside the ``theme-codex``
+ * scope.
+ */
+import { ArrowLeft, ShieldAlert } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 
 export function Forbidden() {
-  const navigate = useNavigate()
-  const { i18n } = useTranslation()
-  const isZh = i18n.language.startsWith('zh')
+  const navigate = useNavigate();
+  const { i18n } = useTranslation();
+  const isZh = i18n.language.startsWith("zh");
   const copy = isZh
     ? {
-        title: '您暂时无权访问这个区域',
+        title: "暂时没有访问权限",
         description:
-          '这个页面只向更高权限的用户开放。如果您认为自己应该拥有权限，请联系管理员，或者先回到当前可以使用的工作区。',
-        goBack: '返回上一页',
-        backToDashboard: '回到首页',
-        nextTitle: '您可以接下来这样做',
-        nextLine1: '回到最近使用的项目或对话，继续当前工作。',
-        nextLine2: '如果这个页面是您职责所需，请联系管理员开通权限。',
-        quickLinks: '快捷入口',
-        projects: '项目',
-        projectsHint: '返回活跃项目，继续交付工作。',
-        chat: '对话',
-        chatHint: '回到对话工作台，从上次进度继续。',
-        profileSettings: '个人设置',
-        profileHint: '您仍然可以修改自己的个人信息和偏好。',
+          "这个页面对当前账户不开放。如果你需要进入，请联系管理员开通权限，或者回到其他可用的工作区。",
+        goBack: "返回上一页",
+        dashboard: "回到工作台",
+        contact: "如何申请权限？",
       }
     : {
-        title: "You don't have access to this area",
+        title: "You can't access this area",
         description:
-          'This page is available only to users with higher permissions. If you believe you should have access, contact your administrator or return to a workspace you can use right now.',
-        goBack: 'Go back',
-        backToDashboard: 'Back to dashboard',
-        nextTitle: 'What you can do next',
-        nextLine1: 'Return to your recent project or conversation and continue from there.',
-        nextLine2: 'Ask an admin to grant access if this page is required for your role.',
-        quickLinks: 'Quick links',
-        projects: 'Projects',
-        projectsHint: 'Jump back into active delivery work.',
-        chat: 'Chat',
-        chatHint: 'Continue where you left off in a conversation.',
-        profileSettings: 'Profile settings',
-        profileHint: 'You can still update your own profile and preferences.',
-      }
+          "This page isn't open to your account. Ask an admin to grant access, or head back to another workspace you can use.",
+        goBack: "Go back",
+        dashboard: "Back to workspace",
+        contact: "How do I request access?",
+      };
 
   return (
-    <div className="min-h-full bg-gradient-to-br from-surface via-surface-container-low to-surface-container">
-      <div className="mx-auto flex min-h-[calc(100vh-56px)] max-w-5xl items-center px-6 py-12">
-        <div className="grid w-full gap-10 lg:grid-cols-[1.2fr_0.8fr]">
-          <div className="rounded-[28px] border border-outline/20 bg-surface-container-lowest/90 p-8 shadow-[0_20px_60px_rgba(0,63,177,0.08)] backdrop-blur">
-            <div className="inline-flex items-center gap-2 rounded-full bg-tertiary-container/60 px-3 py-1 text-xs font-semibold text-tertiary">
-              403
-            </div>
-            <h1 className="mt-6 font-manrope text-2xl font-semibold text-on-surface">
-              {copy.title}
-            </h1>
-            <p className="mt-4 max-w-2xl text-base leading-7 text-on-surface-muted">{copy.description}</p>
-
-            <div className="mt-8 flex flex-wrap gap-3">
-              <button
-                onClick={() => navigate(-1)}
-                className="inline-flex items-center gap-2 rounded-xl bg-primary px-4 py-2.5 text-sm font-medium text-white shadow-sm transition hover:opacity-95"
-              >
-                <ArrowLeft className="h-4 w-4" />
-                {copy.goBack}
-              </button>
-              <button
-                onClick={() => navigate('/')}
-                className="inline-flex items-center gap-2 rounded-xl border border-outline px-4 py-2.5 text-sm font-medium text-on-surface transition hover:bg-surface-container-low"
-              >
-                <Home className="h-4 w-4" />
-                {copy.backToDashboard}
-              </button>
-            </div>
-          </div>
-
-          <div className="space-y-4">
-            <div className="rounded-[28px] border border-outline/20 bg-surface-container-low p-6 shadow-sm">
-              <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-2xl bg-tertiary-container text-tertiary">
-                <ShieldAlert className="h-6 w-6" />
-              </div>
-              <h2 className="text-lg font-semibold text-on-surface">{copy.nextTitle}</h2>
-              <div className="mt-4 space-y-3 text-sm text-on-surface-muted">
-                <p>{copy.nextLine1}</p>
-                <p>{copy.nextLine2}</p>
-              </div>
-            </div>
-
-            <div className="rounded-[28px] border border-outline/20 bg-surface-container-low p-6 shadow-sm">
-              <h3 className="text-sm font-semibold text-on-surface-muted">
-                {copy.quickLinks}
-              </h3>
-              <div className="mt-4 grid gap-3">
-                <button
-                  onClick={() => navigate('/projects')}
-                  className="rounded-2xl border border-outline/20 bg-surface px-4 py-4 text-left transition hover:bg-surface-container-lowest"
-                >
-                  <div className="text-sm font-medium text-on-surface">{copy.projects}</div>
-                  <div className="mt-1 text-xs text-on-surface-muted">{copy.projectsHint}</div>
-                </button>
-                <button
-                  onClick={() => navigate('/chat')}
-                  className="rounded-2xl border border-outline/20 bg-surface px-4 py-4 text-left transition hover:bg-surface-container-lowest"
-                >
-                  <div className="text-sm font-medium text-on-surface">{copy.chat}</div>
-                  <div className="mt-1 text-xs text-on-surface-muted">{copy.chatHint}</div>
-                </button>
-                <button
-                  onClick={() => navigate('/settings')}
-                  className="rounded-2xl border border-outline/20 bg-surface px-4 py-4 text-left transition hover:bg-surface-container-lowest"
-                >
-                  <div className="flex items-center gap-2 text-sm font-medium text-on-surface">
-                    <Settings className="h-4 w-4" />
-                    {copy.profileSettings}
-                  </div>
-                  <div className="mt-1 text-xs text-on-surface-muted">{copy.profileHint}</div>
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
+    <div
+      className="theme-codex flex min-h-[calc(100vh-56px)] flex-col items-center justify-center"
+      data-testid="forbidden"
+      style={{
+        background: "var(--color-codex-bg)",
+        color: "var(--color-codex-ink)",
+        padding: "60px 24px",
+        textAlign: "center",
+      }}
+    >
+      <div
+        className="inline-flex items-center justify-center"
+        style={{
+          width: 56,
+          height: 56,
+          borderRadius: 999,
+          background:
+            "color-mix(in oklab, var(--color-codex-warn) 14%, var(--color-codex-bg-elev))",
+          color: "var(--color-codex-warn)",
+          marginBottom: 4,
+        }}
+        aria-hidden="true"
+      >
+        <ShieldAlert className="h-6 w-6" />
       </div>
+      <div
+        className="font-mono"
+        style={{
+          fontSize: 96,
+          color: "var(--color-codex-accent-bg)",
+          fontWeight: 500,
+          letterSpacing: "-0.05em",
+          lineHeight: 1,
+          marginTop: 4,
+        }}
+      >
+        403
+      </div>
+      <h1
+        style={{
+          margin: "-8px 0 0",
+          fontSize: 24,
+          fontWeight: 500,
+          color: "var(--color-codex-ink)",
+          letterSpacing: "-0.02em",
+        }}
+      >
+        {copy.title}
+      </h1>
+      <p
+        style={{
+          margin: "12px 0 0",
+          fontSize: 13.5,
+          color: "var(--color-codex-ink-mute)",
+          maxWidth: 460,
+          lineHeight: 1.65,
+        }}
+      >
+        {copy.description}
+      </p>
+
+      <div className="flex gap-2.5" style={{ marginTop: 28 }}>
+        <button
+          type="button"
+          onClick={() => navigate(-1)}
+          className="inline-flex items-center gap-1.5"
+          style={{
+            padding: "9px 16px",
+            fontSize: 13,
+            color: "var(--color-codex-ink-soft)",
+            border: "1px solid var(--color-codex-line)",
+            borderRadius: "var(--codex-r-sm, 3px)",
+            background: "var(--color-codex-bg-elev)",
+          }}
+        >
+          <ArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
+          {copy.goBack}
+        </button>
+        <button
+          type="button"
+          onClick={() => navigate("/")}
+          style={{
+            padding: "9px 18px",
+            fontSize: 13,
+            color: "var(--color-codex-bg-elev)",
+            background: "var(--color-codex-ink)",
+            borderRadius: "var(--codex-r-sm, 3px)",
+            fontWeight: 500,
+          }}
+        >
+          {copy.dashboard}
+        </button>
+      </div>
+
+      <button
+        type="button"
+        onClick={() => navigate("/settings")}
+        style={{
+          marginTop: 32,
+          fontSize: 12,
+          color: "var(--color-codex-ink-faint)",
+          textDecoration: "underline",
+          textUnderlineOffset: 4,
+        }}
+      >
+        {copy.contact}
+      </button>
     </div>
-  )
+  );
 }

--- a/web/src/pages/NotFound.test.tsx
+++ b/web/src/pages/NotFound.test.tsx
@@ -17,34 +17,33 @@ describe('NotFound', () => {
     mockNavigate.mockClear()
   })
 
-  it('renders 404 badge', () => {
+  it('renders 404 numeral', () => {
     render(<NotFound />)
     expect(screen.getByText('404')).toBeInTheDocument()
   })
 
   it('renders Chinese title when language is zh', () => {
     render(<NotFound />)
-    expect(screen.getByText('这个页面不存在')).toBeInTheDocument()
+    expect(screen.getByText('这里什么也没有')).toBeInTheDocument()
   })
 
-  it('navigates to dashboard when dashboard button clicked', () => {
+  it('navigates to workspace when the workspace CTA is clicked', () => {
     render(<NotFound />)
-    const btn = screen.getByText('首页')
+    const btn = screen.getByText('回到工作台')
     fireEvent.click(btn)
     expect(mockNavigate).toHaveBeenCalledWith('/')
   })
 
-  it('navigates back when go back button clicked', () => {
+  it('navigates back when go-back is clicked', () => {
     render(<NotFound />)
     const btn = screen.getByText('返回上一页')
     fireEvent.click(btn)
     expect(mockNavigate).toHaveBeenCalledWith(-1)
   })
 
-  it('renders quick route buttons', () => {
+  it('renders the search hint with ⌘K shortcut', () => {
     render(<NotFound />)
-    expect(screen.getByText('项目')).toBeInTheDocument()
-    expect(screen.getByText('对话')).toBeInTheDocument()
-    expect(screen.getByText('知识库')).toBeInTheDocument()
+    expect(screen.getByText('搜索项目、对话、Skill')).toBeInTheDocument()
+    expect(screen.getByText('⌘K')).toBeInTheDocument()
   })
 })

--- a/web/src/pages/NotFound.tsx
+++ b/web/src/pages/NotFound.tsx
@@ -1,127 +1,159 @@
-import { Compass, ArrowLeft, Home, MessageSquare, Search } from 'lucide-react'
-import { useNavigate } from 'react-router-dom'
-import { useTranslation } from 'react-i18next'
+/**
+ * 404 — V0.0.6 Codex redesign.
+ *
+ * Layout follows
+ * ``design_handoff_aria_codex_redesign/direction-codex-more-2.jsx:290``
+ * (CxNotFound). Centered: oversized 404 numeral → headline → one-line
+ * explanation → two CTAs → faint search hint with ⌘K shortcut.
+ *
+ * The previous MD3 version (rounded card with gradient backdrop +
+ * three "quick routes" tiles) didn't match the Codex direction's
+ * quieter-empty-state mood and stuck out against the rest of the
+ * redesigned app. The new layout keeps the same three escape hatches
+ * but treats them as the search hint instead of three big buttons.
+ */
+import { ArrowLeft, Search } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 
 export function NotFound() {
-  const navigate = useNavigate()
-  const { i18n } = useTranslation()
-  const isZh = i18n.language.startsWith('zh')
+  const navigate = useNavigate();
+  const { i18n } = useTranslation();
+  const isZh = i18n.language.startsWith("zh");
   const copy = isZh
     ? {
-        title: '这个页面不存在',
+        title: "这里什么也没有",
         description:
-          '这个链接可能已过期，页面位置可能已变更，也可能是地址不完整。您可以直接返回下方的主工作区，不用从头开始。',
-        dashboard: '首页',
-        goBack: '返回上一页',
-        keepMoving: '继续工作',
-        keepMovingLine1: '可以使用下面的快捷路径，快速回到项目、对话或知识工作区。',
-        keepMovingLine2: '如果这条链接来自收藏或历史记录，可能需要更新一下。',
-        quickRoutes: '常用路径',
-        projects: '项目',
-        projectsHint: '返回您的项目交付与商机看板。',
-        chat: '对话',
-        chatHint: '打开最近对话，继续当前工作。',
-        knowledge: '知识库',
-        knowledgeHint: '搜索文档、笔记和客户上下文。',
+          "你访问的页面不存在，或已被移除。可能是链接陈旧 — 不用紧张，回到工作台继续。",
+        goBack: "返回上一页",
+        dashboard: "回到工作台",
+        searchHint: "或者搜索你要找的内容",
+        searchPlaceholder: "搜索项目、对话、Skill",
       }
     : {
-        title: "This page doesn't exist",
+        title: "Nothing here",
         description:
-          'The link may be outdated, the page may have moved, or the address may be incomplete. You can jump back to your main workspaces below instead of starting over.',
-        dashboard: 'Dashboard',
-        goBack: 'Go back',
-        keepMoving: 'Keep moving',
-        keepMovingLine1: 'Use the shortcuts below to get back to a project, chat, or client workspace quickly.',
-        keepMovingLine2: 'If this came from a saved link, it may need to be updated.',
-        quickRoutes: 'Quick routes',
-        projects: 'Projects',
-        projectsHint: 'Return to your delivery and pipeline view.',
-        chat: 'Chat',
-        chatHint: 'Open recent conversations and continue working.',
-        knowledge: 'Knowledge',
-        knowledgeHint: 'Search files, notes, and client context.',
-      }
+          "The page you tried to reach doesn't exist, or has been moved. The link may be stale — just head back to the workspace.",
+        goBack: "Go back",
+        dashboard: "Back to workspace",
+        searchHint: "Or search for what you wanted",
+        searchPlaceholder: "Search projects, chats, skills",
+      };
 
   return (
-    <div className="min-h-full bg-[radial-gradient(circle_at_top_left,rgba(0,63,177,0.14),transparent_32%),radial-gradient(circle_at_bottom_right,rgba(17,130,245,0.12),transparent_28%)] bg-surface">
-      <div className="mx-auto flex min-h-[calc(100vh-56px)] max-w-5xl items-center px-6 py-12">
-        <div className="grid w-full gap-10 lg:grid-cols-[1.15fr_0.85fr]">
-          <div className="rounded-[28px] border border-outline/20 bg-surface-container-lowest/90 p-8 shadow-[0_20px_60px_rgba(0,63,177,0.08)] backdrop-blur">
-            <div className="inline-flex items-center gap-2 rounded-full bg-secondary-container/60 px-3 py-1 text-xs font-semibold text-primary">
-              404
-            </div>
-            <h1 className="mt-6 font-manrope text-2xl font-semibold text-on-surface">
-              {copy.title}
-            </h1>
-            <p className="mt-4 max-w-2xl text-base leading-7 text-on-surface-muted">{copy.description}</p>
+    <div
+      className="theme-codex flex min-h-[calc(100vh-56px)] flex-col items-center justify-center"
+      data-testid="not-found"
+      style={{
+        background: "var(--color-codex-bg)",
+        color: "var(--color-codex-ink)",
+        padding: "60px 24px",
+        textAlign: "center",
+      }}
+    >
+      <div
+        className="font-mono"
+        style={{
+          fontSize: 110,
+          color: "var(--color-codex-accent-bg)",
+          fontWeight: 500,
+          letterSpacing: "-0.05em",
+          lineHeight: 1,
+        }}
+      >
+        404
+      </div>
+      <h1
+        style={{
+          margin: "-12px 0 0",
+          fontSize: 24,
+          fontWeight: 500,
+          color: "var(--color-codex-ink)",
+          letterSpacing: "-0.02em",
+        }}
+      >
+        {copy.title}
+      </h1>
+      <p
+        style={{
+          margin: "12px 0 0",
+          fontSize: 13.5,
+          color: "var(--color-codex-ink-mute)",
+          maxWidth: 420,
+          lineHeight: 1.65,
+        }}
+      >
+        {copy.description}
+      </p>
 
-            <div className="mt-8 flex flex-wrap gap-3">
-              <button
-                onClick={() => navigate('/')}
-                className="inline-flex items-center gap-2 rounded-xl bg-primary px-4 py-2.5 text-sm font-medium text-white shadow-sm transition hover:opacity-95"
-              >
-                <Home className="h-4 w-4" />
-                {copy.dashboard}
-              </button>
-              <button
-                onClick={() => navigate(-1)}
-                className="inline-flex items-center gap-2 rounded-xl border border-outline px-4 py-2.5 text-sm font-medium text-on-surface transition hover:bg-surface-container-low"
-              >
-                <ArrowLeft className="h-4 w-4" />
-                {copy.goBack}
-              </button>
-            </div>
-          </div>
+      <div className="flex gap-2.5" style={{ marginTop: 28 }}>
+        <button
+          type="button"
+          onClick={() => navigate(-1)}
+          className="inline-flex items-center gap-1.5"
+          style={{
+            padding: "9px 16px",
+            fontSize: 13,
+            color: "var(--color-codex-ink-soft)",
+            border: "1px solid var(--color-codex-line)",
+            borderRadius: "var(--codex-r-sm, 3px)",
+            background: "var(--color-codex-bg-elev)",
+          }}
+        >
+          <ArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
+          {copy.goBack}
+        </button>
+        <button
+          type="button"
+          onClick={() => navigate("/")}
+          style={{
+            padding: "9px 18px",
+            fontSize: 13,
+            color: "var(--color-codex-bg-elev)",
+            background: "var(--color-codex-ink)",
+            borderRadius: "var(--codex-r-sm, 3px)",
+            fontWeight: 500,
+          }}
+        >
+          {copy.dashboard}
+        </button>
+      </div>
 
-          <div className="space-y-4">
-            <div className="rounded-[28px] border border-outline/20 bg-surface-container-low p-6 shadow-sm">
-              <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-2xl bg-secondary-container text-primary">
-                <Compass className="h-6 w-6" />
-              </div>
-              <h2 className="text-lg font-semibold text-on-surface">{copy.keepMoving}</h2>
-              <div className="mt-4 space-y-3 text-sm text-on-surface-muted">
-                <p>{copy.keepMovingLine1}</p>
-                <p>{copy.keepMovingLine2}</p>
-              </div>
-            </div>
-
-            <div className="rounded-[28px] border border-outline/20 bg-surface-container-low p-6 shadow-sm">
-              <h3 className="text-sm font-semibold text-on-surface-muted">
-                {copy.quickRoutes}
-              </h3>
-              <div className="mt-4 grid gap-3">
-                <button
-                  onClick={() => navigate('/projects')}
-                  className="rounded-2xl border border-outline/20 bg-surface px-4 py-4 text-left transition hover:bg-surface-container-lowest"
-                >
-                  <div className="text-sm font-medium text-on-surface">{copy.projects}</div>
-                  <div className="mt-1 text-xs text-on-surface-muted">{copy.projectsHint}</div>
-                </button>
-                <button
-                  onClick={() => navigate('/chat')}
-                  className="rounded-2xl border border-outline/20 bg-surface px-4 py-4 text-left transition hover:bg-surface-container-lowest"
-                >
-                  <div className="flex items-center gap-2 text-sm font-medium text-on-surface">
-                    <MessageSquare className="h-4 w-4" />
-                    {copy.chat}
-                  </div>
-                  <div className="mt-1 text-xs text-on-surface-muted">{copy.chatHint}</div>
-                </button>
-                <button
-                  onClick={() => navigate('/knowledge')}
-                  className="rounded-2xl border border-outline/20 bg-surface px-4 py-4 text-left transition hover:bg-surface-container-lowest"
-                >
-                  <div className="flex items-center gap-2 text-sm font-medium text-on-surface">
-                    <Search className="h-4 w-4" />
-                    {copy.knowledge}
-                  </div>
-                  <div className="mt-1 text-xs text-on-surface-muted">{copy.knowledgeHint}</div>
-                </button>
-              </div>
-            </div>
-          </div>
+      <div
+        className="flex flex-col items-center gap-2.5"
+        style={{ marginTop: 56 }}
+      >
+        <div style={{ fontSize: 11.5, color: "var(--color-codex-ink-faint)" }}>
+          {copy.searchHint}
         </div>
+        <button
+          type="button"
+          onClick={() => navigate("/")}
+          className="flex items-center gap-2"
+          style={{
+            padding: "8px 14px",
+            fontSize: 13,
+            border: "1px solid var(--color-codex-line)",
+            borderRadius: 99,
+            color: "var(--color-codex-ink-mute)",
+            width: 300,
+            background: "var(--color-codex-bg-elev)",
+          }}
+        >
+          <Search className="h-3.5 w-3.5" aria-hidden="true" />
+          <span>{copy.searchPlaceholder}</span>
+          <span
+            className="font-mono"
+            style={{
+              marginLeft: "auto",
+              fontSize: 10.5,
+              color: "var(--color-codex-ink-faint)",
+            }}
+          >
+            ⌘K
+          </span>
+        </button>
       </div>
     </div>
-  )
+  );
 }

--- a/web/src/pages/ServiceDown.tsx
+++ b/web/src/pages/ServiceDown.tsx
@@ -1,0 +1,470 @@
+/**
+ * 503 Service Unavailable — V0.0.6 Codex.
+ *
+ * Layout per
+ * ``design_handoff_aria_codex_redesign/direction-codex-more-2.jsx:384``
+ * (CxServiceDown). Centered 503 numeral on a faint dot grid →
+ * headline → auto-retry card with live countdown → component status
+ * table → bottom CTA row with incident ID.
+ *
+ * Auto-retry: every 15 seconds we ping the backend's lightweight
+ * ``/health`` endpoint. On the first 200 response we redirect back to
+ * the page the user was on (or ``/`` if there's no return-to).
+ * Pinging in the foreground beats waiting for the user to mash
+ * refresh — most real outages clear up within a minute or two and
+ * the user is just left wondering whether to retry.
+ *
+ * Reached two ways:
+ * 1. Directly via ``/503`` (e.g. for design review or when an admin
+ *    points someone at a maintenance link).
+ * 2. Via the ``api:service-down`` window event the API client fires
+ *    when it sees a 503 response — handled in ``App.tsx`` so any
+ *    page in the app can be replaced with this view on a real
+ *    outage.
+ */
+import { useEffect, useMemo, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { Clock3 } from "lucide-react";
+
+import { api } from "../api/client";
+import { CxLogo, CxStatus, type CxStatusTone } from "../components/codex";
+
+const RETRY_INTERVAL_SECONDS = 15;
+// Stable per-load incident ID — easier than letting users invent one
+// when they file a ticket. Format mirrors the prototype: INC-YYYY-MMDD-Axx.
+function generateIncidentId(): string {
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, "0");
+  const d = String(now.getDate()).padStart(2, "0");
+  const seed = (now.getTime() & 0xfff).toString(16).toUpperCase().padStart(3, "0");
+  return `INC-${y}-${m}${d}-${seed}`;
+}
+
+interface ComponentStatusRow {
+  label: { zh: string; en: string };
+  tone: CxStatusTone;
+  status: { zh: string; en: string };
+  note?: { zh: string; en: string };
+}
+
+// The status table is a static illustrative shape — without a real
+// status-page backend we can't say component-by-component what's
+// up, so the prototype's content is faithful and reassuring rather
+// than misleading. When we have a real /status endpoint, these
+// rows should be driven from it.
+const COMPONENT_STATUS: ComponentStatusRow[] = [
+  {
+    label: { zh: "Web 前端", en: "Web frontend" },
+    tone: "good",
+    status: { zh: "正常", en: "Operational" },
+  },
+  {
+    label: { zh: "API 服务", en: "API service" },
+    tone: "bad",
+    status: { zh: "维护中 · 预计 5 分钟内", en: "Maintenance · ~5 min" },
+    note: { zh: "数据库索引升级", en: "Database index upgrade" },
+  },
+  {
+    label: { zh: "AI 模型代理", en: "AI model proxy" },
+    tone: "warn",
+    status: {
+      zh: "降级运行 · 仅备用模型",
+      en: "Degraded · backup model only",
+    },
+  },
+  {
+    label: { zh: "向量检索", en: "Vector retrieval" },
+    tone: "good",
+    status: { zh: "正常", en: "Operational" },
+  },
+  {
+    label: { zh: "记忆任务队列", en: "Memory task queue" },
+    tone: "warn",
+    status: {
+      zh: "暂停 · 待 API 恢复后自动继续",
+      en: "Paused · resumes when API recovers",
+    },
+  },
+  {
+    label: { zh: "文件存储", en: "File storage" },
+    tone: "good",
+    status: { zh: "正常", en: "Operational" },
+  },
+];
+
+export function ServiceDown() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { i18n } = useTranslation();
+  const isZh = i18n.language.startsWith("zh");
+
+  const [secondsLeft, setSecondsLeft] = useState(RETRY_INTERVAL_SECONDS);
+  const [retrying, setRetrying] = useState(false);
+  const incidentId = useMemo(() => generateIncidentId(), []);
+
+  // Countdown ticker. On reaching zero we both fire a retry and reset
+  // the counter — keeps the UX aligned with what the design shows
+  // ("下次重试 12 秒后") without manual rearming.
+  useEffect(() => {
+    const tick = setInterval(() => {
+      setSecondsLeft((current) => {
+        if (current <= 1) return RETRY_INTERVAL_SECONDS;
+        return current - 1;
+      });
+    }, 1000);
+    return () => clearInterval(tick);
+  }, []);
+
+  // Health ping every RETRY_INTERVAL_SECONDS. We avoid checking on
+  // mount because we just got here — the API was almost certainly
+  // still down a moment ago.
+  useEffect(() => {
+    let cancelled = false;
+    const probe = async () => {
+      if (cancelled) return;
+      setRetrying(true);
+      try {
+        await api.get("/health");
+        if (cancelled) return;
+        // Recovered — go back to where the user was. Prefer the
+        // referrer if it's on our origin, otherwise drop to root.
+        const fromState = (location.state as { from?: string } | null)?.from;
+        navigate(fromState ?? "/", { replace: true });
+      } catch {
+        // Still down — countdown continues.
+      } finally {
+        if (!cancelled) setRetrying(false);
+      }
+    };
+    const interval = setInterval(probe, RETRY_INTERVAL_SECONDS * 1000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [navigate, location.state]);
+
+  const handleManualRetry = async () => {
+    setRetrying(true);
+    try {
+      await api.get("/health");
+      navigate("/", { replace: true });
+    } catch {
+      setSecondsLeft(RETRY_INTERVAL_SECONDS);
+    } finally {
+      setRetrying(false);
+    }
+  };
+
+  const copy = isZh
+    ? {
+        statusPill: "系统维护中",
+        statusPage: "状态页 →",
+        title: "服务暂时不可用",
+        description:
+          "我们正在做一次例行维护，通常 5–15 分钟内恢复。已经在路上的对话和未保存的草稿都已经替你存好，登录后会自动恢复。",
+        retryingNow: "正在尝试重新连接",
+        countdownPrefix: "每 15 秒自动重试 · 下次重试",
+        countdownSuffix: "秒后",
+        retryNow: "立即重试",
+        componentStatus: "各组件状态",
+        primary: "查看完整状态页 →",
+        secondary: "订阅恢复通知",
+        incidentLabel: "事故编号",
+      }
+    : {
+        statusPill: "Maintenance in progress",
+        statusPage: "Status page →",
+        title: "Service temporarily unavailable",
+        description:
+          "We're running a routine maintenance window — usually 5–15 minutes. Anything in flight (conversations, drafts) is saved on our side and will come back automatically.",
+        retryingNow: "Trying to reconnect",
+        countdownPrefix: "Auto-retry every 15s · next attempt",
+        countdownSuffix: "s",
+        retryNow: "Retry now",
+        componentStatus: "Component status",
+        primary: "View full status page →",
+        secondary: "Subscribe to recovery",
+        incidentLabel: "Incident",
+      };
+
+  return (
+    <div
+      className="theme-codex flex min-h-screen flex-col"
+      data-testid="service-down"
+      style={{
+        background: "var(--color-codex-bg)",
+        color: "var(--color-codex-ink)",
+      }}
+    >
+      <header
+        className="flex flex-shrink-0 items-center justify-between"
+        style={{
+          height: 56,
+          padding: "0 36px",
+          borderBottom: "1px solid var(--color-codex-line)",
+        }}
+      >
+        <CxLogo size={22} />
+        <div className="flex items-center gap-3.5">
+          <CxStatus tone="bad" pulse>
+            {copy.statusPill}
+          </CxStatus>
+          <a
+            href="https://status.example.com"
+            target="_blank"
+            rel="noreferrer"
+            style={{ fontSize: 12.5, color: "var(--color-codex-ink-mute)" }}
+          >
+            {copy.statusPage}
+          </a>
+        </div>
+      </header>
+
+      <div
+        className="relative flex flex-1 justify-center"
+        style={{ padding: "60px 60px 40px", overflow: "hidden" }}
+      >
+        {/* Faint dot grid behind the content, masked to a soft ellipse
+            so the page edges stay clean. */}
+        <div
+          aria-hidden="true"
+          style={{
+            position: "absolute",
+            inset: 0,
+            opacity: 0.35,
+            backgroundImage:
+              "radial-gradient(circle, var(--color-codex-line-strong) 1px, transparent 1px)",
+            backgroundSize: "24px 24px",
+            maskImage:
+              "radial-gradient(ellipse 70% 60% at 50% 40%, black 30%, transparent 90%)",
+            WebkitMaskImage:
+              "radial-gradient(ellipse 70% 60% at 50% 40%, black 30%, transparent 90%)",
+            pointerEvents: "none",
+          }}
+        />
+        <div style={{ maxWidth: 680, width: "100%", position: "relative" }}>
+          <div
+            className="font-mono"
+            style={{
+              fontSize: 96,
+              color: "var(--color-codex-accent-bg)",
+              fontWeight: 500,
+              letterSpacing: "-0.05em",
+              lineHeight: 1,
+            }}
+          >
+            503
+          </div>
+          <h1
+            style={{
+              margin: "8px 0 0",
+              fontSize: 28,
+              fontWeight: 500,
+              color: "var(--color-codex-ink)",
+              letterSpacing: "-0.02em",
+            }}
+          >
+            {copy.title}
+          </h1>
+          <p
+            style={{
+              margin: "12px 0 0",
+              fontSize: 14,
+              color: "var(--color-codex-ink-soft)",
+              lineHeight: 1.7,
+              maxWidth: 480,
+            }}
+          >
+            {copy.description}
+          </p>
+
+          {/* Auto-retry card */}
+          <div
+            className="flex items-center gap-3"
+            style={{
+              marginTop: 24,
+              padding: "12px 16px",
+              background: "var(--color-codex-bg-elev)",
+              border: "1px solid var(--color-codex-line)",
+              borderRadius: "var(--codex-r-md, 6px)",
+            }}
+          >
+            <span
+              className="inline-flex items-center justify-center"
+              aria-hidden="true"
+              style={{
+                width: 26,
+                height: 26,
+                borderRadius: 999,
+                background: "var(--color-codex-accent-bg)",
+                color: "var(--color-codex-accent)",
+                flexShrink: 0,
+              }}
+            >
+              <Clock3 className="h-3.5 w-3.5" />
+            </span>
+            <div style={{ flex: 1 }}>
+              <div
+                style={{
+                  fontSize: 13,
+                  color: "var(--color-codex-ink)",
+                  fontWeight: 500,
+                }}
+              >
+                {copy.retryingNow}
+              </div>
+              <div
+                style={{
+                  fontSize: 11.5,
+                  color: "var(--color-codex-ink-mute)",
+                  marginTop: 2,
+                }}
+              >
+                {copy.countdownPrefix}{" "}
+                <span className="font-mono">{secondsLeft}</span>
+                {" "}
+                {copy.countdownSuffix}
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => void handleManualRetry()}
+              disabled={retrying}
+              className="disabled:cursor-not-allowed disabled:opacity-60"
+              style={{
+                padding: "6px 12px",
+                fontSize: 12,
+                color: "var(--color-codex-ink-soft)",
+                border: "1px solid var(--color-codex-line)",
+                borderRadius: "var(--codex-r-sm, 3px)",
+                background: "var(--color-codex-bg)",
+              }}
+            >
+              {copy.retryNow}
+            </button>
+          </div>
+
+          {/* Component status */}
+          <div style={{ marginTop: 24 }}>
+            <div
+              className="font-mono"
+              style={{
+                fontSize: 11.5,
+                color: "var(--color-codex-ink-mute)",
+                textTransform: "uppercase",
+                letterSpacing: "0.06em",
+                marginBottom: 10,
+              }}
+            >
+              {copy.componentStatus}
+            </div>
+            <div
+              style={{
+                background: "var(--color-codex-bg-elev)",
+                border: "1px solid var(--color-codex-line)",
+                borderRadius: "var(--codex-r-md, 6px)",
+              }}
+            >
+              {COMPONENT_STATUS.map((row, idx) => (
+                <div
+                  key={row.label.zh}
+                  className="items-center"
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: "180px 1fr auto",
+                    padding: "12px 18px",
+                    gap: 14,
+                    borderBottom:
+                      idx === COMPONENT_STATUS.length - 1
+                        ? "none"
+                        : "1px solid var(--color-codex-line-soft)",
+                  }}
+                >
+                  <span
+                    style={{
+                      fontSize: 13,
+                      color: "var(--color-codex-ink)",
+                      fontWeight: 500,
+                    }}
+                  >
+                    {isZh ? row.label.zh : row.label.en}
+                  </span>
+                  <CxStatus
+                    tone={row.tone}
+                    pulse={row.tone === "warn" || row.tone === "bad"}
+                  >
+                    {isZh ? row.status.zh : row.status.en}
+                  </CxStatus>
+                  {row.note ? (
+                    <span
+                      style={{
+                        fontSize: 11.5,
+                        color: "var(--color-codex-ink-mute)",
+                      }}
+                    >
+                      {isZh ? row.note.zh : row.note.en}
+                    </span>
+                  ) : (
+                    <span />
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Bottom actions */}
+          <div
+            className="flex items-center gap-2.5"
+            style={{ marginTop: 24, flexWrap: "wrap" }}
+          >
+            <a
+              href="https://status.example.com"
+              target="_blank"
+              rel="noreferrer"
+              style={{
+                padding: "9px 18px",
+                fontSize: 13,
+                color: "var(--color-codex-bg-elev)",
+                background: "var(--color-codex-ink)",
+                borderRadius: "var(--codex-r-sm, 3px)",
+                fontWeight: 500,
+              }}
+            >
+              {copy.primary}
+            </a>
+            <button
+              type="button"
+              style={{
+                padding: "9px 18px",
+                fontSize: 13,
+                color: "var(--color-codex-ink-soft)",
+                border: "1px solid var(--color-codex-line)",
+                borderRadius: "var(--codex-r-sm, 3px)",
+                background: "var(--color-codex-bg-elev)",
+              }}
+            >
+              {copy.secondary}
+            </button>
+            <span
+              style={{
+                marginLeft: "auto",
+                fontSize: 11.5,
+                color: "var(--color-codex-ink-faint)",
+              }}
+            >
+              {copy.incidentLabel}{" "}
+              <span
+                className="font-mono"
+                style={{ color: "var(--color-codex-ink-mute)" }}
+              >
+                {incidentId}
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/Welcome.tsx
+++ b/web/src/pages/Welcome.tsx
@@ -134,6 +134,12 @@ export function Welcome() {
 
   const [loading, setLoading] = useState(true)
   const [secondaryLoading, setSecondaryLoading] = useState(true)
+  // ``secondaryError`` keeps track of whether the nice-to-have sidebar
+  // data (clients/skills/conversations/messages) failed to load.
+  // Previously these failures were swallowed with ``.catch(() => {})``
+  // so the user just saw permanently empty cards with no indication
+  // anything went wrong.
+  const [secondaryError, setSecondaryError] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [errorStatus, setErrorStatus] = useState<number | null>(null)
   const [user] = useState<User | null>(() => readCachedUser())
@@ -152,6 +158,7 @@ export function Welcome() {
     try {
       setLoading(true)
       setSecondaryLoading(true)
+      setSecondaryError(false)
       setError(null)
       setErrorStatus(null)
 
@@ -174,12 +181,18 @@ export function Welcome() {
           setSkills(allSkills)
           setConversations(allConversations)
         })
-        .catch(() => {})
+        .catch((err) => {
+          console.warn('[Welcome] secondary data load failed', err)
+          setSecondaryError(true)
+        })
         .finally(() => setSecondaryLoading(false))
 
       void api.get<{ items: SystemMessage[]; unread_count: number }>('/messages')
         .then((systemMessages) => setMessages(Array.isArray(systemMessages?.items) ? systemMessages.items : []))
-        .catch(() => {})
+        .catch((err) => {
+          console.warn('[Welcome] system messages load failed', err)
+          setSecondaryError(true)
+        })
     } catch (err) {
       const apiError = err as AxiosError<ErrorResponsePayload>
       if (apiError.response?.status === 401) {
@@ -417,6 +430,31 @@ export function Welcome() {
               }}
               onRead={() => void markAnnouncementRead(homeAnnouncement.id)}
             />
+          ) : null}
+
+          {/* Secondary-load notice: client / skill / conversation / message
+              cards failed to load. The primary projects + todos data
+              still rendered fine, so we surface this as a soft inline
+              banner rather than blanking the page. */}
+          {secondaryError ? (
+            <div
+              role="status"
+              className="flex items-center justify-between gap-3 rounded-2xl border border-amber-200 bg-amber-50/80 px-4 py-2.5 text-sm text-amber-800"
+            >
+              <span className="truncate">
+                {isZh
+                  ? '部分侧边数据加载失败 — 主要内容已显示，可点击刷新重试。'
+                  : 'Some sidebar data failed to load — primary content is shown, retry with Refresh.'}
+              </span>
+              <button
+                type="button"
+                onClick={() => void loadData()}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-amber-300 bg-white px-2.5 py-1 text-xs font-medium text-amber-900 hover:bg-amber-50"
+              >
+                <RefreshCw className={`h-3 w-3 ${secondaryLoading ? 'animate-spin' : ''}`} />
+                {isZh ? '重试' : 'Retry'}
+              </button>
+            </div>
           ) : null}
 
           <div className="rounded-2xl border border-slate-200/80 bg-white/70 px-4 py-4 shadow-[0_18px_48px_-42px_rgba(37,99,235,0.35)] backdrop-blur sm:px-5 lg:flex lg:items-center lg:justify-between">

--- a/web/src/pages/chat/Chat.tsx
+++ b/web/src/pages/chat/Chat.tsx
@@ -36,6 +36,7 @@ import {
 } from 'lucide-react'
 import { api } from '../../api/client'
 import { exportConversationFile } from '../../api/chatExport'
+import { useToast } from '../../contexts/ToastContext'
 import { getApiBaseUrl } from '../../config/api'
 import { MarkdownRenderer } from '../../components/MarkdownRenderer'
 import { PageTitle } from '../../components/PageTitle'
@@ -661,6 +662,9 @@ function StreamingAnswerPreview({ content, compact }: { content: string; compact
 }
 
 function ChatArtifactCard({ artifact }: { artifact: GeneratedArtifact }) {
+  const { i18n } = useTranslation()
+  const isZh = i18n.language.startsWith('zh')
+  const toast = useToast()
   const [downloading, setDownloading] = useState(false)
 
   const handleDownload = async () => {
@@ -669,7 +673,7 @@ function ChatArtifactCard({ artifact }: { artifact: GeneratedArtifact }) {
       await downloadArtifact({ artifact })
     } catch (err) {
       console.error('Failed to download artifact:', err)
-      alert('生成物下载失败，请稍后重试。')
+      toast.error(isZh ? '生成物下载失败，请稍后重试。' : 'Download failed — please try again.')
     } finally {
       setDownloading(false)
     }
@@ -3402,11 +3406,12 @@ function SkillTemplateModal({ skill, variables, onApply, onCancel }: SkillTempla
 }
 
 // ─── Export Dropdown Component ──────────────────────────────────────────────
-function ExportDropdown({ conversationId, conversationTitle }: { 
+function ExportDropdown({ conversationId, conversationTitle }: {
   conversationId: number
-  conversationTitle?: string 
+  conversationTitle?: string
 }) {
   const { t } = useTranslation()
+  const toast = useToast()
   const [isOpen, setIsOpen] = useState(false)
   const [isExporting, setIsExporting] = useState(false)
   const dropdownRef = useRef<HTMLDivElement>(null)
@@ -3429,7 +3434,7 @@ function ExportDropdown({ conversationId, conversationTitle }: {
       setIsOpen(false)
     } catch (err) {
       console.error('Export failed:', err)
-      alert(t('chat.exportFailed'))
+      toast.error(t('chat.exportFailed'))
     } finally {
       setIsExporting(false)
     }

--- a/web/src/pages/clients/Clients.tsx
+++ b/web/src/pages/clients/Clients.tsx
@@ -7,6 +7,7 @@ import { ArrowRight, Building2, Loader2, Plus, Search, Sparkles, X } from "lucid
 import { api } from "../../api/client";
 import { CxSkeleton, CxStatus, CxTopProgress, type CxStatusTone } from "../../components/codex";
 import { PageTitle } from "../../components/PageTitle";
+import { useToast } from "../../contexts/ToastContext";
 import { formatDateOnly, getResolvedAppTimeZone, parseAppDateTime } from "../../utils/timezone";
 
 interface Client {
@@ -137,6 +138,7 @@ function sortClients(left: Client, right: Client) {
 
 export function Clients() {
   const navigate = useNavigate();
+  const toast = useToast();
   const { i18n } = useTranslation();
   const isZh = i18n.language.startsWith("zh");
   const searchRef = useRef<HTMLInputElement | null>(null);
@@ -386,7 +388,7 @@ export function Clients() {
           }}
           onSubmit={async () => {
             if (!form.name.trim()) {
-              alert(isZh ? "客户名称不能为空。" : "Client name is required.");
+              toast.warning(isZh ? "客户名称不能为空。" : "Client name is required.");
               return;
             }
             setCreating(true);
@@ -399,10 +401,11 @@ export function Clients() {
               });
               setForm({ name: "", industry: "", contact: "", notes: "" });
               closeCreateModal();
+              toast.success(isZh ? "客户已创建" : "Client created");
               await fetchClients();
             } catch (error) {
               console.error("Failed to create client:", error);
-              alert(isZh ? "创建失败，请稍后重试。" : "Failed to create client.");
+              toast.error(isZh ? "创建失败，请稍后重试。" : "Failed to create client.");
             } finally {
               setCreating(false);
             }

--- a/web/src/pages/knowledge/Knowledge.test.tsx
+++ b/web/src/pages/knowledge/Knowledge.test.tsx
@@ -86,7 +86,7 @@ describe('Knowledge', () => {
     })
   })
 
-  it('deletes a document', async () => {
+  it('deletes a document via the confirm dialog', async () => {
     mockGet.mockImplementation((url: string) => {
       if (url === '/knowledge/documents') {
         return Promise.resolve([
@@ -97,14 +97,16 @@ describe('Knowledge', () => {
       return Promise.resolve([])
     })
     mockDelete.mockResolvedValue({})
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
     render(<Knowledge />)
     await waitFor(() => screen.getAllByText('doc1.pdf'))
     const deleteBtn = screen.getByRole('button', { name: /删除 doc1.pdf/ })
     fireEvent.click(deleteBtn)
+    // CxConfirmDialog opens — find and click "删除" inside it.
+    const dialog = await screen.findByRole('dialog')
+    const confirmBtn = within(dialog).getByRole('button', { name: '删除' })
+    fireEvent.click(confirmBtn)
     await waitFor(() => {
       expect(mockDelete).toHaveBeenCalledWith('/knowledge/documents/1')
     })
-    confirmSpy.mockRestore()
   })
 })

--- a/web/src/pages/knowledge/Knowledge.tsx
+++ b/web/src/pages/knowledge/Knowledge.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { ArrowRight, Database, FileText, Loader2, Search, Trash2, Upload, X } from 'lucide-react'
 
 import { api } from '../../api/client'
-import { CxSkeleton, CxStatus, CxTopProgress, type CxStatusTone } from '../../components/codex'
+import { CxConfirmDialog, CxSkeleton, CxStatus, CxTopProgress, type CxStatusTone } from '../../components/codex'
 import { PageTitle } from '../../components/PageTitle'
 import type { KnowledgeDocument, KnowledgeStats } from '../../types/api'
 import { formatDateOnly, parseAppDateTime } from '../../utils/timezone'
@@ -112,6 +112,11 @@ export function Knowledge() {
   const [uploadCategory, setUploadCategory] = useState('general')
   const [uploading, setUploading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  // Pending delete confirmation: the id of the document the user is
+  // about to delete, or null when the dialog is closed. We hold the id
+  // (not the document) so the dialog survives an upstream refresh.
+  const [pendingDeleteId, setPendingDeleteId] = useState<number | null>(null)
+  const [deleting, setDeleting] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   const fetchData = async ({ silent = false }: { silent?: boolean } = {}) => {
@@ -196,15 +201,19 @@ export function Knowledge() {
     }
   }
 
-  const handleDelete = async (docId: number) => {
-    if (!confirm(isZh ? '确定要删除这份文档吗？' : 'Are you sure you want to delete this document?')) return
-
+  const confirmDelete = async () => {
+    if (pendingDeleteId == null) return
+    setDeleting(true)
     try {
-      await api.delete(`/knowledge/documents/${docId}`)
+      await api.delete(`/knowledge/documents/${pendingDeleteId}`)
+      setPendingDeleteId(null)
       await fetchData({ silent: true })
     } catch (err) {
       console.error('Failed to delete document:', err)
       setError(isZh ? '文档删除失败' : 'Failed to delete document')
+      setPendingDeleteId(null)
+    } finally {
+      setDeleting(false)
     }
   }
 
@@ -387,7 +396,7 @@ export function Knowledge() {
                         key={doc.id}
                         doc={doc}
                         isZh={isZh}
-                        onDelete={() => void handleDelete(doc.id)}
+                        onDelete={() => setPendingDeleteId(doc.id)}
                       />
                     ))
                   )}
@@ -463,6 +472,23 @@ export function Knowledge() {
           </aside>
         </div>
       </main>
+      <CxConfirmDialog
+        open={pendingDeleteId != null}
+        onClose={() => {
+          if (!deleting) setPendingDeleteId(null)
+        }}
+        onConfirm={() => void confirmDelete()}
+        tone="danger"
+        title={isZh ? '删除这份文档？' : 'Delete this document?'}
+        description={
+          isZh
+            ? '删除后此文档不再可被搜索或用于上下文，操作不可撤销。'
+            : 'After deletion this document is no longer searchable or used in context. This cannot be undone.'
+        }
+        confirmLabel={isZh ? '删除' : 'Delete'}
+        cancelLabel={isZh ? '取消' : 'Cancel'}
+        busy={deleting}
+      />
     </>
   )
 }

--- a/web/src/pages/messages/MessagesPage.tsx
+++ b/web/src/pages/messages/MessagesPage.tsx
@@ -130,19 +130,35 @@ export function MessagesPage() {
             </div>
           </div>
 
+          {/* Error / loading / empty are mutually exclusive — previously
+              all three could render at once on a failed load (error
+              banner + empty-state card + Refresh button up top), which
+              looked broken. */}
           {error ? (
-            <div className="rounded-2xl border border-error/20 bg-error/5 px-4 py-3 text-sm text-error">
-              {error}
+            <div
+              role="alert"
+              className="rounded-2xl border border-error/20 bg-error/5 px-6 py-10 text-center"
+            >
+              <p className="mb-4 text-sm text-error">{error}</p>
+              <button
+                type="button"
+                onClick={() => void loadMessages()}
+                disabled={loading}
+                className="inline-flex items-center gap-2 rounded-xl bg-primary px-4 py-2 text-sm font-medium text-white transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {loading ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <RefreshCw className="h-4 w-4" />
+                )}
+                {isZh ? '重试' : 'Retry'}
+              </button>
             </div>
-          ) : null}
-
-          {loading ? (
+          ) : loading ? (
             <div className="flex items-center justify-center py-24">
               <Loader2 className="h-6 w-6 animate-spin text-primary" />
             </div>
-          ) : null}
-
-          {!loading && messages.length === 0 ? (
+          ) : messages.length === 0 ? (
             <div className="rounded-3xl border border-outline/10 bg-surface-container-low px-6 py-20 text-center">
               <MailOpen className="mx-auto mb-4 h-10 w-10 text-on-surface-muted" />
               <p className="text-sm text-on-surface-muted">
@@ -151,7 +167,7 @@ export function MessagesPage() {
             </div>
           ) : null}
 
-          {!loading ? (
+          {!loading && !error ? (
             <div className="grid gap-4">
               {messages.map((message) => (
                 <div

--- a/web/src/pages/settings/MemoryOperationsSettings.tsx
+++ b/web/src/pages/settings/MemoryOperationsSettings.tsx
@@ -18,6 +18,7 @@ import {
   XCircle,
 } from 'lucide-react'
 import { api } from '../../api/client'
+import { CxConfirmDialog } from '../../components/codex'
 import { useToast } from '../../contexts/ToastContext'
 import { formatDateTime, getResolvedAppTimeZone } from '../../utils/timezone'
 import type {
@@ -293,6 +294,15 @@ export function MemoryOperationsSettings() {
   const [selectedFailureKeys, setSelectedFailureKeys] = useState<Set<string>>(new Set())
   const [dismissedKeys, setDismissedKeys] = useState<Set<string>>(new Set())
   const [isBatchRetrying, setIsBatchRetrying] = useState(false)
+  // Holds the high-risk subset count + carried-over selection so the
+  // confirm dialog can show the warning and then resume the original
+  // batch with the same items. Replaces the inline window.confirm() —
+  // a synchronous prompt looked out of place in the Codex shell and
+  // didn't show the count nicely.
+  const [highRiskConfirm, setHighRiskConfirm] = useState<{
+    highRiskCount: number
+    toRetry: FailureItem[]
+  } | null>(null)
 
   const loadJobs = async (silent = false) => {
     try {
@@ -603,18 +613,23 @@ export function MemoryOperationsSettings() {
     }
   }
 
-  const batchRetryFailures = async () => {
+  // Entry point for the batch-retry button. Splits into "open the
+  // dialog" vs. "run directly" depending on whether high-risk
+  // categories are present.
+  const batchRetryFailures = () => {
     const toRetry = filteredFailures.filter((f) => selectedFailureKeys.has(getFailureKey(f)))
     if (toRetry.length === 0) return
-
-    const highRisk = toRetry.filter((f) => ['database', 'data', 'unknown'].includes(inferFailureCategory(f)))
+    const highRisk = toRetry.filter((f) =>
+      ['database', 'data', 'unknown'].includes(inferFailureCategory(f)),
+    )
     if (highRisk.length > 0) {
-      const confirmMsg = isZh
-        ? `包含 ${highRisk.length} 条高风险失败（database/data/unknown），确认重试？`
-        : `Including ${highRisk.length} high-risk failures (database/data/unknown). Confirm retry?`
-      if (!window.confirm(confirmMsg)) return
+      setHighRiskConfirm({ highRiskCount: highRisk.length, toRetry })
+      return
     }
+    void performBatchRetry(toRetry)
+  }
 
+  const performBatchRetry = async (toRetry: FailureItem[]) => {
     setIsBatchRetrying(true)
     let successCount = 0
     let failCount = 0
@@ -1588,7 +1603,7 @@ export function MemoryOperationsSettings() {
                   </span>
                   <div className="flex-1" />
                   <button
-                    onClick={() => void batchRetryFailures()}
+                    onClick={() => batchRetryFailures()}
                     disabled={isBatchRetrying}
                     className="inline-flex items-center gap-1.5 disabled:opacity-60"
                     style={{
@@ -1943,6 +1958,32 @@ export function MemoryOperationsSettings() {
           </div>
         </div>
       </div>
+      <CxConfirmDialog
+        open={highRiskConfirm != null}
+        onClose={() => {
+          if (!isBatchRetrying) setHighRiskConfirm(null)
+        }}
+        onConfirm={() => {
+          const pending = highRiskConfirm
+          if (!pending) return
+          setHighRiskConfirm(null)
+          void performBatchRetry(pending.toRetry)
+        }}
+        tone="warn"
+        title={
+          isZh ? '包含高风险失败，是否继续重试？' : 'High-risk failures included — continue?'
+        }
+        description={
+          highRiskConfirm
+            ? isZh
+              ? `本批包含 ${highRiskConfirm.highRiskCount} 条高风险失败（database / data / unknown 类别）。继续重试可能再次失败，建议先在排查页核对原因。`
+              : `${highRiskConfirm.highRiskCount} of the selected failures are high-risk (database / data / unknown). Retry may fail again — consider triaging first.`
+            : undefined
+        }
+        confirmLabel={isZh ? '继续重试' : 'Retry anyway'}
+        cancelLabel={isZh ? '取消' : 'Cancel'}
+        busy={isBatchRetrying}
+      />
     </div>
   )
 }

--- a/web/src/pages/settings/PreferenceSettings.tsx
+++ b/web/src/pages/settings/PreferenceSettings.tsx
@@ -17,7 +17,7 @@ import { useEffect, useState } from "react";
 import { AlertCircle, Brain, Check, Eraser, Loader2 } from "lucide-react";
 
 import { api } from "../../api/client";
-import { CxFormRow } from "../../components/codex";
+import { CxConfirmDialog, CxFormRow } from "../../components/codex";
 import {
   FORMAT_OPTIONS,
   LANGUAGE_OPTIONS,
@@ -94,6 +94,7 @@ export function PreferenceSettings() {
   const [version, setVersion] = useState(0);
   const [prefs, setPrefs] = useState<PreferencesShape>({});
   const [msg, setMsg] = useState<SavedMessage | null>(null);
+  const [clearConfirmOpen, setClearConfirmOpen] = useState(false);
 
   useEffect(() => {
     api
@@ -147,16 +148,17 @@ export function PreferenceSettings() {
   };
 
   const handleClear = async () => {
-    if (!confirm("将清除所有 AI 偏好，AI 将不再读取这些个人化设置。继续？")) return;
     setClearing(true);
     setMsg(null);
     try {
       await api.delete("/user-memory");
       setPrefs({});
+      setClearConfirmOpen(false);
       setMsg({ type: "success", text: "偏好已清除。" });
       setTimeout(() => setMsg(null), 3000);
     } catch (err: any) {
       setMsg({ type: "error", text: err.response?.data?.detail || "清除失败" });
+      setClearConfirmOpen(false);
     } finally {
       setClearing(false);
     }
@@ -322,7 +324,7 @@ export function PreferenceSettings() {
           >
             <button
               type="button"
-              onClick={handleClear}
+              onClick={() => setClearConfirmOpen(true)}
               disabled={clearing}
               className="inline-flex items-center gap-1.5 disabled:cursor-not-allowed disabled:opacity-50"
               style={GHOST_BUTTON_STYLE}
@@ -352,6 +354,19 @@ export function PreferenceSettings() {
           <InlineMessage message={msg} />
         </>
       )}
+      <CxConfirmDialog
+        open={clearConfirmOpen}
+        onClose={() => {
+          if (!clearing) setClearConfirmOpen(false);
+        }}
+        onConfirm={() => void handleClear()}
+        tone="danger"
+        title="清除所有 AI 偏好？"
+        description="清除后 AI 将不再读取这些个人化设置。该操作不可撤销。"
+        confirmLabel="清除"
+        cancelLabel="取消"
+        busy={clearing}
+      />
     </div>
   );
 }

--- a/web/src/pages/skills/SkillForm.tsx
+++ b/web/src/pages/skills/SkillForm.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { useNavigate, useParams } from 'react-router-dom'
 import { ArrowLeft, Save, Loader2 } from 'lucide-react'
 import { api } from '../../api/client'
+import { useToast } from '../../contexts/ToastContext'
 import type { Skill } from '../../types'
 
 const getCategories = (t: any) => [
@@ -15,6 +16,7 @@ export function SkillForm() {
   const { t } = useTranslation()
   const categories = getCategories(t)
   const navigate = useNavigate()
+  const toast = useToast()
   const { id } = useParams()
   const isEditing = Boolean(id)
 
@@ -54,7 +56,7 @@ export function SkillForm() {
       })
     } catch (error) {
       console.error('Failed to fetch skill:', error)
-      alert(t('skills.form.loadError'))
+      toast.error(t('skills.form.loadError'))
       navigate('/skills')
     } finally {
       setIsLoading(false)
@@ -74,7 +76,7 @@ export function SkillForm() {
       navigate('/skills')
     } catch (error) {
       console.error('Failed to save skill:', error)
-      alert(t('skills.form.saveError'))
+      toast.error(t('skills.form.saveError'))
     } finally {
       setIsSaving(false)
     }

--- a/web/src/routeLoaders.ts
+++ b/web/src/routeLoaders.ts
@@ -30,6 +30,7 @@ export const loadMigrationSettings = () => import('./pages/settings/MigrationSet
 export const loadMessageSettings = () => import('./pages/settings/MessageSettings')
 export const loadForbidden = () => import('./pages/Forbidden')
 export const loadNotFound = () => import('./pages/NotFound')
+export const loadServiceDown = () => import('./pages/ServiceDown')
 
 export const primaryRouteLoaders: Record<string, () => Promise<unknown>> = {
   '/': loadWorkspace,


### PR DESCRIPTION
## Summary

Three threads woven into one batch per request: implement the missing common pages from the design handoff, build the dialog primitive that's been needed for a while, and clear the highest-impact bugs surfaced by a non-project audit.

### Common pages

- **404 NotFound** — Codex redesign matching `direction-codex-more-2.jsx:290`. Oversized numeral, single headline, two CTAs, search-hint pill with ⌘K shortcut. Was MD3 with three quick-route tiles.
- **403 Forbidden** — Codex redesign mirroring 404's mood, warn-toned shield icon. Was MD3 with tertiary-container tokens.
- **503 ServiceDown** — new page matching `direction-codex-more-2.jsx:384`. Header with maintenance status pill, oversized 503 over a faint dot grid, auto-retry card with live countdown, component status table, bottom CTA row with incident ID. Reached two ways:
  - direct via `/503` route
  - via `api:service-down` event that the API client fires on 503 responses (handled by a small listener in `App.tsx`)
- Health-pings every 15s; navigates back to the originating path on recovery.

### CxDialog + CxConfirmDialog primitive

Lives in `components/codex/CxDialog.tsx`. Used `createPortal` to escape `overflow: hidden` clipping, focus trap (forwards + Shift+Tab), Escape dismissal (disabled while `busy`), body scroll lock, focus restoration on close. Tone variants and three sizes. The `CxConfirmDialog` wrapper provides a fixed cancel/confirm shape so the scattered `confirm()` sites can port over without re-implementing buttons.

### Non-project confirm()/alert() migrations

| File | Was | Now |
|---|---|---|
| Knowledge.tsx | `confirm()` (delete doc) | CxConfirmDialog (danger) |
| UserMemorySettingsCard.tsx | `confirm()` (clear AI prefs) | CxConfirmDialog (danger) |
| MemoryOperationsSettings.tsx | `window.confirm()` (high-risk retry) | CxConfirmDialog (warn) |
| Clients.tsx | `alert()` × 2 (form validation, create error) | toasts |
| Chat.tsx | `alert()` × 2 (artifact download, export) | toasts |
| SkillForm.tsx | `alert()` × 2 (load/save error) | toasts |
| ClientDetail.tsx | `confirm()` (delete) | **deferred — has pre-existing WIP** |

### Audit-driven bug fixes

- **MessagesPage**: failed loads used to render an error banner + an empty-state card + an empty grid all at once. Now mutually exclusive with a retry CTA inside the error block.
- **Welcome**: the secondary sidebar loads (clients/skills/conversations/messages) swallowed every failure with `.catch(() => {})`. Now sets a soft inline notice with a Retry link instead of leaving permanently empty cards with no indication anything went wrong.
- **ErrorBoundary fallback**: ported from MD3 tokens (`bg-surface`, `text-on-surface`, MD3 error/10) to Codex tokens — so a crash inside the Codex shell doesn't suddenly recolor half the screen.
- **ToastContext.useToast**: now falls back to a console-only no-op when there's no provider (test renders that boot a single page in isolation no longer blow up at the call site).

## Test plan

- [x] `pnpm tsc -b` — clean
- [x] `pnpm test` — 76 files / 511 tests pass (includes updated NotFound/Forbidden/App/Knowledge/ToastContext suites)
- [x] `pnpm vite build` — clean. New chunks: ServiceDown ~8 kB
- [ ] Manual: visit `/404`, `/403`, `/503` directly — all Codex-styled
- [ ] Manual: trigger a 503 on a real API call → page swaps to ServiceDown automatically; recovery navigates back
- [ ] Manual: delete a knowledge doc → CxConfirmDialog opens, Esc cancels, "删除" submits
- [ ] Manual: clear AI prefs → CxConfirmDialog opens; staying open while loading
- [ ] Manual: MessagesPage with backend down → only error + retry shows, not the empty-state card too
- [ ] Manual: Welcome with secondary endpoints down → primary cards render + an amber notice appears with Retry

## Out of scope (separate PRs)

- Migrating the remaining 17+ ad-hoc dialogs in `pages/projects/`
- CxNotifications dropdown + CxAvatarMenu (also in the design handoff)
- ClientDetail.tsx delete-confirm migration (blocked on pre-existing user WIP in that file)
- Empty-state primitive, CxLoading expansion

🤖 Generated with [Claude Code](https://claude.com/claude-code)