### PR TITLE
perf: make /chat feel fast (split bootstrap + visible skeleton + idle-warm)

### DIFF
--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -131,7 +131,7 @@ export function Layout() {
       })
   }, [])
 
-  // Per-route bundles are still preloaded on nav-link hover/focus via
+  // Per-route bundles are preloaded on nav-link hover/focus via
   // ``primaryRouteLoaders[item.path]`` below, so the most-likely-next
   // route is already warmed up by the time the user clicks. The
   // previous blanket ``warmPrimaryRoutes()`` (which prefetched all 9
@@ -139,6 +139,27 @@ export function Layout() {
   // contention on slow connections — fast users got faster, slow users
   // got 10s+ of background traffic competing with the current page's
   // own data calls. Dropped in favor of the hover-only path.
+  //
+  // Exception: ``/chat`` is the single most common destination from the
+  // workspace and gets pre-warmed regardless of hover, scheduled on the
+  // browser's idle queue so it never competes with the current page's
+  // own data calls. Cold-cache visits to /chat used to wait for the
+  // 17.7 kB gzip chunk + its lucide-icon children before any React
+  // code ran — a noticeable stall on slow connections. If the user is
+  // already on /chat we skip (avoid a redundant import).
+  useEffect(() => {
+    if (location.pathname.startsWith('/chat')) return
+    const idle = (window as { requestIdleCallback?: (cb: () => void) => number }).requestIdleCallback
+    const schedule = idle ?? ((cb: () => void) => window.setTimeout(cb, 1200))
+    const handle = schedule(() => {
+      void primaryRouteLoaders['/chat']?.()
+    })
+    return () => {
+      const cancelIdle = (window as { cancelIdleCallback?: (h: number) => void }).cancelIdleCallback
+      if (cancelIdle) cancelIdle(handle as number)
+      else window.clearTimeout(handle as number)
+    }
+  }, [location.pathname])
 
   useEffect(() => {
     const loadUnreadCount = () => {

--- a/web/src/pages/chat/Chat.tsx
+++ b/web/src/pages/chat/Chat.tsx
@@ -1108,21 +1108,27 @@ export function Chat() {
   }, [])
 
   // ── Data fetch ────────────────────────────────────────────────────────────
+  //
+  // Previously this awaited Promise.all([conversations, projects, skills])
+  // before clearing ``isLoadingConversations``, so the sidebar skeleton
+  // stayed up until the slowest of the three arrived. The sidebar only
+  // actually needs the conversation list to render — ``projects`` and
+  // ``skills`` feed dropdowns the user only opens on demand — so we let
+  // those resolve in the background.
   const fetchInitialData = async () => {
-    try {
-      const [convsData, projectsData, skillsData] = await Promise.all([
-        api.get<Conversation[]>('/chat/conversations?standalone=true'),
-        api.get<Project[]>('/projects'),
-        api.get<Skill[]>('/skills'),
-      ])
-      setConversations(convsData)
-      setProjects(projectsData)
-      setSkills(skillsData)
-    } catch (err) {
-      console.error('Failed to fetch initial data:', err)
-    } finally {
-      setIsLoadingConversations(false)
-    }
+    void api
+      .get<Conversation[]>('/chat/conversations?standalone=true')
+      .then((convsData) => setConversations(convsData))
+      .catch((err) => console.error('Failed to fetch conversations:', err))
+      .finally(() => setIsLoadingConversations(false))
+    void api
+      .get<Project[]>('/projects')
+      .then((projectsData) => setProjects(projectsData))
+      .catch((err) => console.error('Failed to fetch projects:', err))
+    void api
+      .get<Skill[]>('/skills')
+      .then((skillsData) => setSkills(skillsData))
+      .catch((err) => console.error('Failed to fetch skills:', err))
   }
 
   const loadConversation = async (id: number, beforeId?: number) => {
@@ -1967,32 +1973,21 @@ export function Chat() {
           {/* Conversation list */}
           <div className="flex-1 overflow-auto" style={{ padding: '4px 10px 12px' }}>
             {isLoadingConversations ? (
+              // CxSkeleton shimmers between bg-tint and bg-sunken so the
+              // skeleton is actually visible on light themes. The earlier
+              // inline divs used a flat bg-tint that was effectively
+              // invisible against the page background (#efede7 on
+              // #ffffff is a ~5% luminance delta).
               <div className="pt-1">
                 {[...Array(6)].map((_, i) => (
                   <div
                     key={i}
-                    className="flex items-center gap-2 animate-pulse"
+                    className="flex items-center gap-2"
                     style={{ padding: '8px 10px' }}
                   >
-                    <div
-                      className="flex-1 space-y-1.5"
-                      style={{ minWidth: 0 }}
-                    >
-                      <div
-                        className="h-3"
-                        style={{
-                          width: `${55 + (i % 3) * 18}%`,
-                          background: 'var(--color-codex-bg-tint)',
-                          borderRadius: 2,
-                        }}
-                      />
-                      <div
-                        className="h-2 w-12"
-                        style={{
-                          background: 'var(--color-codex-bg-tint)',
-                          borderRadius: 2,
-                        }}
-                      />
+                    <div className="flex-1 space-y-1.5" style={{ minWidth: 0 }}>
+                      <CxSkeleton w={`${55 + (i % 3) * 18}%`} h={12} />
+                      <CxSkeleton w={48} h={8} />
                     </div>
                   </div>
                 ))}


### PR DESCRIPTION
## Summary

Three small changes that compound on the user-perceived "Chat feels slow + no skeleton" report. None of them are individually large, but together they shorten both the time-to-first-paint and the time the user sees a clear "loading" cue.

### A — Split `fetchInitialData` so the sidebar paints on the first fetch

[Chat.tsx:1110-1133](web/src/pages/chat/Chat.tsx#L1110)

Previously this awaited `Promise.all([conversations, projects, skills])` and only then flipped `isLoadingConversations`. The sidebar skeleton stayed up until the slowest of the three responded — even though it only needs `conversations`. Split into three independent calls so the conversation list clears the loading flag the moment it arrives. `projects` and `skills` feed dropdowns the user only opens on demand, so they keep resolving in the background.

### B — Sidebar skeleton uses `CxSkeleton` (shimmer)

[Chat.tsx:1969-1989](web/src/pages/chat/Chat.tsx#L1969)

Previously inline `div`s with flat `var(--color-codex-bg-tint)` + `animate-pulse`. On parchment warmth that's `#efede7` against `#ffffff` page bg — a ~5% luminance delta. Effectively invisible; the user reported "没有骨架屏" even though one was rendering. Swapped for `CxSkeleton`, which shimmers between `bg-tint` and `bg-sunken` — same primitive the message-thread skeleton already uses, so the two loading states feel consistent.

### C — Idle-warm `/chat` bundle from Layout mount

[Layout.tsx:134-155](web/src/components/Layout.tsx#L134)

Previously only the hover-on-navlink path preloaded the `/chat` chunk. Users who typed `/chat` directly or arrived via a link still waited for the ~17.7 kB gzip chunk + its lucide-icon children before any Chat code ran. The original `warmPrimaryRoutes()` solved this but pre-fetched all 9 routes blanket-style, which created 10s+ of background contention on slow connections.

New approach: warm just `/chat` (the most common destination), scheduled on `requestIdleCallback` (or a 1.2s `setTimeout` fallback). Skipped when the user is already on `/chat` to avoid a redundant import. Runs only when the browser is idle so it doesn't compete with the current page's own data calls.

### D — Already done

`CxTopProgress` is already wired to the main viewport at [Chat.tsx:2248](web/src/pages/chat/Chat.tsx#L2248) — no change needed.

## Test plan

- [x] `pnpm tsc -b` — clean
- [x] `pnpm test` — 76 files, 511 tests pass
- [x] `pnpm vite build` — clean
- [ ] Manual: visit `/workspace`, observe `/chat` chunk pre-loaded during browser idle (Network panel filter "Chat")
- [ ] Manual: visit `/chat` directly with throttled "Fast 3G" — sidebar skeleton is now obviously shimmering
- [ ] Manual: sidebar conversation list appears as soon as `/chat/conversations` resolves — doesn't wait for `/projects` and `/skills`
- [ ] Manual: project/skill dropdowns still work after the deferred fetches complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)