### PR TITLE
feat(weekly): 待办一键「设为本周重点」(打通待办 ↔ 本周重点)

### DIFF
--- a/backend/alembic/versions/025_v1_25_weekly_focus_source_todo.py
+++ b/backend/alembic/versions/025_v1_25_weekly_focus_source_todo.py
@@ -1,0 +1,55 @@
+"""V1.25 - Weekly focus: link back to source todo
+
+Adds ``weeklyfocusitem.source_todo_id`` so a weekly focus item can record the
+project todo it was promoted from ("设为本周重点"). This keeps promotion
+idempotent (one item per todo per week) and lets the todo list flag which
+todos are already this week's focus.
+
+Purely additive + idempotent (skips when the column already exists, e.g. on
+dev databases created from ``SQLModel.metadata``). No DB-level FK constraint is
+added here — the link is soft (a stale id from a deleted todo is harmless), and
+ALTER-ADD-CONSTRAINT is awkward on SQLite; the ORM model still declares the FK.
+
+Revision ID: 025_v1_25
+Revises: 024_v1_24
+Create Date: 2026-07-01
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+revision = "025_v1_25"
+down_revision = "024_v1_24"
+branch_labels = None
+depends_on = None
+
+
+def _columns() -> set[str]:
+    inspector = inspect(op.get_bind())
+    if "weeklyfocusitem" not in inspector.get_table_names():
+        return set()
+    return {col["name"] for col in inspector.get_columns("weeklyfocusitem")}
+
+
+def upgrade():
+    if "weeklyfocusitem" not in inspect(op.get_bind()).get_table_names():
+        # Table not created yet — the base SQLModel.create_all path will
+        # include the column when it eventually runs.
+        return
+    if "source_todo_id" not in _columns():
+        op.add_column("weeklyfocusitem", sa.Column("source_todo_id", sa.Integer(), nullable=True))
+        # Unique index → promotion is idempotent per (week, todo) at the DB layer.
+        # NULL source_todo_id rows (normal items) are unconstrained (NULLs distinct).
+        op.create_index(
+            "uq_weeklyfocusitem_week_source",
+            "weeklyfocusitem",
+            ["week_start", "source_todo_id"],
+            unique=True,
+        )
+
+
+def downgrade():
+    if "source_todo_id" in _columns():
+        op.drop_index("uq_weeklyfocusitem_week_source", table_name="weeklyfocusitem")
+        op.drop_column("weeklyfocusitem", "source_todo_id")

--- a/backend/app/models/db.py
+++ b/backend/app/models/db.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from typing import Optional
-from sqlalchemy import Column, Text, UniqueConstraint
+from sqlalchemy import Column, Index, Text, UniqueConstraint
 from sqlmodel import SQLModel, Field, Relationship
 import json
 
@@ -193,6 +193,14 @@ class WeeklyFocusItem(SQLModel, table=True):
     an optional link to a project — items can be standalone or attached.
     """
 
+    # One focus item per (week, source todo) — makes "设为本周重点" idempotent at
+    # the DB layer even under concurrent promotes. Rows with NULL source_todo_id
+    # (normal, hand-added items) are unconstrained, since NULLs are distinct in a
+    # unique index on both SQLite and Postgres.
+    __table_args__ = (
+        Index("uq_weeklyfocusitem_week_source", "week_start", "source_todo_id", unique=True),
+    )
+
     id: Optional[int] = Field(default=None, primary_key=True)
     week_start: str = Field(index=True)            # Monday of the week, "YYYY-MM-DD"
     owner_user_id: int = Field(foreign_key="user.id", index=True)
@@ -201,6 +209,11 @@ class WeeklyFocusItem(SQLModel, table=True):
     status: str = Field(default="in_progress")     # in_progress | done | blocked
     progress_note: str = ""
     project_id: Optional[int] = Field(default=None, foreign_key="project.id", index=True)
+    # Back-link when this item was promoted from a project todo ("设为本周重点").
+    # Used to keep promotion idempotent and to flag the source todo as promoted.
+    # No standalone index: the composite unique index below covers lookups
+    # (find-by-source and promoted-ids both filter week_start + source_todo_id).
+    source_todo_id: Optional[int] = Field(default=None, foreign_key="projecttodo.id")
     sort_order: int = 0
     created_at: datetime = Field(default_factory=utc_now_naive)
     updated_at: datetime = Field(default_factory=utc_now_naive)

--- a/backend/app/routers/weekly.py
+++ b/backend/app/routers/weekly.py
@@ -18,16 +18,18 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
+from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session
 
 from app.database import get_session
-from app.models.db import User, WeeklyFocusItem
+from app.models.db import ProjectTodo, User, WeeklyFocusItem
 from app.routers.auth import get_current_user
 from app.routers.chat_security import require_project_access
 from app.services.weekly_focus import (
     build_board,
     carry_over,
     create_item,
+    find_by_source_todo,
     list_items,
     normalize_week_start,
     serialize_item,
@@ -60,6 +62,11 @@ class CarryOverRequest(BaseModel):
     to_week: Optional[str] = None
     from_week: Optional[str] = None
     owner_user_id: Optional[int] = None
+
+
+class PromoteTodoRequest(BaseModel):
+    todo_id: int
+    week_start: Optional[str] = None
 
 
 def _can_manage(current_user: User, owner_user_id: int) -> bool:
@@ -154,6 +161,54 @@ def delete_weekly_item(
         raise HTTPException(status_code=403, detail="无权删除该成员的重点事项")
     session.delete(item)
     session.commit()
+
+
+@router.post("/from-todo", status_code=201)
+def promote_todo(
+    body: PromoteTodoRequest,
+    session: Session = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
+    """Promote a project todo into this week's focus ("设为本周重点").
+
+    Idempotent per (todo, week): a second call returns the existing item with
+    ``created=false`` rather than duplicating. Owner defaults to the todo's
+    assignee (when the caller may manage them), else the caller."""
+    todo = session.get(ProjectTodo, body.todo_id)
+    if todo is None:
+        raise HTTPException(status_code=404, detail="待办不存在")
+    # You must be able to see the project the todo lives in.
+    require_project_access(session, todo.project_id, current_user)
+
+    ws = normalize_week_start(body.week_start, session)
+    existing = find_by_source_todo(session, ws, todo.id)
+    if existing is not None:
+        return {"created": False, "item": _serialize_one(session, existing)}
+
+    # Owner: the assignee if the caller may manage them, otherwise the caller.
+    owner_id = current_user.id
+    if todo.assigned_to_user_id and _can_manage(current_user, todo.assigned_to_user_id):
+        owner_id = todo.assigned_to_user_id
+
+    try:
+        item = create_item(
+            session,
+            week_start=ws,
+            owner_user_id=owner_id,
+            created_by_user_id=current_user.id,
+            content=todo.content,
+            project_id=todo.project_id,
+            source_todo_id=todo.id,
+        )
+    except IntegrityError:
+        # Lost a concurrent promote race (unique index on week_start+source_todo_id).
+        # Fall back to the winner's item so the call stays idempotent.
+        session.rollback()
+        existing = find_by_source_todo(session, ws, todo.id)
+        if existing is not None:
+            return {"created": False, "item": _serialize_one(session, existing)}
+        raise
+    return {"created": True, "item": _serialize_one(session, item)}
 
 
 @router.post("/carry-over")

--- a/backend/app/services/project_details.py
+++ b/backend/app/services/project_details.py
@@ -11,6 +11,7 @@ from app.services.project_files import active_project_files_stmt
 from app.services.project_members import list_project_members, serialize_member
 from app.services.project_progress import list_project_progress_updates, serialize_progress_update
 from app.services.project_todos import list_project_todos, serialize_todo
+from app.services.weekly_focus import current_week_start, promoted_todo_ids
 
 
 def build_project_detail(
@@ -37,6 +38,8 @@ def build_project_detail(
 
     payments = list_project_payments(session, project_id)
     todos = list_project_todos(session, project_id)
+    week_start = current_week_start(session)
+    promoted = promoted_todo_ids(session, week_start, [todo.id for todo in todos])
     members = list_project_members(session, project_id)
     progress_updates = list_project_progress_updates(session, project_id, limit=20)
 
@@ -46,7 +49,10 @@ def build_project_detail(
         "milestones": milestones,
         "folders": folders,
         "md_notes": project.md_notes or "",
-        "todos": [serialize_todo(todo) for todo in todos],
+        "todos": [
+            {**serialize_todo(todo), "weekly_focus_promoted": todo.id in promoted}
+            for todo in todos
+        ],
         "members": [serialize_member(member) for member in members],
         "progress_updates": [serialize_progress_update(update) for update in progress_updates],
         "financials": serialize_financials(project, payments),

--- a/backend/app/services/weekly_focus.py
+++ b/backend/app/services/weekly_focus.py
@@ -95,6 +95,7 @@ def serialize_item(item: WeeklyFocusItem, project_names: Optional[dict[int, str]
         "progress_note": item.progress_note,
         "project_id": item.project_id,
         "project_name": project_name,
+        "source_todo_id": item.source_todo_id,
         "sort_order": item.sort_order,
         "created_at": item.created_at,
         "updated_at": item.updated_at,
@@ -114,6 +115,31 @@ def list_items(
         stmt = stmt.where(WeeklyFocusItem.owner_user_id == owner_user_id)
     stmt = stmt.order_by(WeeklyFocusItem.sort_order, WeeklyFocusItem.id)
     return session.exec(stmt).all()
+
+
+def find_by_source_todo(session: Session, week_start: str, todo_id: int) -> Optional[WeeklyFocusItem]:
+    """The weekly item this todo was promoted into for the given week, if any.
+    Promotion is idempotent on (source_todo_id, week_start)."""
+    return session.exec(
+        select(WeeklyFocusItem).where(
+            WeeklyFocusItem.week_start == week_start,
+            WeeklyFocusItem.source_todo_id == todo_id,
+        )
+    ).first()
+
+
+def promoted_todo_ids(session: Session, week_start: str, todo_ids: list[int]) -> set[int]:
+    """Which of the given todo ids already have a weekly focus item this week."""
+    ids = [tid for tid in todo_ids if tid is not None]
+    if not ids:
+        return set()
+    rows = session.exec(
+        select(WeeklyFocusItem.source_todo_id).where(
+            WeeklyFocusItem.week_start == week_start,
+            WeeklyFocusItem.source_todo_id.in_(ids),
+        )
+    ).all()
+    return {row for row in rows if row is not None}
 
 
 def build_board(session: Session, week_start: str) -> dict:
@@ -191,6 +217,7 @@ def create_item(
     project_id: Optional[int] = None,
     status: str = DEFAULT_STATUS,
     progress_note: str = "",
+    source_todo_id: Optional[int] = None,
 ) -> WeeklyFocusItem:
     content = (content or "").strip()
     if not content:
@@ -203,6 +230,7 @@ def create_item(
         status=status if status in VALID_STATUSES else DEFAULT_STATUS,
         progress_note=(progress_note or "").strip(),
         project_id=project_id,
+        source_todo_id=source_todo_id,
         sort_order=_next_sort_order(session, week_start, owner_user_id),
     )
     session.add(item)

--- a/web/src/pages/projects/codex/CxTodoActions.tsx
+++ b/web/src/pages/projects/codex/CxTodoActions.tsx
@@ -279,3 +279,11 @@ export async function toggleTodoDone(
     is_done: !todo.is_done,
   })
 }
+
+/** Promote a todo into this week's focus ("设为本周重点"). Idempotent per
+ * (todo, week) — a repeat call returns ``created: false``. */
+export async function promoteTodoToWeekly(
+  todo: ProjectTodo,
+): Promise<{ created: boolean }> {
+  return api.post<{ created: boolean }>(`/weekly/from-todo`, { todo_id: todo.id })
+}

--- a/web/src/pages/projects/codex/tabs/Milestones.tsx
+++ b/web/src/pages/projects/codex/tabs/Milestones.tsx
@@ -25,6 +25,7 @@ import {
 import {
   CxTodoDeleteDialog,
   CxTodoFormDialog,
+  promoteTodoToWeekly,
   toggleTodoDone,
 } from '../CxTodoActions'
 import { CxProgressUpdateDialog } from '../CxProgressUpdateActions'
@@ -60,6 +61,7 @@ export function CxProjectMilestones({ projectId, detail, refetch }: MilestonesPr
   const [todoCreating, setTodoCreating] = useState(false)
   const [todoDeleting, setTodoDeleting] = useState<ProjectTodo | null>(null)
   const [todoTogglingId, setTodoTogglingId] = useState<number | null>(null)
+  const [todoPromotingId, setTodoPromotingId] = useState<number | null>(null)
   const [progressCreating, setProgressCreating] = useState(false)
 
   const toggleTodo = async (t: ProjectTodo) => {
@@ -76,6 +78,23 @@ export function CxProjectMilestones({ projectId, detail, refetch }: MilestonesPr
       })
     } finally {
       setTodoTogglingId(null)
+    }
+  }
+
+  const promoteTodo = async (t: ProjectTodo) => {
+    if (todoPromotingId === t.id || t.weekly_focus_promoted) return
+    setTodoPromotingId(t.id)
+    try {
+      const res = await promoteTodoToWeekly(t)
+      toast.success({ title: res.created ? '已加入本周重点' : '已在本周重点中' })
+      await refetch()
+    } catch (err) {
+      toast.error({
+        title: '操作失败',
+        description: err instanceof Error ? err.message : '请稍后重试',
+      })
+    } finally {
+      setTodoPromotingId(null)
     }
   }
 
@@ -270,7 +289,10 @@ export function CxProjectMilestones({ projectId, detail, refetch }: MilestonesPr
                     t={t}
                     last={i === openTodos.length - 1}
                     busy={todoTogglingId === t.id}
+                    promoted={!!t.weekly_focus_promoted}
+                    promoting={todoPromotingId === t.id}
                     onToggle={() => toggleTodo(t)}
+                    onPromote={() => promoteTodo(t)}
                     onEdit={() => setTodoEditing(t)}
                     onDelete={() => setTodoDeleting(t)}
                   />
@@ -469,12 +491,15 @@ interface TodoRowProps {
   t: ProjectTodo
   last: boolean
   busy: boolean
+  promoted?: boolean
+  promoting?: boolean
   onToggle: () => void
+  onPromote?: () => void
   onEdit: () => void
   onDelete: () => void
 }
 
-function TodoRow({ t, last, busy, onToggle, onEdit, onDelete }: TodoRowProps) {
+function TodoRow({ t, last, busy, promoted, promoting, onToggle, onPromote, onEdit, onDelete }: TodoRowProps) {
   // Stacked layout so long titles never collide with the meta row.
   // Row 1: checkbox + title (wraps freely)
   // Row 2: due chip · assignee chip · edit · delete   (small, neutral)
@@ -583,6 +608,25 @@ function TodoRow({ t, last, busy, onToggle, onEdit, onDelete }: TodoRowProps) {
           <span style={{ color: 'var(--ink-faint)' }}>未指派</span>
         )}
         <span style={{ flex: 1 }} />
+        {onPromote && (
+          <button
+            type="button"
+            onClick={onPromote}
+            disabled={promoted || promoting}
+            title={promoted ? '已加入本周重点' : '设为本周重点'}
+            style={{
+              padding: 4,
+              color: promoted ? 'var(--accent)' : 'var(--ink-mute)',
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              cursor: promoted ? 'default' : promoting ? 'wait' : 'pointer',
+              opacity: promoting ? 0.5 : 1,
+            }}
+          >
+            <CxIcon name="target" size={12} />
+          </button>
+        )}
         <button
           type="button"
           onClick={onEdit}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -589,6 +589,8 @@ export interface ProjectTodo {
   assigned_user?: { id: number; display_name: string } | null
   created_at: string
   updated_at: string
+  /** True when this todo is already one of the current week's focus items. */
+  weekly_focus_promoted?: boolean
 }
 
 export interface ProjectProgressUpdate {
@@ -622,6 +624,7 @@ export interface WeeklyFocusItem {
   progress_note: string
   project_id?: number | null
   project_name?: string | null
+  source_todo_id?: number | null
   sort_order: number
   created_at: string
   updated_at: string


### PR DESCRIPTION
## 背景
上一版分析结论：待办和本周重点**不重复、互补**（待办=项目内细活；重点=按周按人的聚焦+全员透明+进展汇报）。本 PR 走**路线 A：打通而非合并** —— 消除唯一真实痛点"重复录入"。

## 做了什么
项目「里程碑」页每条**未完成**待办上加 🎯「设为本周重点」按钮，一键把它提升进**本周**重点看板，归到指派人名下，自动带上 content + 关联项目。

**后端**
- `WeeklyFocusItem.source_todo_id` 回链 + 迁移 `025_v1_25`（接在 024 上）。
- `(week_start, source_todo_id)` **唯一索引** → 提升在 DB 层幂等；NULL 行（普通手加事项）不受约束（NULL 互不相等）。
- `POST /weekly/from-todo`：先查后建 + `IntegrityError` 兜底并发竞态，返回既有项（`created:false`）。owner 取待办指派人（管得到才落对方名下，否则落自己）。
- 项目详情的待办附带 `weekly_focus_promoted`（本周是否已提升）→ 按钮显示「已加入本周重点」并禁用，刷新后仍保持。

**前端**
- `promoteTodoToWeekly` + `TodoRow` 的 🎯 按钮（已提升=accent 色+禁用）。

## 验证
- 后端：import OK · 单一 head `025` · 迁移 `024→025` 隔离实跑（唯一索引）· 约束行为实测：普通 NULL 项同周不冲突 / 重复提升被拒 / 同待办跨周允许 · 提升/幂等/详情打标 smoke 通过
- 前端：`tsc` 0 报错 · **完整 vitest 54 文件 / 382 测试全过** · `vite build` 成功
- 跑了一轮 high-effort 代码评审（前后端各一）；采纳 1 条真问题（并发竞态 → 加唯一索引+IntegrityError 兜底），其余为已证伪/装饰性

## 注意
合并到 `main` 会经 GitHub Actions **自动部署到生产** (aria.d2cgo.co)，迁移自动跑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)