### PR TITLE
[codex] Show legacy project statuses in list

### DIFF
--- a/web/src/pages/projects/codex/ChatEmptyState.tsx
+++ b/web/src/pages/projects/codex/ChatEmptyState.tsx
@@ -41,9 +41,18 @@ const STATUS_TO_PHASE_INDEX: Record<Project['status'], number> = {
   // is done, everything after is pending. Archived sits "past the
   // end" so all 5 stages render done.
   lead: 1,
+  lead_discovery: 1,
   opportunity: 2,
+  opportunity_qualified: 2,
+  proposal: 2,
+  negotiation: 2,
+  contracting: 3,
   won: 3,
   delivering: 4,
+  kickoff: 4,
+  execution: 4,
+  delivery: 4,
+  support: 4,
   archived: 5,
 }
 

--- a/web/src/pages/projects/codex/CxProjectsList.tsx
+++ b/web/src/pages/projects/codex/CxProjectsList.tsx
@@ -17,15 +17,14 @@ type CategoryKey = 'presale' | 'delivery'
 
 /** Backend status → pipeline stage column. Backend only stores 5
  * statuses, while the design has 5 sub-stage columns inside 商务阶段.
- * Until the project table grows a `sub_stage` field we collapse:
- *   lead        → lead column
- *   opportunity → qualify column (lumped)
- *   won         → contract column
- *   proposal / negotiation stay empty (rendered as "—") */
+ * Some existing production rows store UI sub-stage values directly,
+ * so keep both backend statuses and legacy sub-stages visible. */
 function presaleStageOf(status: Project['status']): string | null {
-  if (status === 'lead') return 'lead'
-  if (status === 'opportunity') return 'qualify'
-  if (status === 'won') return 'contract'
+  if (status === 'lead' || status === 'lead_discovery') return 'lead'
+  if (status === 'opportunity' || status === 'opportunity_qualified') return 'qualify'
+  if (status === 'proposal') return 'proposal'
+  if (status === 'negotiation') return 'negotiation'
+  if (status === 'won' || status === 'contracting') return 'contract'
   return null
 }
 
@@ -120,11 +119,11 @@ export function CxProjectsList() {
     return clients.filter((c) => !term || c.name.toLowerCase().includes(term))
   }, [clients, clientSearch])
 
-  const presale = useMemo(
-    () => projects.filter((p) => p.status === 'lead' || p.status === 'opportunity' || p.status === 'won'),
+  const presale = useMemo(() => projects.filter((p) => presaleStageOf(p.status) != null), [projects])
+  const active = useMemo(
+    () => projects.filter((p) => ['delivering', 'kickoff', 'execution', 'delivery', 'support'].includes(p.status)),
     [projects],
   )
-  const active = useMemo(() => projects.filter((p) => p.status === 'delivering'), [projects])
   const archived = useMemo(() => projects.filter((p) => p.status === 'archived'), [projects])
   const presaleStaleCount = useMemo(
     () => projects.filter((p) => p.memory_stale).length,

--- a/web/src/pages/projects/codex/useProjectsApi.ts
+++ b/web/src/pages/projects/codex/useProjectsApi.ts
@@ -128,17 +128,35 @@ export function useProjectDetail(projectId: number | null): DetailState {
 /** Friendly status label for top-bar chip. */
 export const STATUS_LABEL: Record<Project['status'], string> = {
   lead: '线索期',
+  lead_discovery: '线索发现',
   opportunity: '机会期',
+  opportunity_qualified: '确认机会',
+  proposal: '方案投标',
+  negotiation: '商务谈判',
+  contracting: '合同签署',
   won: '已签约',
   delivering: '交付中',
+  kickoff: '项目启动',
+  execution: '执行中',
+  delivery: '交付验收',
+  support: '运维支持',
   archived: '已归档',
 }
 
 export const STATUS_TONE: Record<Project['status'], 'mute' | 'warn' | 'good' | 'accent' | 'neutral'> = {
   lead: 'mute',
+  lead_discovery: 'mute',
   opportunity: 'warn',
+  opportunity_qualified: 'warn',
+  proposal: 'warn',
+  negotiation: 'warn',
+  contracting: 'good',
   won: 'good',
   delivering: 'accent',
+  kickoff: 'accent',
+  execution: 'accent',
+  delivery: 'accent',
+  support: 'accent',
   archived: 'neutral',
 }
 

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -20,12 +20,28 @@ export interface LoginRequest {
 }
 
 // Project
+export type ProjectStatus =
+  | 'lead'
+  | 'lead_discovery'
+  | 'opportunity'
+  | 'opportunity_qualified'
+  | 'proposal'
+  | 'negotiation'
+  | 'contracting'
+  | 'won'
+  | 'delivering'
+  | 'kickoff'
+  | 'execution'
+  | 'delivery'
+  | 'support'
+  | 'archived'
+
 export interface Project {
   id: number
   name: string
   client: string
   description: string
-  status: 'lead' | 'opportunity' | 'won' | 'delivering' | 'archived'
+  status: ProjectStatus
   created_at: string
   updated_at: string
   context_summary?: string


### PR DESCRIPTION
## Summary
- Expand frontend project status typing to include legacy UI sub-stage values stored in production, such as proposal and opportunity_qualified.
- Map those statuses to labels, tones, project list columns, and the chat empty-state phase indicator.
- Restore visibility for project rows like ID 12 that were returned by the API but not rendered in any list group.

## Root Cause
Production has projects whose status stores UI sub-stage strings directly. The project list only grouped the five core statuses, so proposal projects fell through every rendered bucket.

## Validation
- npm test -- --run src/types/enums.test.ts src/App.test.tsx
- npx tsc --noEmit