### PR TITLE
feat(weekly): 每周重点事项 + 全员看板

### DIFF
--- a/backend/alembic/versions/024_v1_24_weekly_focus_items.py
+++ b/backend/alembic/versions/024_v1_24_weekly_focus_items.py
@@ -1,0 +1,57 @@
+"""V1.24 - Weekly focus items
+
+Adds per-person weekly key focus items ("每周重点事项") with a lightweight
+follow-up model: one ``status`` + an in-place one-line ``progress_note`` per
+item, scoped to an ISO week via ``week_start`` (the Monday of that week).
+
+Revision ID: 024_v1_24
+Revises: 023_v1_23
+Create Date: 2026-06-28
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+revision = "024_v1_24"
+down_revision = "023_v1_23"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    inspector = inspect(op.get_bind())
+    if "weeklyfocusitem" in inspector.get_table_names():
+        return
+    op.create_table(
+        "weeklyfocusitem",
+        sa.Column("id", sa.Integer(), nullable=False, primary_key=True),
+        sa.Column("week_start", sa.String(), nullable=False),
+        sa.Column("owner_user_id", sa.Integer(), nullable=False),
+        sa.Column("created_by_user_id", sa.Integer(), nullable=True),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False, server_default="in_progress"),
+        sa.Column("progress_note", sa.Text(), nullable=False, server_default=""),
+        sa.Column("project_id", sa.Integer(), nullable=True),
+        sa.Column("sort_order", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.ForeignKeyConstraint(["owner_user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["created_by_user_id"], ["user.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["project_id"], ["project.id"], ondelete="SET NULL"),
+    )
+    op.create_index("ix_weeklyfocusitem_week_start", "weeklyfocusitem", ["week_start"])
+    op.create_index("ix_weeklyfocusitem_owner_user_id", "weeklyfocusitem", ["owner_user_id"])
+    op.create_index("ix_weeklyfocusitem_created_by_user_id", "weeklyfocusitem", ["created_by_user_id"])
+    op.create_index("ix_weeklyfocusitem_project_id", "weeklyfocusitem", ["project_id"])
+
+
+def downgrade():
+    inspector = inspect(op.get_bind())
+    if "weeklyfocusitem" not in inspector.get_table_names():
+        return
+    op.drop_index("ix_weeklyfocusitem_project_id", table_name="weeklyfocusitem")
+    op.drop_index("ix_weeklyfocusitem_created_by_user_id", table_name="weeklyfocusitem")
+    op.drop_index("ix_weeklyfocusitem_owner_user_id", table_name="weeklyfocusitem")
+    op.drop_index("ix_weeklyfocusitem_week_start", table_name="weeklyfocusitem")
+    op.drop_table("weeklyfocusitem")

--- a/backend/app/models/db.py
+++ b/backend/app/models/db.py
@@ -179,6 +179,40 @@ class ProjectMember(SQLModel, table=True):
     user: Optional["User"] = Relationship(sa_relationship_kwargs={"foreign_keys": "[ProjectMember.user_id]"})
 
 
+class WeeklyFocusItem(SQLModel, table=True):
+    """Per-person weekly key focus item ("每周重点事项").
+
+    One row = one focus item for one person in one ISO week. ``week_start`` is
+    the Monday of that week (``YYYY-MM-DD``), computed in the app timezone, so
+    the team board and "my items" views simply filter by it. Lightweight
+    follow-up: a single ``status`` + an in-place one-line ``progress_note``
+    (no per-week history — that was the deliberately simpler option chosen).
+
+    ``owner_user_id`` is *whose* item it is; ``created_by_user_id`` records who
+    added it (the owner themselves, or an admin assigning it). ``project_id`` is
+    an optional link to a project — items can be standalone or attached.
+    """
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    week_start: str = Field(index=True)            # Monday of the week, "YYYY-MM-DD"
+    owner_user_id: int = Field(foreign_key="user.id", index=True)
+    created_by_user_id: Optional[int] = Field(default=None, foreign_key="user.id", index=True)
+    content: str
+    status: str = Field(default="in_progress")     # in_progress | done | blocked
+    progress_note: str = ""
+    project_id: Optional[int] = Field(default=None, foreign_key="project.id", index=True)
+    sort_order: int = 0
+    created_at: datetime = Field(default_factory=utc_now_naive)
+    updated_at: datetime = Field(default_factory=utc_now_naive)
+
+    owner: Optional["User"] = Relationship(
+        sa_relationship_kwargs={"foreign_keys": "[WeeklyFocusItem.owner_user_id]"}
+    )
+    created_by: Optional["User"] = Relationship(
+        sa_relationship_kwargs={"foreign_keys": "[WeeklyFocusItem.created_by_user_id]"}
+    )
+
+
 class ProjectFolder(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     project_id: int = Field(foreign_key="project.id", index=True)

--- a/backend/app/routers/weekly.py
+++ b/backend/app/routers/weekly.py
@@ -1,0 +1,183 @@
+"""Weekly focus items router ("每周重点事项").
+
+Endpoints under ``/weekly``:
+  - ``GET  /weekly/board``       team board for a week (everyone's items)
+  - ``GET  /weekly/my``          the current user's items for a week
+  - ``POST /weekly``             create an item (self, or any user if admin)
+  - ``PATCH /weekly/{id}``       update status / progress / content / project
+  - ``DELETE /weekly/{id}``      delete an item
+  - ``POST /weekly/carry-over``  roll a user's unfinished items into a week
+
+Visibility is intentionally team-wide: any authenticated user can read the
+board. Writes are gated to the item's owner, with an admin super-user bypass
+(admins act as the "manager" who can assign/adjust anyone's items).
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlmodel import Session
+
+from app.database import get_session
+from app.models.db import User, WeeklyFocusItem
+from app.routers.auth import get_current_user
+from app.routers.chat_security import require_project_access
+from app.services.weekly_focus import (
+    build_board,
+    carry_over,
+    create_item,
+    list_items,
+    normalize_week_start,
+    serialize_item,
+    shift_week,
+    _project_name_map,
+    update_item,
+)
+
+router = APIRouter(prefix="/weekly", tags=["weekly"])
+
+
+class WeeklyItemCreate(BaseModel):
+    content: str
+    week_start: Optional[str] = None
+    owner_user_id: Optional[int] = None
+    project_id: Optional[int] = None
+    status: Optional[str] = None
+    progress_note: Optional[str] = ""
+
+
+class WeeklyItemUpdate(BaseModel):
+    content: Optional[str] = None
+    status: Optional[str] = None
+    progress_note: Optional[str] = None
+    project_id: Optional[int] = None
+    sort_order: Optional[int] = None
+
+
+class CarryOverRequest(BaseModel):
+    to_week: Optional[str] = None
+    from_week: Optional[str] = None
+    owner_user_id: Optional[int] = None
+
+
+def _can_manage(current_user: User, owner_user_id: int) -> bool:
+    """Owner of the item, or an admin acting as manager."""
+    return bool(current_user.is_admin) or current_user.id == owner_user_id
+
+
+def _serialize_one(session: Session, item: WeeklyFocusItem) -> dict:
+    names = _project_name_map(session, {item.project_id} if item.project_id else set())
+    return serialize_item(item, names)
+
+
+@router.get("/board")
+def get_board(
+    week_start: Optional[str] = None,
+    session: Session = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
+    ws = normalize_week_start(week_start, session)
+    return build_board(session, ws)
+
+
+@router.get("/my")
+def get_my_items(
+    week_start: Optional[str] = None,
+    session: Session = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
+    ws = normalize_week_start(week_start, session)
+    items = list_items(session, ws, owner_user_id=current_user.id)
+    names = _project_name_map(session, {i.project_id for i in items if i.project_id})
+    return {"week_start": ws, "items": [serialize_item(i, names) for i in items]}
+
+
+@router.post("", status_code=201)
+def create_weekly_item(
+    body: WeeklyItemCreate,
+    session: Session = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
+    owner_id = body.owner_user_id or current_user.id
+    if not _can_manage(current_user, owner_id):
+        raise HTTPException(status_code=403, detail="无权为其他成员创建重点事项")
+    owner = session.get(User, owner_id)
+    if owner is None or not owner.is_active:
+        raise HTTPException(status_code=404, detail="指定的成员不存在")
+    if body.project_id is not None:
+        require_project_access(session, body.project_id, current_user)
+    ws = normalize_week_start(body.week_start, session)
+    item = create_item(
+        session,
+        week_start=ws,
+        owner_user_id=owner_id,
+        created_by_user_id=current_user.id,
+        content=body.content,
+        project_id=body.project_id,
+        status=body.status or "in_progress",
+        progress_note=body.progress_note or "",
+    )
+    return _serialize_one(session, item)
+
+
+@router.patch("/{item_id}")
+def update_weekly_item(
+    item_id: int,
+    body: WeeklyItemUpdate,
+    session: Session = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
+    item = session.get(WeeklyFocusItem, item_id)
+    if item is None:
+        raise HTTPException(status_code=404, detail="重点事项不存在")
+    if not _can_manage(current_user, item.owner_user_id):
+        raise HTTPException(status_code=403, detail="无权修改该成员的重点事项")
+    changes = body.model_dump(exclude_unset=True)
+    if changes.get("project_id") is not None:
+        require_project_access(session, changes["project_id"], current_user)
+    updated = update_item(session, item, changes)
+    return _serialize_one(session, updated)
+
+
+@router.delete("/{item_id}", status_code=204)
+def delete_weekly_item(
+    item_id: int,
+    session: Session = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
+    item = session.get(WeeklyFocusItem, item_id)
+    if item is None:
+        raise HTTPException(status_code=404, detail="重点事项不存在")
+    if not _can_manage(current_user, item.owner_user_id):
+        raise HTTPException(status_code=403, detail="无权删除该成员的重点事项")
+    session.delete(item)
+    session.commit()
+
+
+@router.post("/carry-over")
+def carry_over_items(
+    body: CarryOverRequest,
+    session: Session = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
+    owner_id = body.owner_user_id or current_user.id
+    if not _can_manage(current_user, owner_id):
+        raise HTTPException(status_code=403, detail="无权为其他成员滚动重点事项")
+    to_week = normalize_week_start(body.to_week, session)
+    from_week = normalize_week_start(body.from_week, session) if body.from_week else shift_week(to_week, -1)
+    created = carry_over(
+        session,
+        from_week=from_week,
+        to_week=to_week,
+        owner_user_id=owner_id,
+        created_by_user_id=current_user.id,
+    )
+    names = _project_name_map(session, {i.project_id for i in created if i.project_id})
+    return {
+        "from_week": from_week,
+        "to_week": to_week,
+        "created_count": len(created),
+        "items": [serialize_item(i, names) for i in created],
+    }

--- a/backend/app/services/weekly_focus.py
+++ b/backend/app/services/weekly_focus.py
@@ -1,0 +1,281 @@
+"""Business logic for weekly focus items ("每周重点事项").
+
+Items are scoped to an ISO week via ``week_start`` (the Monday of that week,
+``YYYY-MM-DD``), computed in the app timezone. The team board groups every
+active user's items for a given week; "my items" filters by owner. Follow-up
+is intentionally lightweight — a single ``status`` plus an in-place one-line
+``progress_note`` per item (no per-week history).
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from typing import Optional
+
+try:  # zoneinfo is stdlib on 3.9+, but tz data may be missing on some hosts
+    from zoneinfo import ZoneInfo
+except Exception:  # pragma: no cover - defensive
+    ZoneInfo = None  # type: ignore[assignment]
+
+from fastapi import HTTPException
+from sqlmodel import Session, select
+
+from app.models.db import Project, User, WeeklyFocusItem
+from app.services.settings_helper import get_setting_value
+from app.services.time_utils import utc_now_naive
+
+VALID_STATUSES = {"in_progress", "done", "blocked"}
+DEFAULT_STATUS = "in_progress"
+
+
+# ── Week math ────────────────────────────────────────────────────────────────
+
+def _today_in_app_tz(session: Session) -> date:
+    tz_name = get_setting_value(session, "timezone", "Asia/Shanghai") or "Asia/Shanghai"
+    if ZoneInfo is not None:
+        try:
+            return datetime.now(ZoneInfo(tz_name)).date()
+        except Exception:
+            pass
+    return datetime.now(timezone.utc).date()
+
+
+def monday_of(day: date) -> date:
+    """Return the Monday on or before ``day`` (weeks start Monday)."""
+    return day - timedelta(days=day.weekday())
+
+
+def current_week_start(session: Session) -> str:
+    return monday_of(_today_in_app_tz(session)).isoformat()
+
+
+def normalize_week_start(value: Optional[str], session: Session) -> str:
+    """Snap any ISO date to its Monday; fall back to the current week."""
+    if not value:
+        return current_week_start(session)
+    try:
+        parsed = date.fromisoformat(value.strip())
+    except (ValueError, AttributeError):
+        return current_week_start(session)
+    return monday_of(parsed).isoformat()
+
+
+def shift_week(week_start: str, weeks: int) -> str:
+    return (date.fromisoformat(week_start) + timedelta(weeks=weeks)).isoformat()
+
+
+# ── Serialization ─────────────────────────────────────────────────────────────
+
+def _project_name_map(session: Session, project_ids: set[int]) -> dict[int, str]:
+    ids = [pid for pid in project_ids if pid is not None]
+    if not ids:
+        return {}
+    rows = session.exec(select(Project.id, Project.name).where(Project.id.in_(ids))).all()
+    return {row[0]: row[1] for row in rows}
+
+
+def _user_brief(user: Optional[User]) -> Optional[dict]:
+    if user is None:
+        return None
+    return {"id": user.id, "display_name": user.display_name or user.email}
+
+
+def serialize_item(item: WeeklyFocusItem, project_names: Optional[dict[int, str]] = None) -> dict:
+    project_name = None
+    if item.project_id is not None and project_names is not None:
+        project_name = project_names.get(item.project_id)
+    return {
+        "id": item.id,
+        "week_start": item.week_start,
+        "owner_user_id": item.owner_user_id,
+        "owner": _user_brief(item.owner),
+        "created_by_user_id": item.created_by_user_id,
+        "created_by": _user_brief(item.created_by),
+        "content": item.content,
+        "status": item.status,
+        "progress_note": item.progress_note,
+        "project_id": item.project_id,
+        "project_name": project_name,
+        "sort_order": item.sort_order,
+        "created_at": item.created_at,
+        "updated_at": item.updated_at,
+    }
+
+
+# ── Queries ───────────────────────────────────────────────────────────────────
+
+def list_items(
+    session: Session,
+    week_start: str,
+    *,
+    owner_user_id: Optional[int] = None,
+) -> list[WeeklyFocusItem]:
+    stmt = select(WeeklyFocusItem).where(WeeklyFocusItem.week_start == week_start)
+    if owner_user_id is not None:
+        stmt = stmt.where(WeeklyFocusItem.owner_user_id == owner_user_id)
+    stmt = stmt.order_by(WeeklyFocusItem.sort_order, WeeklyFocusItem.id)
+    return session.exec(stmt).all()
+
+
+def build_board(session: Session, week_start: str) -> dict:
+    """Group a week's items by owner. Every active user appears (even with no
+    items) so the board reads as the whole team, not just whoever has filled in."""
+    items = list_items(session, week_start)
+    project_names = _project_name_map(session, {i.project_id for i in items if i.project_id})
+
+    by_owner: dict[int, list[WeeklyFocusItem]] = {}
+    for item in items:
+        by_owner.setdefault(item.owner_user_id, []).append(item)
+
+    active_users = session.exec(select(User).where(User.is_active == True)).all()  # noqa: E712
+    user_map = {u.id: u for u in active_users}
+
+    owner_ids = list(user_map.keys())
+    # Include owners with items who are no longer active (deactivated) at the end.
+    for oid in by_owner:
+        if oid not in user_map:
+            owner_ids.append(oid)
+
+    people = []
+    total_items = 0
+    done_items = 0
+    for uid in owner_ids:
+        owner_items = by_owner.get(uid, [])
+        done = sum(1 for it in owner_items if it.status == "done")
+        total_items += len(owner_items)
+        done_items += done
+        user = user_map.get(uid)
+        if user is not None:
+            display_name = user.display_name or user.email
+            is_admin = user.is_admin
+        else:
+            owner_rel = owner_items[0].owner if owner_items else None
+            display_name = (owner_rel.display_name if owner_rel else None) or f"用户 #{uid}"
+            is_admin = False
+        people.append(
+            {
+                "user": {"id": uid, "display_name": display_name, "is_admin": is_admin},
+                "items": [serialize_item(it, project_names) for it in owner_items],
+                "total_count": len(owner_items),
+                "done_count": done,
+            }
+        )
+
+    # People with items first, then alphabetical — the frontend pins "me" itself.
+    people.sort(key=lambda p: (p["total_count"] == 0, (p["user"]["display_name"] or "").lower()))
+
+    return {
+        "week_start": week_start,
+        "stats": {
+            "total_items": total_items,
+            "done": done_items,
+            "people": sum(1 for p in people if p["total_count"] > 0),
+        },
+        "people": people,
+    }
+
+
+# ── Mutations ─────────────────────────────────────────────────────────────────
+
+def _next_sort_order(session: Session, week_start: str, owner_user_id: int) -> int:
+    existing = list_items(session, week_start, owner_user_id=owner_user_id)
+    return max((i.sort_order for i in existing), default=-1) + 1
+
+
+def create_item(
+    session: Session,
+    *,
+    week_start: str,
+    owner_user_id: int,
+    created_by_user_id: Optional[int],
+    content: str,
+    project_id: Optional[int] = None,
+    status: str = DEFAULT_STATUS,
+    progress_note: str = "",
+) -> WeeklyFocusItem:
+    content = (content or "").strip()
+    if not content:
+        raise HTTPException(status_code=400, detail="重点事项内容不能为空")
+    item = WeeklyFocusItem(
+        week_start=week_start,
+        owner_user_id=owner_user_id,
+        created_by_user_id=created_by_user_id,
+        content=content,
+        status=status if status in VALID_STATUSES else DEFAULT_STATUS,
+        progress_note=(progress_note or "").strip(),
+        project_id=project_id,
+        sort_order=_next_sort_order(session, week_start, owner_user_id),
+    )
+    session.add(item)
+    session.commit()
+    session.refresh(item)
+    return item
+
+
+def update_item(session: Session, item: WeeklyFocusItem, changes: dict) -> WeeklyFocusItem:
+    if "content" in changes:
+        content = (changes["content"] or "").strip()
+        if not content:
+            raise HTTPException(status_code=400, detail="重点事项内容不能为空")
+        item.content = content
+    if "status" in changes:
+        if changes["status"] not in VALID_STATUSES:
+            raise HTTPException(status_code=400, detail="无效的状态值")
+        item.status = changes["status"]
+    if "progress_note" in changes:
+        item.progress_note = (changes["progress_note"] or "").strip()
+    if "project_id" in changes:
+        item.project_id = changes["project_id"]
+    if "sort_order" in changes and changes["sort_order"] is not None:
+        item.sort_order = int(changes["sort_order"])
+    item.updated_at = utc_now_naive()
+    session.add(item)
+    session.commit()
+    session.refresh(item)
+    return item
+
+
+def carry_over(
+    session: Session,
+    *,
+    from_week: str,
+    to_week: str,
+    owner_user_id: int,
+    created_by_user_id: Optional[int],
+) -> list[WeeklyFocusItem]:
+    """Copy a user's unfinished (not ``done``) items from one week to another.
+
+    Skips items whose content already exists in the target week so repeated
+    presses are idempotent. Status/progress are preserved so a "blocked" item
+    still reads as blocked in the new week."""
+    source = [i for i in list_items(session, from_week, owner_user_id=owner_user_id) if i.status != "done"]
+    if not source:
+        return []
+    target = list_items(session, to_week, owner_user_id=owner_user_id)
+    existing_contents = {i.content.strip() for i in target}
+    next_order = max((i.sort_order for i in target), default=-1) + 1
+
+    created: list[WeeklyFocusItem] = []
+    for src in source:
+        key = src.content.strip()
+        if key in existing_contents:
+            continue
+        item = WeeklyFocusItem(
+            week_start=to_week,
+            owner_user_id=owner_user_id,
+            created_by_user_id=created_by_user_id,
+            content=src.content,
+            status=src.status,
+            progress_note=src.progress_note,
+            project_id=src.project_id,
+            sort_order=next_order,
+        )
+        next_order += 1
+        session.add(item)
+        created.append(item)
+        existing_contents.add(key)
+
+    if created:
+        session.commit()
+        for item in created:
+            session.refresh(item)
+    return created

--- a/backend/main.py
+++ b/backend/main.py
@@ -13,7 +13,7 @@ from app.config import (
     JWT_EXPIRATION_HOURS, SCHEDULER_ENABLED, SETTINGS_CACHE_TTL, validate_jwt_secret
 )
 from app.database import create_db, get_database_health, get_database_migration_governance, migrate_db, engine
-from app.routers import chat, projects, projects_memory, projects_files, projects_briefing, projects_tasks, knowledge, settings, skills, schedules, templates, clients, clients_memory, clients_stakeholders, contacts, artifacts, messages, memory_operations, user_memory
+from app.routers import chat, projects, projects_memory, projects_files, projects_briefing, projects_tasks, knowledge, settings, skills, schedules, templates, clients, clients_memory, clients_stakeholders, contacts, artifacts, messages, memory_operations, user_memory, weekly
 from app.routers import auth as auth_router
 from app.routers.auth import seed_admin_user
 from app.services import scheduler
@@ -272,6 +272,7 @@ app.include_router(artifacts.router)
 app.include_router(messages.router)
 app.include_router(memory_operations.router)
 app.include_router(user_memory.router)
+app.include_router(weekly.router)
 
 
 @app.get("/health")

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9,6 +9,7 @@ import { Login } from './pages/Login'
 import {
   loadPreferenceOnboarding,
   loadWorkspace,
+  loadWeekly,
   loadChat,
   loadSkills,
   loadProjects,
@@ -44,6 +45,7 @@ const PreferenceOnboarding = lazy(() =>
   loadPreferenceOnboarding().then((module) => ({ default: module.PreferenceOnboarding })),
 )
 const Workspace = lazy(() => loadWorkspace().then((module) => ({ default: module.Workspace })))
+const WeeklyFocus = lazy(() => loadWeekly().then((module) => ({ default: module.WeeklyFocus })))
 const Chat = lazy(() => loadChat().then((module) => ({ default: module.Chat })))
 const Skills = lazy(() => loadSkills().then((module) => ({ default: module.Skills })))
 const SkillDetailPage = lazy(() => loadSkills().then((module) => ({ default: module.SkillDetailPage })))
@@ -277,6 +279,14 @@ function AppRoutes() {
           element={
             <LazyPage>
               <Workspace />
+            </LazyPage>
+          }
+        />
+        <Route
+          path="weekly"
+          element={
+            <LazyPage>
+              <WeeklyFocus />
             </LazyPage>
           }
         />

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -9,6 +9,7 @@ import {
   Building2,
   Users,
   BookOpen,
+  Target,
   LogOut,
   Settings,
   UserRound,
@@ -106,6 +107,7 @@ export function Layout() {
 
   const navItems = [
     { path: '/', label: isZh ? '工作台' : 'Workspace', icon: LayoutDashboard },
+    { path: '/weekly', label: isZh ? '本周重点' : 'Weekly', icon: Target },
     { path: '/chat', label: t('nav.chat'), icon: MessageSquare },
     { path: '/skills', label: t('nav.skills'), icon: Wrench },
     { path: '/projects', label: t('nav.projects'), icon: FolderKanban },

--- a/web/src/pages/Workspace.tsx
+++ b/web/src/pages/Workspace.tsx
@@ -33,6 +33,7 @@ import type { AxiosError } from "axios";
 
 import { api } from "../api/client";
 import { CxLogo, CxSkeleton, CxStatus, CxTopProgress, type CxStatusTone } from "../components/codex";
+import { MyWeeklyFocusCard } from "./weekly/MyWeeklyFocusCard";
 import { PageTitle } from "../components/PageTitle";
 import { parseAppDateTime } from "../utils/timezone";
 import type {
@@ -809,6 +810,8 @@ export function Workspace() {
                     </button>
                   </div>
                 </form>
+
+                <MyWeeklyFocusCard />
               </div>
             </section>
 

--- a/web/src/pages/weekly/MyWeeklyFocusCard.tsx
+++ b/web/src/pages/weekly/MyWeeklyFocusCard.tsx
@@ -1,0 +1,197 @@
+/**
+ * "我的本周重点" — a compact widget for the Workspace home that mirrors the
+ * full /weekly board but scoped to the current user + current week. Self-
+ * contained (fetches its own data) so it can drop into Workspace without
+ * touching its data-loading. Click-through to /weekly for the team board.
+ */
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { Plus, Target } from "lucide-react";
+
+import { api } from "../../api/client";
+import { currentWeekStart } from "../../utils/weekDate";
+import type { WeeklyFocusItem, WeeklyFocusMyResponse, WeeklyFocusStatus } from "../../types/api";
+
+const STATUS_ORDER: WeeklyFocusStatus[] = ["in_progress", "done", "blocked"];
+
+function statusColor(status: WeeklyFocusStatus): string {
+  if (status === "done") return "var(--color-codex-good)";
+  if (status === "blocked") return "var(--color-codex-warn)";
+  return "var(--color-codex-accent)";
+}
+
+function nextStatus(status: WeeklyFocusStatus): WeeklyFocusStatus {
+  const idx = STATUS_ORDER.indexOf(status);
+  return STATUS_ORDER[(idx + 1) % STATUS_ORDER.length];
+}
+
+export function MyWeeklyFocusCard() {
+  const { i18n } = useTranslation();
+  const isZh = i18n.language.startsWith("zh");
+  const navigate = useNavigate();
+  const weekStart = useMemo(() => currentWeekStart(), []);
+
+  const [items, setItems] = useState<WeeklyFocusItem[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await api.get<WeeklyFocusMyResponse>("/weekly/my", { params: { week_start: weekStart } });
+      setItems(res.items);
+    } catch {
+      /* soft-fail: the widget just stays empty */
+    } finally {
+      setLoaded(true);
+    }
+  }, [weekStart]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const addItem = async () => {
+    const content = draft.trim();
+    if (!content || busy) return;
+    setBusy(true);
+    try {
+      await api.post("/weekly", { content, week_start: weekStart });
+      setDraft("");
+      await load();
+    } catch {
+      /* surfaced on the full page; keep the widget quiet */
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const cycleStatus = async (item: WeeklyFocusItem) => {
+    // optimistic
+    const updated = nextStatus(item.status);
+    setItems((prev) => prev.map((it) => (it.id === item.id ? { ...it, status: updated } : it)));
+    try {
+      await api.patch(`/weekly/${item.id}`, { status: updated });
+    } catch {
+      void load();
+    }
+  };
+
+  const doneCount = items.filter((it) => it.status === "done").length;
+
+  return (
+    <div
+      style={{
+        background: "var(--color-codex-bg-elev)",
+        border: "1px solid var(--color-codex-line)",
+        borderRadius: "var(--codex-r-md, 6px)",
+        padding: "16px 18px",
+        display: "flex",
+        flexDirection: "column",
+        gap: 10,
+      }}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span className="inline-flex items-center gap-2" style={{ fontSize: 13, color: "var(--color-codex-ink)" }}>
+          <Target className="h-3.5 w-3.5" aria-hidden="true" />
+          {isZh ? "我的本周重点" : "My weekly focus"}
+          {loaded && items.length ? (
+            <span className="font-mono" style={{ fontSize: 11.5, color: "var(--color-codex-ink-mute)" }}>
+              {doneCount}/{items.length}
+            </span>
+          ) : null}
+        </span>
+        <button
+          type="button"
+          onClick={() => navigate("/weekly")}
+          style={{ fontSize: 12, color: "var(--color-codex-ink-mute)" }}
+        >
+          {isZh ? "全员看板 →" : "Team board →"}
+        </button>
+      </div>
+
+      {loaded && items.length === 0 ? (
+        <p style={{ fontSize: 12, color: "var(--color-codex-ink-faint)", margin: 0 }}>
+          {isZh ? "本周还没有重点事项，添加一条吧。" : "No focus items yet this week — add one."}
+        </p>
+      ) : null}
+
+      {items.length ? (
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          {items.slice(0, 6).map((item) => (
+            <div key={item.id} className="flex items-start gap-2">
+              <button
+                type="button"
+                onClick={() => void cycleStatus(item)}
+                title={isZh ? "点击切换状态" : "Click to change status"}
+                style={{
+                  flexShrink: 0,
+                  width: 9,
+                  height: 9,
+                  marginTop: 5,
+                  borderRadius: "50%",
+                  background: statusColor(item.status),
+                }}
+                aria-label={isZh ? "切换状态" : "Toggle status"}
+              />
+              <span
+                style={{
+                  fontSize: 12.5,
+                  lineHeight: 1.5,
+                  color: item.status === "done" ? "var(--color-codex-ink-mute)" : "var(--color-codex-ink)",
+                  textDecoration: item.status === "done" ? "line-through" : "none",
+                  wordBreak: "break-word",
+                }}
+              >
+                {item.content}
+                {item.project_name ? (
+                  <span style={{ color: "var(--color-codex-ink-faint)" }}> · {item.project_name}</span>
+                ) : null}
+              </span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      <div className="flex items-center gap-2">
+        <input
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") void addItem();
+          }}
+          placeholder={isZh ? "添加本周重点…" : "Add a focus item…"}
+          disabled={busy}
+          style={{
+            flex: 1,
+            minHeight: 32,
+            background: "var(--color-codex-bg)",
+            border: "1px solid var(--color-codex-line)",
+            borderRadius: "var(--codex-r-sm, 3px)",
+            color: "var(--color-codex-ink)",
+            fontSize: 12.5,
+            padding: "0 10px",
+          }}
+        />
+        <button
+          type="button"
+          onClick={() => void addItem()}
+          disabled={!draft.trim() || busy}
+          className="inline-flex items-center gap-1.5"
+          style={{
+            padding: "7px 11px",
+            fontSize: 12,
+            fontWeight: 500,
+            borderRadius: "var(--codex-r-sm, 3px)",
+            background: !draft.trim() || busy ? "var(--color-codex-bg-tint)" : "var(--color-codex-ink)",
+            color: !draft.trim() || busy ? "var(--color-codex-ink-mute)" : "var(--color-codex-bg-elev)",
+          }}
+        >
+          <Plus className="h-3.5 w-3.5" aria-hidden="true" />
+          {isZh ? "添加" : "Add"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/weekly/WeeklyFocus.tsx
+++ b/web/src/pages/weekly/WeeklyFocus.tsx
@@ -1,0 +1,773 @@
+/**
+ * Weekly focus board ("本周重点") — per-person weekly key items with a
+ * team-wide board. Weeks start Monday; the switcher rolls week-by-week so
+ * you can look back or plan ahead ("双周滚动"). Each person is a card; your
+ * own card is pinned first and is inline-editable. Admins can add/adjust any
+ * card (the "manager assigns" path). Mobile: cards stack to a single column.
+ */
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import {
+  ChevronLeft,
+  ChevronRight,
+  History,
+  Plus,
+  Target,
+  Trash2,
+  X,
+} from "lucide-react";
+
+import { api } from "../../api/client";
+import { CxTopProgress } from "../../components/codex";
+import { PageTitle } from "../../components/PageTitle";
+import { useToast } from "../../contexts/ToastContext";
+import { currentWeekStart, shiftWeek, weekRangeLabel } from "../../utils/weekDate";
+import type {
+  WeeklyFocusBoard,
+  WeeklyFocusCarryOverResponse,
+  WeeklyFocusItem,
+  WeeklyFocusPerson,
+  WeeklyFocusStatus,
+} from "../../types/api";
+
+interface ProjectOption {
+  id: number;
+  name: string;
+  client: string;
+  status: string;
+}
+
+const STATUS_ORDER: WeeklyFocusStatus[] = ["in_progress", "done", "blocked"];
+
+function statusMeta(status: WeeklyFocusStatus, isZh: boolean): { label: string; color: string } {
+  if (status === "done") return { label: isZh ? "完成" : "Done", color: "var(--color-codex-good)" };
+  if (status === "blocked") return { label: isZh ? "受阻" : "Blocked", color: "var(--color-codex-warn)" };
+  return { label: isZh ? "进行中" : "In progress", color: "var(--color-codex-accent)" };
+}
+
+function nextStatus(status: WeeklyFocusStatus): WeeklyFocusStatus {
+  const idx = STATUS_ORDER.indexOf(status);
+  return STATUS_ORDER[(idx + 1) % STATUS_ORDER.length];
+}
+
+function readStoredUser(): { id: number; is_admin: boolean } | null {
+  try {
+    const raw = localStorage.getItem("user");
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as { id?: number; is_admin?: boolean };
+    if (typeof parsed?.id !== "number") return null;
+    return { id: parsed.id, is_admin: !!parsed.is_admin };
+  } catch {
+    return null;
+  }
+}
+
+// ── Status chip ───────────────────────────────────────────────────────────────
+
+function StatusChip({
+  status,
+  editable,
+  onCycle,
+  isZh,
+}: {
+  status: WeeklyFocusStatus;
+  editable: boolean;
+  onCycle: () => void;
+  isZh: boolean;
+}) {
+  const meta = statusMeta(status, isZh);
+  return (
+    <button
+      type="button"
+      onClick={editable ? onCycle : undefined}
+      disabled={!editable}
+      title={editable ? (isZh ? "点击切换状态" : "Click to change status") : undefined}
+      className="inline-flex items-center gap-1.5"
+      style={{
+        flexShrink: 0,
+        padding: "2px 8px",
+        fontSize: 11,
+        fontWeight: 500,
+        borderRadius: "var(--codex-r-pill, 999px)",
+        border: "1px solid var(--color-codex-line)",
+        background: "var(--color-codex-bg)",
+        color: "var(--color-codex-ink-soft)",
+        cursor: editable ? "pointer" : "default",
+      }}
+    >
+      <span
+        style={{
+          width: 7,
+          height: 7,
+          borderRadius: "50%",
+          background: meta.color,
+          display: "inline-block",
+        }}
+      />
+      {meta.label}
+    </button>
+  );
+}
+
+// ── One item row ───────────────────────────────────────────────────────────────
+
+function ItemRow({
+  item,
+  canManage,
+  isZh,
+  onCycleStatus,
+  onSaveProgress,
+  onDelete,
+  onOpenProject,
+}: {
+  item: WeeklyFocusItem;
+  canManage: boolean;
+  isZh: boolean;
+  onCycleStatus: () => void;
+  onSaveProgress: (note: string) => void;
+  onDelete: () => void;
+  onOpenProject: (projectId: number) => void;
+}) {
+  // Uncontrolled-with-a-key: the parent remounts this row (key includes
+  // updated_at) whenever the server value changes, so local edits aren't
+  // clobbered mid-typing and we avoid syncing prop→state in an effect.
+  const [note, setNote] = useState(item.progress_note || "");
+
+  const assignedByOther =
+    item.created_by && item.created_by.id !== item.owner_user_id ? item.created_by.display_name : null;
+
+  return (
+    <div
+      style={{
+        padding: "10px 0",
+        borderTop: "1px solid var(--color-codex-line)",
+        display: "flex",
+        flexDirection: "column",
+        gap: 6,
+      }}
+    >
+      <div className="flex items-start gap-2" style={{ justifyContent: "space-between" }}>
+        <div className="flex items-start gap-2" style={{ minWidth: 0 }}>
+          <StatusChip status={item.status} editable={canManage} onCycle={onCycleStatus} isZh={isZh} />
+          <span
+            style={{
+              fontSize: 13,
+              color: item.status === "done" ? "var(--color-codex-ink-mute)" : "var(--color-codex-ink)",
+              textDecoration: item.status === "done" ? "line-through" : "none",
+              lineHeight: 1.5,
+              wordBreak: "break-word",
+            }}
+          >
+            {item.content}
+          </span>
+        </div>
+        {canManage ? (
+          <button
+            type="button"
+            onClick={onDelete}
+            aria-label={isZh ? "删除" : "Delete"}
+            title={isZh ? "删除" : "Delete"}
+            className="cx-no-hover"
+            style={{ flexShrink: 0, color: "var(--color-codex-ink-faint)", padding: 2 }}
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </button>
+        ) : null}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2" style={{ paddingLeft: 2 }}>
+        {item.project_id ? (
+          <button
+            type="button"
+            onClick={() => onOpenProject(item.project_id as number)}
+            className="cx-no-hover"
+            style={{
+              fontSize: 11,
+              padding: "1px 7px",
+              borderRadius: "var(--codex-r-sm, 3px)",
+              background: "var(--color-codex-bg-tint)",
+              color: "var(--color-codex-ink-soft)",
+            }}
+          >
+            {item.project_name || (isZh ? "关联项目" : "Project")}
+          </button>
+        ) : null}
+        {assignedByOther ? (
+          <span style={{ fontSize: 11, color: "var(--color-codex-ink-faint)" }}>
+            {isZh ? `由 ${assignedByOther} 指派` : `Assigned by ${assignedByOther}`}
+          </span>
+        ) : null}
+      </div>
+
+      {canManage ? (
+        <input
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          onBlur={() => {
+            if (note.trim() !== (item.progress_note || "").trim()) onSaveProgress(note.trim());
+          }}
+          placeholder={isZh ? "一句话进展 / 下一步…" : "One line: progress / next step…"}
+          style={{
+            width: "100%",
+            background: "var(--color-codex-bg)",
+            border: "1px solid var(--color-codex-line)",
+            borderRadius: "var(--codex-r-sm, 3px)",
+            color: "var(--color-codex-ink-soft)",
+            fontSize: 12,
+            padding: "5px 8px",
+          }}
+        />
+      ) : item.progress_note ? (
+        <p style={{ fontSize: 12, color: "var(--color-codex-ink-soft)", lineHeight: 1.5, margin: 0, paddingLeft: 2 }}>
+          {item.progress_note}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+// ── Add-item form (inline on a manageable card) ─────────────────────────────────
+
+function AddItemForm({
+  projects,
+  isZh,
+  onAdd,
+}: {
+  projects: ProjectOption[];
+  isZh: boolean;
+  onAdd: (content: string, projectId: number | null) => Promise<void>;
+}) {
+  const [open, setOpen] = useState(false);
+  const [content, setContent] = useState("");
+  const [projectId, setProjectId] = useState<number | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="inline-flex items-center gap-1.5"
+        style={{
+          marginTop: 10,
+          fontSize: 12,
+          color: "var(--color-codex-ink-mute)",
+        }}
+      >
+        <Plus className="h-3.5 w-3.5" />
+        {isZh ? "添加重点事项" : "Add focus item"}
+      </button>
+    );
+  }
+
+  const submit = async () => {
+    const text = content.trim();
+    if (!text || busy) return;
+    setBusy(true);
+    try {
+      await onAdd(text, projectId);
+      setContent("");
+      setProjectId(null);
+      setOpen(false);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div style={{ marginTop: 10, display: "flex", flexDirection: "column", gap: 8 }}>
+      <textarea
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        autoFocus
+        rows={2}
+        placeholder={isZh ? "本周重点：要推进什么？" : "This week's focus: what to push forward?"}
+        onKeyDown={(e) => {
+          if ((e.metaKey || e.ctrlKey) && e.key === "Enter") void submit();
+        }}
+        style={{
+          width: "100%",
+          resize: "vertical",
+          minHeight: 48,
+          background: "var(--color-codex-bg)",
+          border: "1px solid var(--color-codex-line)",
+          borderRadius: "var(--codex-r-sm, 3px)",
+          color: "var(--color-codex-ink)",
+          fontSize: 12.5,
+          lineHeight: 1.5,
+          padding: "7px 9px",
+        }}
+      />
+      <div className="flex items-center gap-2" style={{ flexWrap: "wrap" }}>
+        <select
+          value={projectId ?? ""}
+          onChange={(e) => setProjectId(Number(e.target.value) || null)}
+          style={{
+            flex: "1 1 160px",
+            minHeight: 30,
+            background: "var(--color-codex-bg)",
+            border: "1px solid var(--color-codex-line)",
+            borderRadius: "var(--codex-r-sm, 3px)",
+            color: "var(--color-codex-ink)",
+            fontSize: 12,
+            padding: "0 8px",
+          }}
+        >
+          <option value="">{isZh ? "不关联项目（可选）" : "No project (optional)"}</option>
+          {projects.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+              {p.client ? ` · ${p.client}` : ""}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          onClick={() => void submit()}
+          disabled={!content.trim() || busy}
+          style={{
+            padding: "6px 12px",
+            fontSize: 12,
+            fontWeight: 500,
+            borderRadius: "var(--codex-r-sm, 3px)",
+            background: !content.trim() || busy ? "var(--color-codex-bg-tint)" : "var(--color-codex-ink)",
+            color: !content.trim() || busy ? "var(--color-codex-ink-mute)" : "var(--color-codex-bg-elev)",
+          }}
+        >
+          {busy ? (isZh ? "添加中" : "Adding") : isZh ? "添加" : "Add"}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setOpen(false);
+            setContent("");
+          }}
+          aria-label={isZh ? "取消" : "Cancel"}
+          className="cx-no-hover"
+          style={{ color: "var(--color-codex-ink-faint)", padding: 4 }}
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── Person card ────────────────────────────────────────────────────────────────
+
+function PersonCard({
+  person,
+  isMe,
+  canManage,
+  projects,
+  isZh,
+  onAdd,
+  onCycleStatus,
+  onSaveProgress,
+  onDelete,
+  onCarryOver,
+  onOpenProject,
+}: {
+  person: WeeklyFocusPerson;
+  isMe: boolean;
+  canManage: boolean;
+  projects: ProjectOption[];
+  isZh: boolean;
+  onAdd: (ownerId: number, content: string, projectId: number | null) => Promise<void>;
+  onCycleStatus: (item: WeeklyFocusItem) => void;
+  onSaveProgress: (item: WeeklyFocusItem, note: string) => void;
+  onDelete: (item: WeeklyFocusItem) => void;
+  onCarryOver: (ownerId: number) => void;
+  onOpenProject: (projectId: number) => void;
+}) {
+  const initials = (person.user.display_name || "?").trim().slice(0, 2).toUpperCase();
+  return (
+    <div
+      style={{
+        background: "var(--color-codex-bg-elev)",
+        border: isMe ? "1px solid var(--color-codex-accent)" : "1px solid var(--color-codex-line)",
+        borderRadius: "var(--codex-r-md, 6px)",
+        padding: "14px 16px",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      <div className="flex items-center justify-between gap-2" style={{ marginBottom: 4 }}>
+        <div className="flex items-center gap-2" style={{ minWidth: 0 }}>
+          <span
+            className="inline-flex items-center justify-center"
+            style={{
+              width: 26,
+              height: 26,
+              borderRadius: "50%",
+              background: "var(--color-codex-bg-tint)",
+              color: "var(--color-codex-ink-soft)",
+              fontSize: 11,
+              fontWeight: 600,
+              flexShrink: 0,
+            }}
+          >
+            {initials}
+          </span>
+          <span style={{ fontSize: 13.5, fontWeight: 600, color: "var(--color-codex-ink)" }}>
+            {person.user.display_name}
+            {isMe ? (isZh ? "（我）" : " (me)") : ""}
+          </span>
+          {person.user.is_admin ? (
+            <span style={{ fontSize: 10.5, color: "var(--color-codex-ink-faint)" }}>{isZh ? "管理员" : "Admin"}</span>
+          ) : null}
+        </div>
+        <span
+          className="font-mono"
+          style={{ fontSize: 11.5, color: "var(--color-codex-ink-mute)", fontVariantNumeric: "tabular-nums" }}
+        >
+          {person.done_count}/{person.total_count}
+        </span>
+      </div>
+
+      {person.items.length === 0 ? (
+        <p style={{ fontSize: 12, color: "var(--color-codex-ink-faint)", padding: "8px 0", margin: 0 }}>
+          {isZh ? "本周还没有重点事项" : "No focus items this week"}
+        </p>
+      ) : (
+        <div>
+          {person.items.map((item) => (
+            <ItemRow
+              key={`${item.id}:${item.updated_at}`}
+              item={item}
+              canManage={canManage}
+              isZh={isZh}
+              onCycleStatus={() => onCycleStatus(item)}
+              onSaveProgress={(note) => onSaveProgress(item, note)}
+              onDelete={() => onDelete(item)}
+              onOpenProject={onOpenProject}
+            />
+          ))}
+        </div>
+      )}
+
+      {canManage ? (
+        <div className="flex items-center justify-between gap-2" style={{ flexWrap: "wrap" }}>
+          <AddItemForm projects={projects} isZh={isZh} onAdd={(c, pid) => onAdd(person.user.id, c, pid)} />
+          <button
+            type="button"
+            onClick={() => onCarryOver(person.user.id)}
+            className="inline-flex items-center gap-1"
+            title={isZh ? "把上周未完成的事项复制到本周" : "Copy last week's unfinished items here"}
+            style={{ marginTop: 10, fontSize: 11.5, color: "var(--color-codex-ink-faint)" }}
+          >
+            <History className="h-3 w-3" />
+            {isZh ? "滚动上周未完成" : "Carry over"}
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+// ── Page ─────────────────────────────────────────────────────────────────────
+
+export function WeeklyFocus() {
+  const { i18n } = useTranslation();
+  const isZh = i18n.language.startsWith("zh");
+  const navigate = useNavigate();
+  const toast = useToast();
+
+  const currentUser = useMemo(() => readStoredUser(), []);
+  const thisWeek = useMemo(() => currentWeekStart(), []);
+  const [weekStart, setWeekStart] = useState<string>(thisWeek);
+  const [board, setBoard] = useState<WeeklyFocusBoard | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [projects, setProjects] = useState<ProjectOption[]>([]);
+
+  const isCurrentWeek = weekStart === thisWeek;
+
+  const loadBoard = useCallback(
+    async (ws: string) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await api.get<WeeklyFocusBoard>("/weekly/board", { params: { week_start: ws } });
+        setBoard(data);
+      } catch {
+        setError(isZh ? "加载本周重点失败" : "Failed to load weekly focus");
+      } finally {
+        setLoading(false);
+      }
+    },
+    [isZh],
+  );
+
+  useEffect(() => {
+    void loadBoard(weekStart);
+  }, [weekStart, loadBoard]);
+
+  useEffect(() => {
+    api
+      .get<ProjectOption[]>("/projects/meta/dashboard-summary")
+      .then((rows) => setProjects(rows.filter((r) => r.status !== "archived")))
+      .catch(() => {});
+  }, []);
+
+  const refresh = useCallback(() => loadBoard(weekStart), [loadBoard, weekStart]);
+
+  const handleError = useCallback(
+    (err: unknown) => {
+      const status = (err as { response?: { status?: number } })?.response?.status;
+      toast.error({
+        title: isZh ? "操作失败" : "Action failed",
+        description: status === 403 ? (isZh ? "无权进行该操作" : "Not allowed") : undefined,
+      });
+    },
+    [isZh, toast],
+  );
+
+  const addItem = useCallback(
+    async (ownerId: number, content: string, projectId: number | null) => {
+      try {
+        await api.post("/weekly", {
+          content,
+          week_start: weekStart,
+          owner_user_id: ownerId,
+          project_id: projectId,
+        });
+        await refresh();
+      } catch (err) {
+        handleError(err);
+      }
+    },
+    [weekStart, refresh, handleError],
+  );
+
+  const cycleStatus = useCallback(
+    async (item: WeeklyFocusItem) => {
+      try {
+        await api.patch(`/weekly/${item.id}`, { status: nextStatus(item.status) });
+        await refresh();
+      } catch (err) {
+        handleError(err);
+      }
+    },
+    [refresh, handleError],
+  );
+
+  const saveProgress = useCallback(
+    async (item: WeeklyFocusItem, note: string) => {
+      try {
+        await api.patch(`/weekly/${item.id}`, { progress_note: note });
+        await refresh();
+      } catch (err) {
+        handleError(err);
+      }
+    },
+    [refresh, handleError],
+  );
+
+  const deleteItem = useCallback(
+    async (item: WeeklyFocusItem) => {
+      try {
+        await api.delete(`/weekly/${item.id}`);
+        await refresh();
+      } catch (err) {
+        handleError(err);
+      }
+    },
+    [refresh, handleError],
+  );
+
+  const carryOver = useCallback(
+    async (ownerId: number) => {
+      try {
+        const res = await api.post<WeeklyFocusCarryOverResponse>("/weekly/carry-over", {
+          to_week: weekStart,
+          owner_user_id: ownerId,
+        });
+        await refresh();
+        toast.success({
+          title: res.created_count
+            ? isZh
+              ? `已滚动 ${res.created_count} 条未完成事项`
+              : `Carried over ${res.created_count} item(s)`
+            : isZh
+              ? "上周没有可滚动的未完成事项"
+              : "Nothing to carry over",
+        });
+      } catch (err) {
+        handleError(err);
+      }
+    },
+    [weekStart, refresh, toast, isZh, handleError],
+  );
+
+  // Pin my own card first; the backend already sorts the rest.
+  const people = useMemo(() => {
+    if (!board) return [];
+    const mine = board.people.filter((p) => p.user.id === currentUser?.id);
+    const others = board.people.filter((p) => p.user.id !== currentUser?.id);
+    return [...mine, ...others];
+  }, [board, currentUser]);
+
+  return (
+    <>
+      <PageTitle title={isZh ? "本周重点" : "Weekly focus"} />
+      <main
+        className="theme-codex min-h-full"
+        style={{
+          background: "var(--color-codex-bg)",
+          color: "var(--color-codex-ink)",
+          fontSize: 13.5,
+          lineHeight: 1.6,
+        }}
+      >
+        {loading && !board ? <CxTopProgress /> : null}
+        <div style={{ padding: "32px clamp(20px, 4vw, 56px) 48px", minWidth: 0 }}>
+          <header className="flex flex-col gap-4" style={{ marginBottom: 24 }}>
+            <div className="flex flex-wrap items-end justify-between gap-4">
+              <div>
+                <h1
+                  className="inline-flex items-center gap-2"
+                  style={{ margin: 0, fontSize: 26, fontWeight: 500, color: "var(--color-codex-ink)" }}
+                >
+                  <Target className="h-5 w-5" style={{ color: "var(--color-codex-accent)" }} />
+                  {isZh ? "本周重点" : "Weekly focus"}
+                </h1>
+                <p style={{ margin: "6px 0 0", fontSize: 13, color: "var(--color-codex-ink-mute)" }}>
+                  {isZh
+                    ? "每个人的每周重点事项，一眼看全团队进展"
+                    : "Each person's weekly key items — the whole team at a glance"}
+                </p>
+              </div>
+
+              {/* Week switcher */}
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => setWeekStart((w) => shiftWeek(w, -1))}
+                  aria-label={isZh ? "上一周" : "Previous week"}
+                  className="cx-no-hover inline-flex items-center justify-center"
+                  style={{
+                    width: 30,
+                    height: 30,
+                    border: "1px solid var(--color-codex-line)",
+                    borderRadius: "var(--codex-r-sm, 3px)",
+                    color: "var(--color-codex-ink-soft)",
+                  }}
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                </button>
+                <div
+                  className="flex flex-col items-center"
+                  style={{ minWidth: 150, textAlign: "center" }}
+                >
+                  <span style={{ fontSize: 13, fontWeight: 600, color: "var(--color-codex-ink)" }}>
+                    {weekRangeLabel(weekStart, isZh)}
+                  </span>
+                  <span style={{ fontSize: 11, color: "var(--color-codex-ink-faint)" }}>
+                    {isCurrentWeek ? (isZh ? "本周" : "This week") : null}
+                    {!isCurrentWeek ? (
+                      <button
+                        type="button"
+                        onClick={() => setWeekStart(thisWeek)}
+                        style={{ fontSize: 11, color: "var(--color-codex-accent)" }}
+                      >
+                        {isZh ? "回到本周" : "Back to this week"}
+                      </button>
+                    ) : null}
+                  </span>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setWeekStart((w) => shiftWeek(w, 1))}
+                  aria-label={isZh ? "下一周" : "Next week"}
+                  className="cx-no-hover inline-flex items-center justify-center"
+                  style={{
+                    width: 30,
+                    height: 30,
+                    border: "1px solid var(--color-codex-line)",
+                    borderRadius: "var(--codex-r-sm, 3px)",
+                    color: "var(--color-codex-ink-soft)",
+                  }}
+                >
+                  <ChevronRight className="h-4 w-4" />
+                </button>
+              </div>
+            </div>
+
+            {board ? (
+              <div
+                className="flex items-center gap-4"
+                style={{ fontSize: 12, color: "var(--color-codex-ink-mute)" }}
+              >
+                <span>
+                  {isZh ? "共" : "Total"} <strong style={{ color: "var(--color-codex-ink)" }}>{board.stats.total_items}</strong>{" "}
+                  {isZh ? "项" : "items"}
+                </span>
+                <span>
+                  {isZh ? "完成" : "Done"}{" "}
+                  <strong style={{ color: "var(--color-codex-good)" }}>{board.stats.done}</strong>
+                </span>
+                <span>
+                  {board.stats.people} {isZh ? "人有重点" : "people active"}
+                </span>
+              </div>
+            ) : null}
+          </header>
+
+          {error ? (
+            <div
+              style={{
+                padding: "12px 14px",
+                border: "1px solid var(--color-codex-line)",
+                borderRadius: "var(--codex-r-md, 6px)",
+                color: "var(--color-codex-bad)",
+                fontSize: 13,
+              }}
+            >
+              {error}
+            </div>
+          ) : null}
+
+          {!error && board ? (
+            people.length === 0 ? (
+              <p style={{ fontSize: 13, color: "var(--color-codex-ink-mute)" }}>
+                {isZh ? "暂无成员" : "No members yet"}
+              </p>
+            ) : (
+              <div
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "repeat(auto-fill, minmax(min(100%, 340px), 1fr))",
+                  gap: 16,
+                  alignItems: "start",
+                }}
+              >
+                {people.map((person) => {
+                  const isMe = person.user.id === currentUser?.id;
+                  const canManage = !!currentUser && (currentUser.is_admin || isMe);
+                  return (
+                    <PersonCard
+                      key={person.user.id}
+                      person={person}
+                      isMe={isMe}
+                      canManage={canManage}
+                      projects={projects}
+                      isZh={isZh}
+                      onAdd={addItem}
+                      onCycleStatus={cycleStatus}
+                      onSaveProgress={saveProgress}
+                      onDelete={deleteItem}
+                      onCarryOver={carryOver}
+                      onOpenProject={(pid) => navigate(`/projects/${pid}`)}
+                    />
+                  );
+                })}
+              </div>
+            )
+          ) : null}
+        </div>
+      </main>
+    </>
+  );
+}

--- a/web/src/routeLoaders.ts
+++ b/web/src/routeLoaders.ts
@@ -1,5 +1,6 @@
 export const loadPreferenceOnboarding = () => import('./pages/PreferenceOnboarding')
 export const loadWorkspace = () => import('./pages/Workspace')
+export const loadWeekly = () => import('./pages/weekly/WeeklyFocus')
 export const loadChat = () => import('./pages/chat/Chat')
 export const loadSkills = () => import('./pages/skills/Skills')
 export const loadProjects = () => import('./pages/projects/Projects')
@@ -33,6 +34,7 @@ export const loadServiceDown = () => import('./pages/ServiceDown')
 export const primaryRouteLoaders: Record<string, () => Promise<unknown>> = {
   '/': loadWorkspace,
   '/workspace': loadWorkspace,
+  '/weekly': loadWeekly,
   '/chat': loadChat,
   '/skills': loadSkills,
   '/projects': loadProjects,

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -607,6 +607,56 @@ export interface MyProjectTodo extends ProjectTodo {
   priority?: 'low' | 'medium' | 'high'
 }
 
+// Weekly focus items ("每周重点事项")
+export type WeeklyFocusStatus = 'in_progress' | 'done' | 'blocked'
+
+export interface WeeklyFocusItem {
+  id: number
+  week_start: string
+  owner_user_id: number
+  owner?: { id: number; display_name: string } | null
+  created_by_user_id?: number | null
+  created_by?: { id: number; display_name: string } | null
+  content: string
+  status: WeeklyFocusStatus
+  progress_note: string
+  project_id?: number | null
+  project_name?: string | null
+  sort_order: number
+  created_at: string
+  updated_at: string
+}
+
+export interface WeeklyFocusPerson {
+  user: { id: number; display_name: string; is_admin: boolean }
+  items: WeeklyFocusItem[]
+  total_count: number
+  done_count: number
+}
+
+export interface WeeklyFocusBoard {
+  week_start: string
+  stats: { total_items: number; done: number; people: number }
+  people: WeeklyFocusPerson[]
+}
+
+export interface WeeklyFocusMyResponse {
+  week_start: string
+  items: WeeklyFocusItem[]
+}
+
+export interface WeeklyFocusCarryOverResponse {
+  from_week: string
+  to_week: string
+  created_count: number
+  items: WeeklyFocusItem[]
+}
+
+export interface UserSimple {
+  id: number
+  display_name: string
+}
+
 export interface ProjectMember {
   id: number
   project_id: number

--- a/web/src/utils/weekDate.ts
+++ b/web/src/utils/weekDate.ts
@@ -1,0 +1,51 @@
+// Week math for weekly focus items. Weeks start on Monday. All values are
+// plain "YYYY-MM-DD" strings so they round-trip cleanly with the backend
+// (which snaps any date to its Monday in the app timezone).
+import { formatDatePartsKey, getResolvedAppTimeZone } from "./timezone";
+
+function pad(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+function toIso(dt: Date): string {
+  return `${dt.getFullYear()}-${pad(dt.getMonth() + 1)}-${pad(dt.getDate())}`;
+}
+
+/** Today's date ("YYYY-MM-DD") in the resolved app timezone. */
+export function isoTodayInAppTz(): string {
+  return formatDatePartsKey(new Date(), getResolvedAppTimeZone());
+}
+
+/** The Monday on or before the given ISO date. */
+export function mondayOf(isoDate: string): string {
+  const [y, m, d] = isoDate.split("-").map(Number);
+  const dt = new Date(y, m - 1, d); // local midnight — weekday is tz-stable here
+  const daysSinceMonday = (dt.getDay() + 6) % 7; // getDay(): 0=Sun … 6=Sat
+  dt.setDate(dt.getDate() - daysSinceMonday);
+  return toIso(dt);
+}
+
+/** Monday of the current week, in the app timezone. */
+export function currentWeekStart(): string {
+  return mondayOf(isoTodayInAppTz());
+}
+
+/** Shift a week-start by N weeks (negative = earlier). */
+export function shiftWeek(weekStart: string, weeks: number): string {
+  const [y, m, d] = weekStart.split("-").map(Number);
+  const dt = new Date(y, m - 1, d);
+  dt.setDate(dt.getDate() + weeks * 7);
+  return toIso(dt);
+}
+
+/** Human label for a week, e.g. "6月29日 – 7月5日" (zh) / "Jun 29 – Jul 5" (en). */
+export function weekRangeLabel(weekStart: string, isZh: boolean): string {
+  const [y, m, d] = weekStart.split("-").map(Number);
+  const start = new Date(y, m - 1, d);
+  const end = new Date(y, m - 1, d + 6);
+  if (isZh) {
+    return `${start.getMonth() + 1}月${start.getDate()}日 – ${end.getMonth() + 1}月${end.getDate()}日`;
+  }
+  const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+  return `${months[start.getMonth()]} ${start.getDate()} – ${months[end.getMonth()]} ${end.getDate()}`;
+}


### PR DESCRIPTION
## 做了什么

新增「每周重点事项」功能：每个人每周有一组重点事项，外加一个**全员看板**一眼看到所有人的进展。

设计取舍（与产品确认过）：本人 + 管理者(admin) 都能定 · 可选关联项目 · 轻量跟进（状态 + 一句话进展）· 周一为一周起点 · 支持翻周（双周滚动）· 手机端单列堆叠。

## 后端
- `WeeklyFocusItem` 模型 + 迁移 `024_v1_24`（接在 `023_v1_23` 上，**单一 head**，符合线上 `alembic upgrade head` 要求）。事项按 ISO 周分桶（`week_start` = 周一，按应用时区算）。状态 `in_progress/done/blocked` + 就地 `progress_note`。`owner_user_id` 删除级联、`created_by` 置空。
- `weekly_focus` 服务：周计算、看板聚合、未完成事项的幂等滚动（carry-over）。
- `/weekly` 路由：`board / my / 创建 / 修改 / 删除 / carry-over`。全员可读；写操作限本人，admin 作为"管理者"可改任何人。

## 前端
- `/weekly` 看板页：每人一张卡（自己的置顶且可编辑，admin 可编辑任何人），周一制翻周器（上周/本周/下周 + 滚动未完成），状态点按切换 + 进展就地编辑，可选关联项目；窄屏单列。
- 工作台首页「我的本周重点」小块，紧挨"快速更新状态"。
- 导航加「本周重点」(`Target` 图标)、路由接线、共享周日期工具、API 类型。

## 验证
- 后端 import OK · `alembic heads` 单一 `024_v1_24` · 模拟线上部署 `023→024` 实跑成功（11 列 + 4 索引）· 双头守卫测试 7 passed · 服务逻辑（周对齐 / 看板 / carry-over 幂等 / 非法状态 400）实测通过
- 前端 `tsc` 0 报错 · `eslint` 0 报错 · `vite build` 成功
- 跑了一轮 high-effort 代码评审，修了 2 个真问题：PATCH 非法状态改为返回 400；迁移补 `ondelete` 避免硬删用户时的 FK 冲突

## 注意
- 合并到 `main` 会经 GitHub Actions **自动部署到生产** (aria.d2cgo.co)，迁移会自动跑。
- 尚未做真机端到端 QA。

🤖 Generated with [Claude Code](https://claude.com/claude-code)