### PR TITLE
[codex] Add project progress updates

### DIFF
--- a/backend/alembic/versions/021_v1_21_project_progress_updates.py
+++ b/backend/alembic/versions/021_v1_21_project_progress_updates.py
@@ -1,0 +1,48 @@
+"""V1.21 - Project progress updates
+
+Adds lightweight human-authored progress updates for project activity.
+
+Revision ID: 021_v1_21
+Revises: 020_v1_20
+Create Date: 2026-06-03
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+revision = "021_v1_21"
+down_revision = "020_v1_20"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    inspector = inspect(op.get_bind())
+    if "projectprogressupdate" in inspector.get_table_names():
+        return
+    op.create_table(
+        "projectprogressupdate",
+        sa.Column("id", sa.Integer(), nullable=False, primary_key=True),
+        sa.Column("project_id", sa.Integer(), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("next_step", sa.Text(), nullable=False, server_default=""),
+        sa.Column("risk", sa.Text(), nullable=False, server_default=""),
+        sa.Column("created_by_user_id", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.ForeignKeyConstraint(["project_id"], ["project.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["created_by_user_id"], ["user.id"]),
+    )
+    op.create_index("ix_projectprogressupdate_project_id", "projectprogressupdate", ["project_id"])
+    op.create_index("ix_projectprogressupdate_created_at", "projectprogressupdate", ["created_at"])
+    op.create_index("ix_projectprogressupdate_created_by_user_id", "projectprogressupdate", ["created_by_user_id"])
+
+
+def downgrade():
+    inspector = inspect(op.get_bind())
+    if "projectprogressupdate" not in inspector.get_table_names():
+        return
+    op.drop_index("ix_projectprogressupdate_created_by_user_id", table_name="projectprogressupdate")
+    op.drop_index("ix_projectprogressupdate_created_at", table_name="projectprogressupdate")
+    op.drop_index("ix_projectprogressupdate_project_id", table_name="projectprogressupdate")
+    op.drop_table("projectprogressupdate")

--- a/backend/app/models/db.py
+++ b/backend/app/models/db.py
@@ -87,6 +87,7 @@ class Project(SQLModel, table=True):
     payments: list["ProjectPayment"] = Relationship(back_populates="project")
     todos: list["ProjectTodo"] = Relationship(back_populates="project")
     members: list["ProjectMember"] = Relationship(back_populates="project")
+    progress_updates: list["ProjectProgressUpdate"] = Relationship(back_populates="project")
 
 
 class ProjectMemorySummary(SQLModel, table=True):
@@ -152,6 +153,19 @@ class ProjectTodo(SQLModel, table=True):
 
     project: Optional[Project] = Relationship(back_populates="todos")
     assigned_user: Optional["User"] = Relationship(sa_relationship_kwargs={"foreign_keys": "[ProjectTodo.assigned_to_user_id]"})
+
+
+class ProjectProgressUpdate(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    project_id: int = Field(foreign_key="project.id", index=True)
+    content: str
+    next_step: str = ""
+    risk: str = ""
+    created_by_user_id: Optional[int] = Field(default=None, foreign_key="user.id", index=True)
+    created_at: datetime = Field(default_factory=utc_now_naive, index=True)
+
+    project: Optional[Project] = Relationship(back_populates="progress_updates")
+    created_by: Optional["User"] = Relationship(sa_relationship_kwargs={"foreign_keys": "[ProjectProgressUpdate.created_by_user_id]"})
 
 
 class ProjectMember(SQLModel, table=True):

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -57,6 +57,11 @@ from app.services.project_milestones import (
     update_project_milestone,
 )
 from app.services.project_notes import build_project_note_polish_messages, save_project_notes
+from app.services.project_progress import (
+    create_project_progress_update,
+    list_project_progress_updates,
+    serialize_progress_update,
+)
 from app.routers.projects_deps import complete_with_selected_model, stream_with_selected_model
 from app.services.project_todos import (
     create_project_todo,
@@ -84,6 +89,7 @@ from app.routers.projects_deps import (
     NoteBody,
     NotePolishBody,
     PaymentCreate,
+    ProgressUpdateCreate,
     ProjectAISuggestQuery,
     ProjectAISuggestion,
     ProjectCreate,
@@ -362,6 +368,45 @@ def delete_milestone(
     _mark_project_memory_stale(session, project_id)
     _bust_project(project_id)
     return {"ok": True}
+
+
+# ── Project Progress Updates ─────────────────────────────────────────────────
+
+@router.get("/{project_id}/progress-updates")
+def list_progress_updates(
+    project_id: int,
+    session: Session = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
+    require_project_access(session, project_id, current_user)
+    return [
+        serialize_progress_update(update)
+        for update in list_project_progress_updates(session, project_id)
+    ]
+
+
+@router.post("/{project_id}/progress-updates", status_code=201)
+def create_progress_update(
+    project_id: int,
+    data: ProgressUpdateCreate,
+    session: Session = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
+    require_project_access(session, project_id, current_user, require_write=True)
+    content = data.content.strip()
+    if not content:
+        raise HTTPException(status_code=400, detail="Progress content cannot be empty")
+    update = create_project_progress_update(
+        session,
+        project_id,
+        content=content,
+        next_step=data.next_step.strip(),
+        risk=data.risk.strip(),
+        created_by_user_id=current_user.id,
+    )
+    _mark_project_memory_stale(session, project_id)
+    _bust_project(project_id)
+    return serialize_progress_update(_refresh_instance(session, update))
 
 
 # ── Financials ────────────────────────────────────────────────────────────────

--- a/backend/app/routers/projects_deps.py
+++ b/backend/app/routers/projects_deps.py
@@ -197,6 +197,12 @@ class TodoUpdate(BaseModel):
     assigned_to_user_id: Optional[int] = None
 
 
+class ProgressUpdateCreate(BaseModel):
+    content: str
+    next_step: str = ""
+    risk: str = ""
+
+
 class NoteBody(BaseModel):
     content: str
     append: bool = True   # True = append to existing notes; False = overwrite

--- a/backend/app/services/context_builder/project_context.py
+++ b/backend/app/services/context_builder/project_context.py
@@ -16,6 +16,7 @@ from app.models.db import (
     Project,
     ProjectFile,
     ProjectPayment,
+    ProjectProgressUpdate,
     ProjectTodo,
 )
 from app.services.project_files import active_project_files_stmt
@@ -195,6 +196,22 @@ def build_project_context(
             status_icon = "✓" if todo.is_done else "○"
             due = f" (due: {todo.due_date})" if todo.due_date else ""
             lines.append(f"  {status_icon} {todo.content}{due}")
+
+    progress_updates = session.exec(
+        select(ProjectProgressUpdate)
+        .where(ProjectProgressUpdate.project_id == project.id)
+        .order_by(ProjectProgressUpdate.created_at.desc())
+        .limit(8)
+    ).all()
+    if progress_updates:
+        lines.append("\n**Recent Progress Updates:**")
+        for update in progress_updates:
+            by = update.created_by.display_name if update.created_by else "unknown"
+            lines.append(f"  - {by}: {update.content}")
+            if update.next_step:
+                lines.append(f"    next: {update.next_step}")
+            if update.risk:
+                lines.append(f"    risk: {update.risk}")
     
     should_inject_file_text = bool(file_ids) or _content_requests_file_details(content)
 

--- a/backend/app/services/project_contexts.py
+++ b/backend/app/services/project_contexts.py
@@ -11,6 +11,7 @@ from app.models.db import Project, ProjectMemorySnapshot, ProjectMemorySummary
 from app.services.project_files import list_project_files
 from app.services.project_financials import list_project_payments
 from app.services.project_milestones import list_project_milestones
+from app.services.project_progress import list_project_progress_updates
 from app.services.project_todos import list_project_todos
 from app.services.stakeholder_contexts import (
     format_client_stakeholders_for_prompt,
@@ -20,12 +21,14 @@ from app.services.time_utils import utc_now_naive
 
 MAX_SUMMARY_MILESTONES = 6
 MAX_SUMMARY_FILES = 8
+MAX_SUMMARY_PROGRESS_UPDATES = 5
 MAX_FILE_SUMMARY_CHARS = 60
 MAX_DESCRIPTION_CHARS = 240
 OUTPUT_TRUNCATED_MARKER = "[OUTPUT_TRUNCATED]"
 
 MAX_MEMORY_FILE_SUMMARY_CHARS = 200
 MAX_MEMORY_DESCRIPTION_CHARS = 1200
+MAX_MEMORY_PROGRESS_UPDATES = 8
 PROJECT_MEMORY_SUMMARY_TYPES = (
     "overview",
     "risk",
@@ -201,6 +204,7 @@ def build_project_context_data(session: Session, project_id: int) -> tuple[Proje
 
     milestones = list_project_milestones(session, project_id)
     files = list_project_files(session, project_id)
+    progress_updates = list_project_progress_updates(session, project_id, limit=MAX_SUMMARY_PROGRESS_UPDATES)
 
     lines = [
         f"Project: {project.name}",
@@ -209,6 +213,15 @@ def build_project_context_data(session: Session, project_id: int) -> tuple[Proje
     ]
     if project.description:
         lines.append(f"Description: {project.description[:MAX_DESCRIPTION_CHARS]}")
+    if progress_updates:
+        lines.append(f"Progress updates (showing latest {len(progress_updates)}):")
+        for update in progress_updates:
+            by = update.created_by.display_name if update.created_by else "unknown"
+            lines.append(f"  - {by}: {update.content}")
+            if update.next_step:
+                lines.append(f"    next: {update.next_step}")
+            if update.risk:
+                lines.append(f"    risk: {update.risk}")
     if milestones:
         completed_count = sum(1 for milestone in milestones if milestone.is_done)
         lines.append(
@@ -247,6 +260,7 @@ def build_project_memory_data(session: Session, project_id: int) -> tuple[Projec
     files = list_project_files(session, project_id)
     todos = list_project_todos(session, project_id)
     payments = list_project_payments(session, project_id)
+    progress_updates = list_project_progress_updates(session, project_id, limit=MAX_MEMORY_PROGRESS_UPDATES)
     client_stakeholders = list_client_stakeholder_dicts_by_name(session, project.client)
 
     lines = [
@@ -261,6 +275,15 @@ def build_project_memory_data(session: Session, project_id: int) -> tuple[Projec
         lines.append(f"Notes:\n{project.notes[:MAX_MEMORY_DESCRIPTION_CHARS]}")
     if project.md_notes:
         lines.append(f"Markdown notes:\n{project.md_notes[:MAX_MEMORY_DESCRIPTION_CHARS]}")
+    if progress_updates:
+        lines.append(f"Progress updates ({len(progress_updates)} recent):")
+        for update in progress_updates:
+            by = update.created_by.display_name if update.created_by else "unknown"
+            lines.append(f"  - {by}: {update.content}")
+            if update.next_step:
+                lines.append(f"    next: {update.next_step}")
+            if update.risk:
+                lines.append(f"    risk: {update.risk}")
     if milestones:
         completed_count = sum(1 for milestone in milestones if milestone.is_done)
         lines.append(f"Milestones ({len(milestones)} total, {completed_count} completed):")

--- a/backend/app/services/project_deletion.py
+++ b/backend/app/services/project_deletion.py
@@ -21,6 +21,7 @@ from app.models.db import (
     ProjectMemorySnapshot,
     ProjectMemorySummary,
     ProjectPayment,
+    ProjectProgressUpdate,
     ProjectTodo,
     ScheduledTask,
     TaskArtifact,
@@ -205,6 +206,10 @@ def delete_project_cascade(session: Session, project_id: int) -> None:
 
     for todo in session.exec(select(ProjectTodo).where(ProjectTodo.project_id == project_id)).all():
         session.delete(todo)
+    session.flush()
+
+    for update in session.exec(select(ProjectProgressUpdate).where(ProjectProgressUpdate.project_id == project_id)).all():
+        session.delete(update)
     session.flush()
 
     for member in session.exec(select(ProjectMember).where(ProjectMember.project_id == project_id)).all():

--- a/backend/app/services/project_details.py
+++ b/backend/app/services/project_details.py
@@ -9,6 +9,7 @@ from app.models.db import Milestone, Project, ProjectFile, ProjectFolder
 from app.services.project_financials import list_project_payments, serialize_financials
 from app.services.project_files import active_project_files_stmt
 from app.services.project_members import list_project_members, serialize_member
+from app.services.project_progress import list_project_progress_updates, serialize_progress_update
 from app.services.project_todos import list_project_todos, serialize_todo
 
 
@@ -37,6 +38,7 @@ def build_project_detail(
     payments = list_project_payments(session, project_id)
     todos = list_project_todos(session, project_id)
     members = list_project_members(session, project_id)
+    progress_updates = list_project_progress_updates(session, project_id, limit=20)
 
     return {
         "project": project,
@@ -46,5 +48,6 @@ def build_project_detail(
         "md_notes": project.md_notes or "",
         "todos": [serialize_todo(todo) for todo in todos],
         "members": [serialize_member(member) for member in members],
+        "progress_updates": [serialize_progress_update(update) for update in progress_updates],
         "financials": serialize_financials(project, payments),
     }

--- a/backend/app/services/project_progress.py
+++ b/backend/app/services/project_progress.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from fastapi import HTTPException
+from sqlmodel import Session, select
+
+from app.models.db import Project, ProjectProgressUpdate
+
+
+def ensure_project_exists(session: Session, project_id: int) -> Project:
+    project = session.get(Project, project_id)
+    if not project:
+        raise HTTPException(404, "Project not found")
+    return project
+
+
+def serialize_progress_update(update: ProjectProgressUpdate) -> dict:
+    return {
+        "id": update.id,
+        "project_id": update.project_id,
+        "content": update.content,
+        "next_step": update.next_step,
+        "risk": update.risk,
+        "created_by_user_id": update.created_by_user_id,
+        "created_by": (
+            {"id": update.created_by.id, "display_name": update.created_by.display_name}
+            if update.created_by else None
+        ),
+        "created_at": update.created_at,
+    }
+
+
+def list_project_progress_updates(
+    session: Session,
+    project_id: int,
+    *,
+    limit: int | None = None,
+) -> list[ProjectProgressUpdate]:
+    ensure_project_exists(session, project_id)
+    stmt = (
+        select(ProjectProgressUpdate)
+        .where(ProjectProgressUpdate.project_id == project_id)
+        .order_by(ProjectProgressUpdate.created_at.desc(), ProjectProgressUpdate.id.desc())
+    )
+    if limit:
+        stmt = stmt.limit(limit)
+    return session.exec(stmt).all()
+
+
+def create_project_progress_update(
+    session: Session,
+    project_id: int,
+    *,
+    content: str,
+    next_step: str = "",
+    risk: str = "",
+    created_by_user_id: int | None = None,
+) -> ProjectProgressUpdate:
+    ensure_project_exists(session, project_id)
+    update = ProjectProgressUpdate(
+        project_id=project_id,
+        content=content,
+        next_step=next_step,
+        risk=risk,
+        created_by_user_id=created_by_user_id,
+    )
+    session.add(update)
+    session.commit()
+    session.refresh(update)
+    return update

--- a/backend/tests/test_project_progress_updates.py
+++ b/backend/tests/test_project_progress_updates.py
@@ -1,0 +1,72 @@
+import unittest
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlmodel import Session, SQLModel
+
+from app.models.db import Project, User
+from app.routers import projects as projects_module
+from app.routers.auth import get_current_user
+from app.routers.projects import router
+from app.services.cache import projects_cache
+from tests.test_database import create_test_engine, drop_all_tables
+
+
+def _override_admin_user():
+    return User(id=1, email="admin@test.com", display_name="Admin", is_admin=True)
+
+
+class ProjectProgressUpdatesTestCase(unittest.TestCase):
+    def setUp(self):
+        self.engine = create_test_engine()
+        drop_all_tables(self.engine)
+        SQLModel.metadata.create_all(self.engine)
+
+        with Session(self.engine) as session:
+            user = User(email="admin@test.com", password_hash="h", display_name="Admin", is_admin=True)
+            project = Project(name="Progress Project", client="Acme", description="Demo")
+            session.add(user)
+            session.add(project)
+            session.commit()
+            session.refresh(user)
+            session.refresh(project)
+            self.user_id = user.id
+            self.project_id = project.id
+
+        app = FastAPI()
+        app.include_router(router)
+
+        def override_session():
+            with Session(self.engine) as session:
+                yield session
+
+        app.dependency_overrides[projects_module.get_session] = override_session
+        app.dependency_overrides[get_current_user] = _override_admin_user
+        self.client = TestClient(app, raise_server_exceptions=False)
+        projects_cache.clear()
+
+    def tearDown(self):
+        projects_cache.clear()
+        SQLModel.metadata.drop_all(self.engine)
+        self.engine.dispose()
+
+    def test_create_progress_update_and_include_in_detail(self):
+        payload = {
+            "content": "客户已确认周五讲标。",
+            "next_step": "准备讲标提纲",
+            "risk": "预算审批时间未定",
+        }
+        resp = self.client.post(f"/projects/{self.project_id}/progress-updates", json=payload)
+        self.assertEqual(resp.status_code, 201)
+        created = resp.json()
+        self.assertEqual(created["content"], payload["content"])
+        self.assertEqual(created["created_by"]["display_name"], "Admin")
+
+        list_resp = self.client.get(f"/projects/{self.project_id}/progress-updates")
+        self.assertEqual(list_resp.status_code, 200)
+        self.assertEqual(len(list_resp.json()), 1)
+
+        detail_resp = self.client.get(f"/projects/{self.project_id}/detail")
+        self.assertEqual(detail_resp.status_code, 200)
+        detail = detail_resp.json()
+        self.assertEqual(detail["progress_updates"][0]["next_step"], payload["next_step"])

--- a/web/src/pages/projects/codex/ChatEmptyState.tsx
+++ b/web/src/pages/projects/codex/ChatEmptyState.tsx
@@ -138,10 +138,11 @@ export function ChatEmptyState({ projectId, detail, onSelectPrompt }: EmptyState
         milestones,
         files,
         todos,
+        progressUpdates: detail.progress_updates,
         projectId,
         limit: 3,
       }).slice(0, 3),
-    [project, milestones, files, todos, projectId],
+    [project, milestones, files, todos, detail.progress_updates, projectId],
   )
 
   return (

--- a/web/src/pages/projects/codex/CxProgressUpdateActions.tsx
+++ b/web/src/pages/projects/codex/CxProgressUpdateActions.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useState, type ChangeEvent, type FormEvent } from 'react'
+import { api } from '../../../api/client'
+import { CxDialog } from '../../../components/codex'
+import { useToast } from '../../../contexts/ToastContext'
+import type { ProjectProgressUpdate } from '../../../types/api'
+
+const INPUT_STYLE = {
+  width: '100%',
+  padding: '8px 10px',
+  fontSize: 13.5,
+  background: 'var(--color-codex-bg)',
+  border: '1px solid var(--color-codex-line)',
+  borderRadius: 'var(--codex-r-sm, 3px)',
+  color: 'var(--color-codex-ink)',
+  outline: 'none',
+} as const
+
+const LABEL_STYLE = {
+  display: 'block',
+  fontSize: 11.5,
+  color: 'var(--color-codex-ink-mute)',
+  marginBottom: 6,
+  fontWeight: 500,
+} as const
+
+interface ProgressUpdateDialogProps {
+  open: boolean
+  projectId: number
+  onClose: () => void
+  onSaved: () => void | Promise<void>
+}
+
+export function CxProgressUpdateDialog({
+  open,
+  projectId,
+  onClose,
+  onSaved,
+}: ProgressUpdateDialogProps) {
+  const toast = useToast()
+  const [busy, setBusy] = useState(false)
+  const [form, setForm] = useState({
+    content: '',
+    next_step: '',
+    risk: '',
+  })
+
+  useEffect(() => {
+    if (!open) return
+    setForm({ content: '', next_step: '', risk: '' })
+  }, [open])
+
+  const update =
+    (k: 'content' | 'next_step' | 'risk') =>
+    (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
+      setForm((s) => ({ ...s, [k]: e.target.value }))
+
+  const submit = async (e: FormEvent) => {
+    e.preventDefault()
+    if (busy) return
+    if (!form.content.trim()) {
+      toast.warning({ title: '进展内容不能为空' })
+      return
+    }
+    setBusy(true)
+    try {
+      await api.post<ProjectProgressUpdate>(`/projects/${projectId}/progress-updates`, {
+        content: form.content.trim(),
+        next_step: form.next_step.trim(),
+        risk: form.risk.trim(),
+      })
+      toast.success({ title: '项目进展已更新' })
+      onClose()
+      await onSaved()
+    } catch (err) {
+      toast.error({
+        title: '保存失败',
+        description: err instanceof Error ? err.message : '请稍后重试',
+      })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <CxDialog
+      open={open}
+      onClose={onClose}
+      title="更新项目进展"
+      description="补一句最新情况，让团队知道项目推进到哪了"
+      size="md"
+      busy={busy}
+      footer={
+        <>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={busy}
+            style={{
+              padding: '6px 14px',
+              fontSize: 13,
+              border: '1px solid var(--color-codex-line)',
+              borderRadius: 'var(--codex-r-sm, 3px)',
+              color: 'var(--color-codex-ink-soft)',
+              background: 'transparent',
+              cursor: busy ? 'not-allowed' : 'pointer',
+            }}
+          >
+            取消
+          </button>
+          <button
+            type="submit"
+            form="cx-progress-update-form"
+            disabled={busy}
+            style={{
+              padding: '6px 16px',
+              fontSize: 13,
+              fontWeight: 500,
+              borderRadius: 'var(--codex-r-sm, 3px)',
+              background: 'var(--color-codex-ink)',
+              color: 'var(--color-codex-bg-elev)',
+              cursor: busy ? 'not-allowed' : 'pointer',
+              opacity: busy ? 0.6 : 1,
+            }}
+          >
+            {busy ? '保存中…' : '保存'}
+          </button>
+        </>
+      }
+    >
+      <form id="cx-progress-update-form" onSubmit={submit}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+          <div>
+            <label style={LABEL_STYLE}>这次有什么新进展？</label>
+            <textarea
+              rows={4}
+              value={form.content}
+              onChange={update('content')}
+              required
+              autoFocus
+              placeholder="例: 已和客户确认讲标时间，客户仍在内部评审，预计本周五反馈。"
+              className="codex-input"
+              style={{ ...INPUT_STYLE, resize: 'vertical' }}
+            />
+          </div>
+          <div>
+            <label style={LABEL_STYLE}>下一步是什么？（可选）</label>
+            <input
+              value={form.next_step}
+              onChange={update('next_step')}
+              placeholder="例: 本周内跟进预算审批和评审时间"
+              className="codex-input"
+              style={INPUT_STYLE}
+            />
+          </div>
+          <div>
+            <label style={LABEL_STYLE}>有没有风险或卡点？（可选）</label>
+            <input
+              value={form.risk}
+              onChange={update('risk')}
+              placeholder="例: 客户预算审批时间不确定"
+              className="codex-input"
+              style={INPUT_STYLE}
+            />
+          </div>
+        </div>
+      </form>
+    </CxDialog>
+  )
+}

--- a/web/src/pages/projects/codex/activityFeed.tsx
+++ b/web/src/pages/projects/codex/activityFeed.tsx
@@ -2,6 +2,7 @@ import type {
   Milestone,
   Project,
   ProjectFile,
+  ProjectProgressUpdate,
   ProjectTodo,
 } from '../../../types/api'
 
@@ -25,7 +26,7 @@ export interface FeedEvent {
   what: string
   href?: string
   /** Category badge for the expanded view ("文档" / "里程碑" / etc.). */
-  category: '记忆' | '里程碑' | '待办' | '文档' | '档案'
+  category: '进展' | '记忆' | '里程碑' | '待办' | '文档' | '档案'
 }
 
 interface SynthInput {
@@ -33,6 +34,7 @@ interface SynthInput {
   milestones: Milestone[]
   files: ProjectFile[]
   todos: ProjectTodo[]
+  progressUpdates?: ProjectProgressUpdate[]
   projectId: number
   /** Max events to keep. Default 30 — Overview consumer slices
    * further. */
@@ -44,10 +46,28 @@ export function synthesizeActivityFeed({
   milestones,
   files,
   todos,
+  progressUpdates = [],
   projectId,
   limit = 30,
 }: SynthInput): FeedEvent[] {
   const out: FeedEvent[] = []
+
+  for (const update of progressUpdates) {
+    const ts = parseIsoDate(update.created_at)
+    if (!ts) continue
+    const pieces = [update.content]
+    if (update.next_step) pieces.push(`下一步: ${update.next_step}`)
+    if (update.risk) pieces.push(`风险: ${update.risk}`)
+    out.push({
+      id: `progress:${update.id}`,
+      ts,
+      tone: update.risk ? 'warn' : 'accent',
+      who: update.created_by?.display_name ?? '—',
+      what: truncateText(pieces.join(' · '), 90),
+      href: `/projects/${projectId}/milestones`,
+      category: '进展',
+    })
+  }
 
   // Memory rebuilds — memory_updated_at marks the last time the
   // structured memory changed (manual edit or LLM rebuild).

--- a/web/src/pages/projects/codex/tabs/Milestones.tsx
+++ b/web/src/pages/projects/codex/tabs/Milestones.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react'
 import type {
   Milestone,
   ProjectDetail as ProjectDetailType,
+  ProjectProgressUpdate,
   ProjectTodo,
 } from '../../../../types/api'
 import { useToast } from '../../../../contexts/ToastContext'
@@ -26,6 +27,7 @@ import {
   CxTodoFormDialog,
   toggleTodoDone,
 } from '../CxTodoActions'
+import { CxProgressUpdateDialog } from '../CxProgressUpdateActions'
 
 interface MilestonesProps {
   projectId: number
@@ -58,6 +60,7 @@ export function CxProjectMilestones({ projectId, detail, refetch }: MilestonesPr
   const [todoCreating, setTodoCreating] = useState(false)
   const [todoDeleting, setTodoDeleting] = useState<ProjectTodo | null>(null)
   const [todoTogglingId, setTodoTogglingId] = useState<number | null>(null)
+  const [progressCreating, setProgressCreating] = useState(false)
 
   const toggleTodo = async (t: ProjectTodo) => {
     if (todoTogglingId === t.id) return
@@ -118,10 +121,11 @@ export function CxProjectMilestones({ projectId, detail, refetch }: MilestonesPr
         milestones,
         files: detail.files,
         todos,
+        progressUpdates: detail.progress_updates,
         projectId,
         limit: 50,
       }),
-    [project, milestones, detail.files, todos, projectId],
+    [project, milestones, detail.files, todos, detail.progress_updates, projectId],
   )
   const grouped = useMemo(() => groupFeedByDay(feed), [feed])
 
@@ -180,6 +184,11 @@ export function CxProjectMilestones({ projectId, detail, refetch }: MilestonesPr
 
         {/* RIGHT — milestones + todos panels stacked */}
         <aside style={{ display: 'flex', flexDirection: 'column', gap: 18, minWidth: 0 }}>
+          <ProjectProgressPanel
+            updates={detail.progress_updates}
+            onCreate={() => setProgressCreating(true)}
+          />
+
           <CxPanel
             title="里程碑"
             subtitle={`${done} / ${total} 完成`}
@@ -361,7 +370,98 @@ export function CxProjectMilestones({ projectId, detail, refetch }: MilestonesPr
         onClose={() => setTodoDeleting(null)}
         onDeleted={refetch}
       />
+      <CxProgressUpdateDialog
+        open={progressCreating}
+        projectId={projectId}
+        onClose={() => setProgressCreating(false)}
+        onSaved={refetch}
+      />
     </CxProjectShell>
+  )
+}
+
+function ProjectProgressPanel({
+  updates,
+  onCreate,
+}: {
+  updates: ProjectProgressUpdate[]
+  onCreate: () => void
+}) {
+  const latest = updates[0]
+  return (
+    <CxPanel
+      title="项目进展"
+      subtitle={latest ? `${updates.length} 条团队更新` : '用一句话同步项目推进'}
+      action={
+        <button
+          type="button"
+          onClick={onCreate}
+          style={{
+            fontSize: 12,
+            color: 'var(--accent)',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 4,
+          }}
+        >
+          <CxIcon name="plus" size={11} stroke={1.6} /> 更新
+        </button>
+      }
+    >
+      {!latest ? (
+        <div style={{ fontSize: 12.5, color: 'var(--ink-faint)', lineHeight: 1.7 }}>
+          还没有人工进展。团队成员可以在这里补充最新沟通、下一步和卡点。
+        </div>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+          <div>
+            <div style={{ fontSize: 11.5, color: 'var(--ink-mute)', marginBottom: 5 }}>当前状态</div>
+            <div style={{ fontSize: 13.5, color: 'var(--ink)', lineHeight: 1.65 }}>
+              {latest.content}
+            </div>
+            <div style={{ marginTop: 7, fontSize: 11.5, color: 'var(--ink-faint)' }}>
+              {latest.created_by?.display_name ?? '—'} · {formatFeedTime(new Date(latest.created_at))}
+            </div>
+          </div>
+          <ProgressHint label="下一步" value={latest.next_step} empty="暂未填写下一步" />
+          <ProgressHint label="风险/卡点" value={latest.risk} empty="暂无明确风险" warn />
+          {updates.length > 1 && (
+            <div style={{ borderTop: '1px solid var(--line-soft)', paddingTop: 10 }}>
+              {updates.slice(1, 4).map((u) => (
+                <div key={u.id} style={{ padding: '7px 0', fontSize: 12.5, color: 'var(--ink-soft)', lineHeight: 1.55 }}>
+                  <span style={{ color: 'var(--ink-mute)' }}>
+                    {u.created_by?.display_name ?? '—'} · {formatFeedTime(new Date(u.created_at))}
+                  </span>
+                  <br />
+                  {u.content}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </CxPanel>
+  )
+}
+
+function ProgressHint({
+  label,
+  value,
+  empty,
+  warn = false,
+}: {
+  label: string
+  value: string
+  empty: string
+  warn?: boolean
+}) {
+  return (
+    <div>
+      <div style={{ fontSize: 11.5, color: 'var(--ink-mute)', marginBottom: 4 }}>{label}</div>
+      <div style={{ fontSize: 13, color: value && warn ? 'var(--warn)' : value ? 'var(--ink)' : 'var(--ink-faint)', lineHeight: 1.55 }}>
+        {value || empty}
+      </div>
+    </div>
   )
 }
 

--- a/web/src/pages/projects/codex/tabs/Overview.tsx
+++ b/web/src/pages/projects/codex/tabs/Overview.tsx
@@ -90,6 +90,21 @@ export function CxProjectOverview({ detail, refetch }: OverviewProps) {
         {/* Main column */}
         <div style={{ display: 'flex', flexDirection: 'column', gap: 20, minWidth: 0 }}>
           <CxPanel
+            title="项目进展"
+            subtitle={detail.progress_updates.length > 0 ? '团队最近更新' : '还没有人工进展'}
+            action={
+              <a
+                style={{ fontSize: 11.5, color: 'var(--accent)' }}
+                href={`/projects/${projectId}/milestones`}
+              >
+                去活动页更新 →
+              </a>
+            }
+          >
+            <ProgressSummary updates={detail.progress_updates} />
+          </CxPanel>
+
+          <CxPanel
             title="项目快照"
             subtitle={
               project.context_summary
@@ -254,6 +269,7 @@ export function CxProjectOverview({ detail, refetch }: OverviewProps) {
             milestones={milestones}
             files={detail.files}
             todos={todos}
+            progressUpdates={detail.progress_updates}
             projectId={projectId}
           />
         </div>
@@ -528,6 +544,53 @@ export function CxProjectOverview({ detail, refetch }: OverviewProps) {
         onRemoved={refetch}
       />
     </CxProjectShell>
+  )
+}
+
+function ProgressSummary({ updates }: { updates: ProjectDetailType['progress_updates'] }) {
+  const latest = updates[0]
+  if (!latest) {
+    return (
+      <div style={{ fontSize: 13, color: 'var(--ink-faint)', lineHeight: 1.7 }}>
+        团队还没有更新项目进展。可以到「活动」页补一句最新情况。
+      </div>
+    )
+  }
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
+      <div>
+        <div style={{ fontSize: 11.5, color: 'var(--ink-mute)', marginBottom: 5 }}>当前状态</div>
+        <div style={{ fontSize: 14, color: 'var(--ink)', lineHeight: 1.65 }}>{latest.content}</div>
+        <div style={{ marginTop: 8, fontSize: 11.5, color: 'var(--ink-faint)' }}>
+          {latest.created_by?.display_name ?? '—'} · {formatFeedTime(new Date(latest.created_at))}
+        </div>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+        <ProgressField label="下一步" value={latest.next_step} empty="暂未填写下一步" />
+        <ProgressField label="风险/卡点" value={latest.risk} empty="暂无明确风险" warn />
+      </div>
+    </div>
+  )
+}
+
+function ProgressField({
+  label,
+  value,
+  empty,
+  warn = false,
+}: {
+  label: string
+  value: string
+  empty: string
+  warn?: boolean
+}) {
+  return (
+    <div>
+      <div style={{ fontSize: 11.5, color: 'var(--ink-mute)', marginBottom: 4 }}>{label}</div>
+      <div style={{ fontSize: 13.5, color: value && warn ? 'var(--warn)' : value ? 'var(--ink)' : 'var(--ink-faint)', lineHeight: 1.55 }}>
+        {value || empty}
+      </div>
+    </div>
   )
 }
 

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -591,6 +591,17 @@ export interface ProjectTodo {
   updated_at: string
 }
 
+export interface ProjectProgressUpdate {
+  id: number
+  project_id: number
+  content: string
+  next_step: string
+  risk: string
+  created_by_user_id?: number | null
+  created_by?: { id: number; display_name: string } | null
+  created_at: string
+}
+
 export interface MyProjectTodo extends ProjectTodo {
   project_name: string
   priority?: 'low' | 'medium' | 'high'
@@ -623,6 +634,7 @@ export interface ProjectDetail {
   md_notes: string
   todos: ProjectTodo[]
   members: ProjectMember[]
+  progress_updates: ProjectProgressUpdate[]
   financials: ProjectFinancials
 }
 


### PR DESCRIPTION
## Summary
- Add lightweight project progress updates with content, next step, risk, author, and timestamp.
- Surface progress summaries on the project Overview tab and make the Activity tab the main update entry point.
- Include progress updates in the project activity feed, project detail payload, and AI context/memory rebuild inputs.
- Add backend migration, service layer, routes, and endpoint coverage.

## UX
- Overview shows a compact latest progress card with a link to Activity.
- Activity shows a Project Progress panel and a simple + Update dialog.

## Validation
- npx tsc --noEmit
- npm test -- --run src/types/enums.test.ts src/App.test.tsx
- .venv/bin/python -m pytest tests/test_project_progress_updates.py tests/test_project_members.py -q
- .venv/bin/python -m py_compile app/models/db.py app/routers/projects.py app/services/project_progress.py app/services/project_details.py app/services/project_contexts.py app/services/context_builder/project_context.py app/services/project_deletion.py