### PR TITLE
fix: default deliverables to markdown when no format is specified

### DIFF
--- a/backend/app/services/intent_router.py
+++ b/backend/app/services/intent_router.py
@@ -433,6 +433,10 @@ async def classify_chat_intent_async(
         "Tool access is controlled by a separate deterministic tool_access_policy and must not be inferred from analysis requests. "
         "For ambiguous non-destructive deliverable requests, you may return artifact_contract with delivery_required=true, "
         "output_kind, title, and allowed_tools. Only do this when the user wants a real file delivered. "
+        "When delivery is required but the user did NOT explicitly name a file format, set output_kind to 'md'. "
+        "Only choose docx, pptx, xlsx, or pdf when the user explicitly asks for that format "
+        "(e.g. 'word'/'doc'/'docx', 'ppt'/'pptx', 'excel'/'xlsx', 'pdf'). A bare request like '给我一个方案' / "
+        "'写一份报告' with no format word defaults to md, not docx. "
         "Never infer destructive or write permissions from vague analysis requests."
     )
     prompt = {


### PR DESCRIPTION
## Problem

A bare request like `给我一个项目方案思路` (no format word) produced a `.docx`, when the documented default for generic text deliverables is markdown.

## Root cause

Two routing layers disagreed:
- The **deterministic rule router** (`task_orchestrator.py`) defaults generic text deliverables to **md** — see the rationale in `artifact_intent.py` for dropping 文档/报告/方案/材料 from docx detection (they were silently turning every "帮我准备方案" into Word).
- The **LLM intent router** (`intent_router.py`) had **no such rule**. When it upgraded an ambiguous request to an artifact (`_can_llm_upgrade_to_artifact`), it freely picked the `output_kind` — and chose docx, overriding the documented md default.

## Fix

Add the missing constraint to the LLM router system prompt: when `delivery_required` is true but the user did **not** explicitly name a format, `output_kind` defaults to `md`; docx/pptx/xlsx/pdf are chosen only on an explicit format request (word/ppt/excel/pdf). This aligns the LLM layer with the deterministic layer and the documented intent.

## Test

`pytest tests/test_task_orchestrator.py tests/test_chat_flow.py tests/test_chat_golden_set.py tests/test_capability_frame_prompt.py` — 237 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)