### PR TITLE
fix: project delete 500 — cascade missed ChatTrace/ConversationState/ProjectFileVersion

### DIFF
--- a/backend/app/services/project_deletion.py
+++ b/backend/app/services/project_deletion.py
@@ -4,7 +4,9 @@ from fastapi import HTTPException
 from sqlmodel import Session, select
 
 from app.models.db import (
+    ChatTrace,
     Conversation,
+    ConversationState,
     DocumentChunk,
     GeneratedFile,
     KnowledgeDocument,
@@ -13,6 +15,7 @@ from app.models.db import (
     PendingToolAction,
     Project,
     ProjectFile,
+    ProjectFileVersion,
     ProjectFolder,
     ProjectMember,
     ProjectMemorySnapshot,
@@ -37,6 +40,40 @@ def delete_project_cascade(session: Session, project_id: int) -> None:
         select(Conversation).where(Conversation.project_id == project_id)
     ).all()
     conversation_ids = [conversation.id for conversation in conversations if conversation.id is not None]
+
+    # ChatTrace, ConversationState, and ProjectFileVersion were added after this
+    # cascade was first written and were never included. They carry FKs to
+    # conversation / message / project_file / project, so deleting those parents
+    # below raises an IntegrityError (surfaced to the client as a 500). They are
+    # leaf tables (nothing references them), so delete them up front. Dedupe by
+    # id since a row can match both the project_id and conversation_id filters.
+    traces: dict[int, ChatTrace] = {}
+    for trace in session.exec(select(ChatTrace).where(ChatTrace.project_id == project_id)).all():
+        traces[trace.id] = trace
+    if conversation_ids:
+        for trace in session.exec(
+            select(ChatTrace).where(ChatTrace.conversation_id.in_(conversation_ids))
+        ).all():
+            traces[trace.id] = trace
+    for trace in traces.values():
+        session.delete(trace)
+
+    conversation_states: dict[int, ConversationState] = {}
+    for state in session.exec(select(ConversationState).where(ConversationState.project_id == project_id)).all():
+        conversation_states[state.id] = state
+    if conversation_ids:
+        for state in session.exec(
+            select(ConversationState).where(ConversationState.conversation_id.in_(conversation_ids))
+        ).all():
+            conversation_states[state.id] = state
+    for state in conversation_states.values():
+        session.delete(state)
+
+    for version in session.exec(
+        select(ProjectFileVersion).where(ProjectFileVersion.project_id == project_id)
+    ).all():
+        session.delete(version)
+    session.flush()
 
     task_runs = session.exec(
         select(TaskRun).where(TaskRun.project_id == project_id)

--- a/backend/tests/test_project_deletion.py
+++ b/backend/tests/test_project_deletion.py
@@ -1,0 +1,117 @@
+"""Regression tests for delete_project_cascade.
+
+The cascade is a hand-rolled, ordered delete across every table that carries a
+FK to a project (or its conversations / messages / files). When a new such
+table is added but not wired into the cascade, deleting a project that has rows
+in it raises a Postgres IntegrityError — surfaced to the client as a 500.
+
+This guards the three tables that were originally missed: ChatTrace,
+ConversationState, and ProjectFileVersion.
+"""
+from __future__ import annotations
+
+import unittest
+
+from sqlmodel import Session, SQLModel, select
+
+from app.models.db import (
+    ChatTrace,
+    Conversation,
+    ConversationState,
+    Message,
+    Project,
+    ProjectFile,
+    ProjectFileVersion,
+)
+from app.services.project_deletion import delete_project_cascade
+from tests.test_database import create_test_engine, drop_all_tables
+
+
+class DeleteProjectCascadeTest(unittest.TestCase):
+    def setUp(self):
+        self.engine = create_test_engine()
+        drop_all_tables(self.engine)
+        SQLModel.metadata.create_all(self.engine)
+
+    def tearDown(self):
+        self.engine.dispose()
+
+    def test_deletes_project_with_trace_state_and_file_versions(self):
+        """A project carrying ChatTrace / ConversationState / ProjectFileVersion
+        rows must delete cleanly (these used to violate FKs → 500)."""
+        with Session(self.engine) as session:
+            project = Project(name="GTM Project", client="Client")
+            session.add(project)
+            session.commit()
+            session.refresh(project)
+            project_id = project.id
+
+            conversation = Conversation(title="Chat", project_id=project_id)
+            session.add(conversation)
+            session.commit()
+            session.refresh(conversation)
+
+            message = Message(conversation_id=conversation.id, role="user", content="hi")
+            session.add(message)
+            session.commit()
+            session.refresh(message)
+
+            project_file = ProjectFile(
+                project_id=project_id,
+                name="plan.md",
+                file_type="md",
+                path="plan.md",
+            )
+            session.add(project_file)
+            session.commit()
+            session.refresh(project_file)
+
+            # The exact rows that triggered the original 500.
+            session.add(
+                ProjectFileVersion(
+                    project_file_id=project_file.id,
+                    project_id=project_id,
+                    version_number=1,
+                    name="plan.md",
+                    message_id=message.id,
+                )
+            )
+            session.add(
+                ConversationState(conversation_id=conversation.id, project_id=project_id)
+            )
+            session.add(
+                ChatTrace(
+                    trace_id="trace-1",
+                    conversation_id=conversation.id,
+                    message_id=message.id,
+                    project_id=project_id,
+                )
+            )
+            session.commit()
+
+        # Should not raise (previously raised IntegrityError → 500).
+        with Session(self.engine) as session:
+            delete_project_cascade(session, project_id)
+
+        with Session(self.engine) as session:
+            self.assertIsNone(session.get(Project, project_id))
+            self.assertEqual(
+                session.exec(select(ChatTrace).where(ChatTrace.project_id == project_id)).all(),
+                [],
+            )
+            self.assertEqual(
+                session.exec(
+                    select(ConversationState).where(ConversationState.project_id == project_id)
+                ).all(),
+                [],
+            )
+            self.assertEqual(
+                session.exec(
+                    select(ProjectFileVersion).where(ProjectFileVersion.project_id == project_id)
+                ).all(),
+                [],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Deleting a project failed with `Request failed with status code 500`.

## Root cause

`delete_project_cascade` ([project_deletion.py](backend/app/services/project_deletion.py)) is a hand-rolled, ordered delete across every table with a FK to the project (or its conversations / messages / files). Three tables added *after* the cascade was written were never wired in:

- **ProjectFileVersion** → FKs `projectfile.id`, `project.id`, `message.id`
- **ConversationState** → FKs `conversation.id`, `project.id`
- **ChatTrace** → FKs `conversation.id`, `message.id`, `project.id`

On Postgres (FKs enforced) deleting the project's messages/conversations/files/project then violates those constraints → `IntegrityError` → 500. Because ProjectFileVersion and ChatTrace both reference `message.id`, the cascade actually died at the **message** delete — which is why only projects with chat-trace / file-version history (active ones) hit it.

## Fix

Delete the three leaf tables up front (nothing references them), deduping by id since a row can match both the `project_id` and `conversation_id` filters.

## Test

New `tests/test_project_deletion.py` seeds exactly these rows and asserts a clean cascade. Verified it **fails** (IntegrityError on the message delete) without the fix and **passes** with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)