### PR TITLE
perf: single-shot contact detail fetch (kill N+1 stakeholder fan-out)

### DIFF
--- a/backend/app/routers/contacts.py
+++ b/backend/app/routers/contacts.py
@@ -1,0 +1,135 @@
+"""Cross-client contact lookup endpoints.
+
+The original frontend stakeholder routes are all scoped under
+``/clients/{client_id}/stakeholders/...``, which forces the contact
+detail page to fetch the entire client list and then walk every
+client's stakeholders to find one by ID. Production showed this as
+~12 sequential ``stakeholders`` XHRs taking ~6 s on contacts/3.
+
+This router gives the contact detail page a single round-trip:
+``GET /contacts/{stakeholder_id}`` returns the stakeholder, its
+parent client (in the same shape as ``/clients`` list items), the
+sibling stakeholders, projects, and recent history. The page makes
+one call instead of N.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlmodel import Session, select
+
+from app.database import get_session
+from app.models.db import (
+    ClientRecord,
+    ClientStakeholder,
+    ClientStakeholderHistory,
+    KnowledgeDocument,
+    Project,
+)
+from app.routers.clients_deps import (
+    ClientOut,
+    ClientStakeholderOut,
+    _build_client_out,
+    _normalized_name,
+    _serialize_client_stakeholder,
+)
+
+router = APIRouter(tags=["contacts"])
+
+
+class ContactProjectOut(BaseModel):
+    id: int
+    name: str
+    status: str
+    contract_amount: float | None = None
+    memory_version: int | None = None
+    memory_stale: bool | None = None
+
+
+class ContactHistoryOut(BaseModel):
+    id: int
+    field_name: str
+    old_value: str
+    new_value: str
+    trigger: str
+    changed_at: str | None = None
+
+
+class ContactDetailOut(BaseModel):
+    client: ClientOut
+    stakeholder: ClientStakeholderOut
+    sibling_stakeholders: list[ClientStakeholderOut]
+    projects: list[ContactProjectOut]
+    history: list[ContactHistoryOut]
+
+
+@router.get("/{stakeholder_id}", response_model=ContactDetailOut)
+def get_contact(stakeholder_id: int, session: Session = Depends(get_session)) -> ContactDetailOut:
+    stakeholder = session.get(ClientStakeholder, stakeholder_id)
+    if not stakeholder:
+        raise HTTPException(status_code=404, detail="Contact not found")
+    client = session.get(ClientRecord, stakeholder.client_id)
+    if not client:
+        # Orphaned stakeholder — shouldn't happen because of the FK, but
+        # better to 404 explicitly than blow up in the serializer.
+        raise HTTPException(status_code=404, detail="Contact's client is missing")
+
+    # Sibling stakeholders for the side rail. Same ordering as
+    # ``list_client_stakeholders`` so the column matches what the
+    # /clients/{id}/stakeholders endpoint would return.
+    siblings = session.exec(
+        select(ClientStakeholder)
+        .where(ClientStakeholder.client_id == client.id)
+        .order_by(ClientStakeholder.updated_at.desc(), ClientStakeholder.id.desc())
+    ).all()
+
+    # Project list — mirrors ``/clients/{id}/projects``: normalized
+    # client-name match because Project.client is a free-text column,
+    # not an FK.
+    client_key = _normalized_name(client.name)
+    all_projects = session.exec(select(Project)).all()
+    matching_projects = [p for p in all_projects if _normalized_name(p.client) == client_key]
+
+    # Documents for the client-out shape (same as the /clients list).
+    docs = session.exec(
+        select(KnowledgeDocument).where(KnowledgeDocument.client_id == client.id)
+    ).all()
+    docs_by_client = {client.id: list(docs)}
+    projects_by_name = {client_key: [p.name for p in matching_projects]}
+
+    # Recent history for this stakeholder — same shape + cap as
+    # ``get_stakeholder_history``.
+    history = session.exec(
+        select(ClientStakeholderHistory)
+        .where(ClientStakeholderHistory.stakeholder_id == stakeholder_id)
+        .order_by(ClientStakeholderHistory.changed_at.desc())
+        .limit(50)
+    ).all()
+
+    return ContactDetailOut(
+        client=_build_client_out(client, docs_by_client, projects_by_name),
+        stakeholder=_serialize_client_stakeholder(stakeholder),
+        sibling_stakeholders=[_serialize_client_stakeholder(s) for s in siblings],
+        projects=[
+            ContactProjectOut(
+                id=p.id,
+                name=p.name,
+                status=p.status,
+                contract_amount=p.contract_amount,
+                memory_version=p.memory_version,
+                memory_stale=p.memory_stale,
+            )
+            for p in matching_projects
+        ],
+        history=[
+            ContactHistoryOut(
+                id=h.id,
+                field_name=h.field_name,
+                old_value=h.old_value,
+                new_value=h.new_value,
+                trigger=h.trigger,
+                changed_at=h.changed_at.isoformat() if h.changed_at else None,
+            )
+            for h in history
+        ],
+    )

--- a/backend/main.py
+++ b/backend/main.py
@@ -13,7 +13,7 @@ from app.config import (
     JWT_EXPIRATION_HOURS, SCHEDULER_ENABLED, SETTINGS_CACHE_TTL, validate_jwt_secret
 )
 from app.database import create_db, get_database_health, get_database_migration_governance, migrate_db, engine
-from app.routers import chat, projects, projects_memory, projects_files, projects_briefing, projects_tasks, knowledge, settings, skills, schedules, templates, clients, clients_memory, clients_stakeholders, artifacts, messages, memory_operations, user_memory
+from app.routers import chat, projects, projects_memory, projects_files, projects_briefing, projects_tasks, knowledge, settings, skills, schedules, templates, clients, clients_memory, clients_stakeholders, contacts, artifacts, messages, memory_operations, user_memory
 from app.routers import auth as auth_router
 from app.routers.auth import seed_admin_user
 from app.services import scheduler
@@ -267,6 +267,7 @@ app.include_router(templates.router)
 app.include_router(clients.router)
 app.include_router(clients_memory.router, prefix="/clients")
 app.include_router(clients_stakeholders.router, prefix="/clients")
+app.include_router(contacts.router, prefix="/contacts")
 app.include_router(artifacts.router)
 app.include_router(messages.router)
 app.include_router(memory_operations.router)

--- a/backend/tests/test_contacts_router.py
+++ b/backend/tests/test_contacts_router.py
@@ -1,0 +1,155 @@
+"""Integration tests for the cross-client contact lookup endpoint.
+
+Covers the optimisation that replaced the ContactDetail page's
+N+1 stakeholder fan-out (one ``/clients/{id}/stakeholders`` call per
+client) with a single ``/contacts/{id}`` round-trip.
+"""
+import unittest
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlmodel import Session, SQLModel
+
+from app.models.db import (
+    ClientRecord,
+    ClientStakeholder,
+    ClientStakeholderHistory,
+    KnowledgeDocument,
+    Project,
+)
+from app.routers import contacts as contacts_module
+from app.routers.contacts import router as contacts_router
+from tests.test_database import create_test_engine, drop_all_tables
+
+
+def _make_app(engine):
+    app = FastAPI()
+    app.include_router(contacts_router, prefix="/contacts")
+
+    def override_session():
+        with Session(engine) as session:
+            yield session
+
+    app.dependency_overrides[contacts_module.get_session] = override_session
+    return app
+
+
+class ContactsRouterTestCase(unittest.TestCase):
+    def setUp(self):
+        self.engine = create_test_engine()
+        drop_all_tables(self.engine)
+        SQLModel.metadata.create_all(self.engine)
+
+        with Session(self.engine) as session:
+            # Two clients so we can verify that GETting a contact bundles
+            # only its own client's siblings, projects, and docs.
+            client_a = ClientRecord(name="Acme Corp", industry="Insurance", contact="", notes="")
+            client_b = ClientRecord(name="Other Inc", industry="Retail", contact="", notes="")
+            session.add(client_a)
+            session.add(client_b)
+            session.commit()
+            session.refresh(client_a)
+            session.refresh(client_b)
+            self.client_a_id = client_a.id
+            self.client_b_id = client_b.id
+
+            target = ClientStakeholder(
+                client_id=client_a.id,
+                name="Vivian",
+                role="CTO",
+                organization_level="decision",
+            )
+            sibling = ClientStakeholder(
+                client_id=client_a.id,
+                name="Other Sibling",
+                role="COO",
+                organization_level="influence",
+            )
+            unrelated = ClientStakeholder(
+                client_id=client_b.id,
+                name="Should Not Appear",
+                role="CFO",
+                organization_level="decision",
+            )
+            session.add(target)
+            session.add(sibling)
+            session.add(unrelated)
+
+            # Project linked by free-text client name (matches the real
+            # join used in clients/projects).
+            session.add(Project(name="Digital Roadmap", client="Acme Corp", status="active"))
+            session.add(Project(name="Wrong Client Project", client="Other Inc", status="active"))
+
+            # A doc attached to the client so document_count comes back > 0.
+            session.add(
+                KnowledgeDocument(
+                    name="acme_brief.pdf",
+                    file_type="pdf",
+                    path="/tmp/x.pdf",
+                    category="general",
+                    client_id=client_a.id,
+                )
+            )
+
+            session.commit()
+            session.refresh(target)
+            self.target_id = target.id
+
+            # One history entry for the target so we know the bundle
+            # carries history through.
+            session.add(
+                ClientStakeholderHistory(
+                    stakeholder_id=target.id,
+                    client_id=client_a.id,
+                    field_name="role",
+                    old_value="VP",
+                    new_value="CTO",
+                    trigger="manual",
+                )
+            )
+            session.commit()
+
+    def tearDown(self):
+        SQLModel.metadata.drop_all(self.engine)
+        self.engine.dispose()
+
+    def test_get_contact_returns_bundle(self):
+        app = _make_app(self.engine)
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get(f"/contacts/{self.target_id}")
+        self.assertEqual(resp.status_code, 200, resp.text)
+        data = resp.json()
+
+        self.assertEqual(data["client"]["id"], self.client_a_id)
+        self.assertEqual(data["client"]["name"], "Acme Corp")
+        # document_count should reflect the one doc we attached.
+        self.assertEqual(data["client"]["document_count"], 1)
+        # project_names should list the Acme-only project, not Other Inc's.
+        self.assertEqual(data["client"]["project_names"], ["Digital Roadmap"])
+
+        self.assertEqual(data["stakeholder"]["id"], self.target_id)
+        self.assertEqual(data["stakeholder"]["name"], "Vivian")
+
+        # Sibling rail must include both stakeholders from client A and
+        # none from client B.
+        sibling_names = {s["name"] for s in data["sibling_stakeholders"]}
+        self.assertEqual(sibling_names, {"Vivian", "Other Sibling"})
+
+        # Projects must be scoped to the parent client.
+        project_names = {p["name"] for p in data["projects"]}
+        self.assertEqual(project_names, {"Digital Roadmap"})
+
+        # History entry for the target should round-trip.
+        self.assertEqual(len(data["history"]), 1)
+        self.assertEqual(data["history"][0]["field_name"], "role")
+        self.assertEqual(data["history"][0]["new_value"], "CTO")
+
+    def test_get_contact_missing_returns_404(self):
+        app = _make_app(self.engine)
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/contacts/999999")
+        self.assertEqual(resp.status_code, 404)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/src/pages/contacts/ContactDetail.test.tsx
+++ b/web/src/pages/contacts/ContactDetail.test.tsx
@@ -64,6 +64,19 @@ function makeClient(overrides: Partial<any> = {}) {
   }
 }
 
+// Helper for the new single-shot ``GET /contacts/{id}`` bundle that
+// replaced the old per-client stakeholder fan-out.
+function makeBundle(overrides: Partial<any> = {}) {
+  return {
+    client: makeClient(),
+    stakeholder: makeStakeholder(),
+    sibling_stakeholders: [makeStakeholder()],
+    projects: [],
+    history: [],
+    ...overrides,
+  }
+}
+
 describe('ContactDetail', () => {
   beforeEach(() => {
     mockGet.mockClear()
@@ -80,12 +93,7 @@ describe('ContactDetail', () => {
 
   it('renders contact data after loading', async () => {
     mockGet.mockImplementation((url: string) => {
-      if (url === '/clients') {
-        return Promise.resolve([makeClient()])
-      }
-      if (url === '/clients/1/stakeholders') {
-        return Promise.resolve([makeStakeholder()])
-      }
+      if (url === '/contacts/5') return Promise.resolve(makeBundle())
       return Promise.resolve({})
     })
     render(<ContactDetail />)
@@ -96,8 +104,9 @@ describe('ContactDetail', () => {
 
   it('shows not found when contact does not exist', async () => {
     mockGet.mockImplementation((url: string) => {
-      if (url === '/clients') return Promise.resolve([makeClient()])
-      if (url === '/clients/1/stakeholders') return Promise.resolve([makeStakeholder({ id: 2, name: '李四' })])
+      if (url === '/contacts/5') {
+        return Promise.reject({ response: { status: 404 } })
+      }
       return Promise.resolve({})
     })
     render(<ContactDetail />)
@@ -108,12 +117,15 @@ describe('ContactDetail', () => {
 
   it('switches tabs', async () => {
     mockGet.mockImplementation((url: string) => {
-      if (url === '/clients') return Promise.resolve([makeClient()])
-      if (url === '/clients/1/stakeholders') {
-        return Promise.resolve([makeStakeholder({ last_action: '项目例会：讨论续约推进' })])
+      if (url === '/contacts/5') {
+        return Promise.resolve(
+          makeBundle({
+            stakeholder: makeStakeholder({ last_action: '项目例会：讨论续约推进' }),
+            projects: [{ id: 9, name: 'P1', status: 'opportunity' }],
+            history: [],
+          }),
+        )
       }
-      if (url === '/clients/1/projects') return Promise.resolve([{ id: 9, name: 'P1', status: 'opportunity' }])
-      if (url === '/clients/1/stakeholders/5/history') return Promise.resolve([])
       return Promise.resolve({})
     })
     render(<ContactDetail />)

--- a/web/src/pages/contacts/ContactDetail.tsx
+++ b/web/src/pages/contacts/ContactDetail.tsx
@@ -60,6 +60,14 @@ interface ContactRecord {
   stakeholder: ClientStakeholder
 }
 
+interface ContactDetailBundle {
+  client: ClientListItem
+  stakeholder: ClientStakeholder
+  sibling_stakeholders: ClientStakeholder[]
+  projects: ClientProjectSummary[]
+  history: StakeholderHistoryEntry[]
+}
+
 type ContactDetailTab = 'overview' | 'history' | 'projects' | 'notes'
 type ContactLevel = 'decision' | 'influence' | 'execution'
 
@@ -99,35 +107,26 @@ export function ContactDetail() {
     else setLoading(true)
     setError(null)
 
+    // Single round-trip via ``GET /contacts/{id}``. Previously this page
+    // GET'd ``/clients`` and then walked the list calling
+    // ``/clients/{id}/stakeholders`` for each one until it found the
+    // target — N+1 fan-out that took ~6s on prod with ~12 clients.
     try {
-      const clients = await api.get<ClientListItem[]>('/clients')
-      const clientList = Array.isArray(clients) ? clients : []
-
-      for (const client of clientList) {
-        const stakeholdersResponse = await api.get<ClientStakeholder[]>(`/clients/${client.id}/stakeholders`)
-        const stakeholders = Array.isArray(stakeholdersResponse) ? stakeholdersResponse : []
-        const found = stakeholders.find((stakeholder) => stakeholder.id === contactId)
-
-        if (found) {
-          const [clientProjects, stakeholderHistory] = await Promise.all([
-            api.get<ClientProjectSummary[]>(`/clients/${client.id}/projects`).catch(() => []),
-            api.get<StakeholderHistoryEntry[]>(`/clients/${client.id}/stakeholders/${found.id}/history`).catch(() => []),
-          ])
-
-          setRecord({ client, stakeholder: found })
-          setClientContacts(stakeholders)
-          setProjects(Array.isArray(clientProjects) ? clientProjects : [])
-          setHistory(Array.isArray(stakeholderHistory) ? stakeholderHistory : [])
-          setEditDraft(buildEditDraft(found))
-          setLoading(false)
-          return
-        }
+      const bundle = await api.get<ContactDetailBundle>(`/contacts/${contactId}`)
+      setRecord({ client: bundle.client, stakeholder: bundle.stakeholder })
+      setClientContacts(
+        Array.isArray(bundle.sibling_stakeholders) ? bundle.sibling_stakeholders : [],
+      )
+      setProjects(Array.isArray(bundle.projects) ? bundle.projects : [])
+      setHistory(Array.isArray(bundle.history) ? bundle.history : [])
+      setEditDraft(buildEditDraft(bundle.stakeholder))
+    } catch (err: any) {
+      if (err?.response?.status === 404) {
+        setRecord(null)
+        setError(isZh ? '没有找到这个联系人' : 'Contact not found')
+      } else {
+        setError(isZh ? '联系人详情加载失败' : 'Failed to load contact detail')
       }
-
-      setRecord(null)
-      setError(isZh ? '没有找到这个联系人' : 'Contact not found')
-    } catch {
-      setError(isZh ? '联系人详情加载失败' : 'Failed to load contact detail')
     } finally {
       setLoading(false)
       setRefreshing(false)


### PR DESCRIPTION
## Summary

Fixes the slow contact detail page seen on prod (`aria.d2cgo.co/contacts/3`). DevTools showed ~12 sequential `stakeholders` XHRs taking ~6s before anything useful rendered, even though DOMContentLoaded was 2s.

### Root cause

`ContactDetail.loadContact` (`web/src/pages/contacts/ContactDetail.tsx:97`) didn't have a single-contact lookup endpoint to call, so it brute-forced:

```js
const clients = await api.get('/clients')
for (const client of clients) {                         // ← serial
  const stakeholders = await api.get(`/clients/${client.id}/stakeholders`)
  if (stakeholders.find(s => s.id === contactId)) { ... }
}
```

`for (... of ...)` + `await` is sequential, so wall time = sum of all per-client round-trips. The directory page (`Contacts.tsx`) uses `Promise.all` for the same fan-out, which is why the **list** feels fast and the **detail** feels slow despite hitting the same endpoints.

### Both fixes in one PR (you said "both"):

**Backend (the real fix):**
- New `GET /contacts/{stakeholder_id}` returns `{ client, stakeholder, sibling_stakeholders, projects, history }` in one round-trip. Reuses `ClientOut` + `ClientStakeholderOut` shapes so frontend types align.
- Lives in `backend/app/routers/contacts.py`, mounted at `/contacts/` in `main.py`.
- `test_contacts_router.py` covers the happy path (verifies siblings/projects from OTHER clients don't leak through) and a 404 for missing IDs.

**Frontend (consumes the new endpoint):**
- `ContactDetail.loadContact` is now a single `api.get('/contacts/{id}')` call.
- `try/catch` handles 404 → "没有找到这个联系人" empty state; other failures → generic error banner.
- `ContactDetail.test.tsx` mocks the new endpoint shape.

### Impact

- Frontend: N+1 XHRs → 1 XHR. Wall time ~N×RTT → ~1×RTT (~6s → ~600ms on prod with ~12 clients).
- Backend: same single bundle does the work that the N walks did. SELECTs needed per page load drop from `1 (clients) + N (stakeholders) + 2 (winner's projects + history)` → `1 stakeholder + 1 client + 1 stakeholder list + 1 docs + 1 projects + 1 history = 6 ≪ N+3`.

## Test plan

- [x] `pytest backend/tests/test_contacts_router.py` — 2/2 pass
- [x] `pytest backend/tests/` — 1290 pass, 1 skipped
- [x] `pnpm tsc -b` — clean
- [x] `pnpm test` — 76 files, 511 tests pass
- [x] `pnpm vite build` — clean
- [ ] Manual: visit `/contacts/3` on prod after deploy — should render under 1s after backend response
- [ ] Manual: visit `/contacts/99999` (unknown) — empty state shows, no crash
- [ ] Manual: sibling contact rail still lists other contacts for the same client only

🤖 Generated with [Claude Code](https://claude.com/claude-code)