### PR TITLE
fix(upload): stop client aborting large file uploads at 15s

### DIFF
--- a/backend/app/routers/projects_files.py
+++ b/backend/app/routers/projects_files.py
@@ -532,8 +532,13 @@ def restore_file_version(project_id: int, file_id: int, version_id: int, session
     return {"ok": True, "restored_version_id": version_id, "file": result}
 
 
+# NOTE: sync ``def`` on purpose. The save path does blocking file I/O
+# (shutil.copyfileobj over the uploaded SpooledTemporaryFile); FastAPI runs
+# sync endpoints in a threadpool, so a large upload no longer blocks the
+# asyncio event loop (which previously stalled concurrent requests and made
+# uploads appear to hang).
 @router.post("/{project_id}/files", status_code=201)
-async def upload_file(
+def upload_file(
     project_id: int,
     background_tasks: BackgroundTasks,
     file: UploadFile = File(...),

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -6,6 +6,25 @@ interface ErrorResponsePayload {
   message?: string
 }
 
+// File uploads (multipart/form-data) can take far longer than a JSON API
+// call: a multi-MB PDF over a typical connection routinely exceeds the 15s
+// default, which aborted the request client-side (ECONNABORTED) even though
+// the backend had already saved the file. Give FormData bodies a generous
+// timeout (aligned with nginx proxy_read_timeout = 300s) unless the caller
+// passes an explicit timeout.
+const UPLOAD_TIMEOUT_MS = 5 * 60 * 1000
+
+function withUploadTimeout(
+  body: unknown,
+  config?: AxiosRequestConfig,
+): AxiosRequestConfig | undefined {
+  const isUpload = typeof FormData !== 'undefined' && body instanceof FormData
+  if (isUpload && config?.timeout === undefined) {
+    return { ...config, timeout: UPLOAD_TIMEOUT_MS }
+  }
+  return config
+}
+
 class ApiClient {
   private client: AxiosInstance
   private isDev = import.meta.env.DEV
@@ -124,17 +143,17 @@ class ApiClient {
   }
 
   async post<T>(path: string, body?: unknown, config?: AxiosRequestConfig): Promise<T> {
-    const response = await this.client.post<T>(path, body, config)
+    const response = await this.client.post<T>(path, body, withUploadTimeout(body, config))
     return response.data
   }
 
   async put<T>(path: string, body?: unknown, config?: AxiosRequestConfig): Promise<T> {
-    const response = await this.client.put<T>(path, body, config)
+    const response = await this.client.put<T>(path, body, withUploadTimeout(body, config))
     return response.data
   }
 
   async patch<T>(path: string, body?: unknown, config?: AxiosRequestConfig): Promise<T> {
-    const response = await this.client.patch<T>(path, body, config)
+    const response = await this.client.patch<T>(path, body, withUploadTimeout(body, config))
     return response.data
   }
 

--- a/web/src/pages/projects/codex/CxDocsActions.tsx
+++ b/web/src/pages/projects/codex/CxDocsActions.tsx
@@ -496,12 +496,14 @@ export function CxUploadDropzone({ projectId, folderId, onUploaded }: UploadDrop
     setBusy(true)
     let ok = 0
     let failed = 0
+    let lastError: unknown = null
     for (const f of Array.from(files)) {
       try {
         await uploadOne(f)
         ok += 1
-      } catch {
+      } catch (err) {
         failed += 1
+        lastError = err
       }
     }
     setBusy(false)
@@ -511,7 +513,15 @@ export function CxUploadDropzone({ projectId, folderId, onUploaded }: UploadDrop
         description: failed > 0 ? `${failed} 份失败` : undefined,
       })
     } else {
-      toast.error({ title: '上传失败' })
+      const isTimeout =
+        (lastError as { code?: string } | null)?.code === 'ECONNABORTED' ||
+        ((lastError as { message?: string } | null)?.message ?? '').includes('timeout')
+      toast.error({
+        title: '上传失败',
+        description: isTimeout
+          ? '上传超时,文件可能较大或网络较慢。请刷新确认是否已上传,或重试。'
+          : undefined,
+      })
     }
     await onUploaded()
   }


### PR DESCRIPTION
## 问题
线上 `/projects/:id/docs` 上传稍大的文件(几 MB 的 PDF/DOC)就弹"上传失败",但刷新后文件其实又出现了。

## 根因
用你的账号在线上复现并测量(都打到 project 29,测完已清理):

| 文件 | 后端结果 | 整条请求耗时 |
|---|---|---|
| 47B txt | 201 成功 | 2.0s |
| 10MB pdf | 201 成功 | 42.6s |
| 49MB pdf | 201 成功 | 32.5s |
| 60MB pdf | 201 成功 | 78.6s |

后端**始终成功并落库**,但中大文件整条请求耗时 30–80s,而前端 axios 全局超时写死 **15s**(`web/src/api/client.ts`),上传调用又没单独覆盖 → axios 在 15s 抛 `ECONNABORTED` 中止,UI 计为失败弹"上传失败"。文件已存到后端 → 这就是"报错了但刷新又在"的原因。

排除:**不是** nginx 大小限制(60MB 也能 201;线上实际限制 ≥100M),**不是**文件类型。

## 改动
- **`web/src/api/client.ts`**:`post/put/patch` 检测 `FormData`(multipart 上传),在调用方未显式设置时给 5 分钟超时(与 nginx `proxy_read_timeout 300s` 对齐)。一次修好 docs 上传和 knowledge 上传两个入口。
- **`backend/app/routers/projects_files.py`**:`upload_file` 由 `async def` 改为同步 `def`。原本在 async 端点里跑阻塞式 `shutil.copyfileobj`,会卡住事件循环、拖慢并发请求;改成 sync 后 FastAPI 自动放进线程池执行。
- **`web/.../CxDocsActions.tsx`**:全部失败时区分超时,给出"可能已上传成功,请刷新确认"的提示,而不是笼统的"上传失败"。

## 验证
- 前端 `tsc -b` 通过(exit 0);后端 `py_compile` 通过。
- 合并部署后会在线上再做一轮真实上传回归测试。

🤖 Generated with [Claude Code](https://claude.com/claude-code)